### PR TITLE
Add possibilty to use a cache

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -198,6 +198,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c58ec36aac5066d5ca17df51b3e70279f5670a72102f5752cb7e7c856adfc70"
 
 [[package]]
+name = "cachedir"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e236bf5873ea57ec2877445297f4da008916bfae51567131acfc54a073d694f3"
+dependencies = [
+ "tempfile",
+]
+
+[[package]]
 name = "cc"
 version = "1.0.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -408,7 +417,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3fd78930633bd1c6e35c4b42b1df7b0cbc6bc191146e512bb3bedf243fcc3901"
 dependencies = [
  "libc",
- "redox_users",
+ "redox_users 0.3.5",
+ "winapi",
+]
+
+[[package]]
+name = "dirs"
+version = "4.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca3aa72a6f96ea37bbc5aa912f6788242832f75369bdfdadcb0e38423f100059"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b1d1d91c932ef41c0f2663aa8b0ca0342d444d842c06914aa0a7e352d0bada6"
+dependencies = [
+ "libc",
+ "redox_users 0.4.3",
  "winapi",
 ]
 
@@ -1161,6 +1190,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_users"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b033d837a7cf162d7993aded9304e30a83213c648b6e389db233191f891e5c2b"
+dependencies = [
+ "getrandom 0.2.7",
+ "redox_syscall 0.2.13",
+ "thiserror",
+]
+
+[[package]]
 name = "regex"
 version = "1.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1285,12 +1325,14 @@ dependencies = [
  "base64",
  "binrw",
  "bytesize",
+ "cachedir",
  "cdc",
  "chrono",
  "clap",
  "derivative",
  "derive-getters",
  "derive_more",
+ "dirs 4.0.0",
  "futures",
  "gethostname",
  "hex",
@@ -1543,7 +1585,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "edd106a334b7657c10b7c540a0106114feadeb4dc314513e97df481d5d966f42"
 dependencies = [
  "byteorder",
- "dirs",
+ "dirs 1.0.5",
  "winapi",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,6 +52,9 @@ walkdir = "2"
 ignore = "0.4"
 # rest backend
 reqwest = {version = "0.11", default-features = false, features = ["json", "rustls-tls", "stream"] }
+# cache
+dirs = "4"
+cachedir = "0.3"
 # commands
 clap = { version = "3", features = ["derive"] }
 rpassword = "6"

--- a/README.md
+++ b/README.md
@@ -39,7 +39,6 @@ Current limitations:
  
 ## Open points:
  * [ ] Add tests and benchmarks
- * [ ] Implement a local cache
  * [ ] Add more backends, backup-sources and restore-destinations
  * [ ] Add missing commands: copy, dump, find, mount
  * [ ] Improve error handling

--- a/src/backend/cache.rs
+++ b/src/backend/cache.rs
@@ -24,6 +24,10 @@ impl<BE: WriteBackend> CachedBackend<BE> {
             cache: Cache::new(id, create).unwrap(),
         }
     }
+
+    pub fn cache(&self) -> &Option<Cache> {
+        &self.cache
+    }
 }
 
 #[async_trait]
@@ -127,7 +131,7 @@ impl<BE: WriteBackend> WriteBackend for CachedBackend<BE> {
 }
 
 #[derive(Clone)]
-struct Cache {
+pub struct Cache {
     path: PathBuf,
 }
 
@@ -160,7 +164,7 @@ impl Cache {
         self.path.join(tpe.name()).join(&hex_id[0..2]).join(&hex_id)
     }
 
-    async fn list_with_size(&self, tpe: FileType) -> Result<HashMap<Id, u32>> {
+    pub async fn list_with_size(&self, tpe: FileType) -> Result<HashMap<Id, u32>> {
         let path = self.path.join(tpe.name());
 
         let walker = WalkDir::new(path)
@@ -192,6 +196,7 @@ impl Cache {
     // TODO: this function is yet only called from list_with_size. This cleans up
     // index and snapshot files.
     // It should also be called when reading the index to clean up pack files.
+
     pub async fn remove_not_in_list(&self, tpe: FileType, list: &Vec<(Id, u32)>) -> Result<()> {
         let mut list_cache = self.list_with_size(tpe).await?;
         // remove present files from the cache list
@@ -210,7 +215,7 @@ impl Cache {
         Ok(())
     }
 
-    async fn read_full(&self, tpe: FileType, id: &Id) -> Result<Vec<u8>> {
+    pub async fn read_full(&self, tpe: FileType, id: &Id) -> Result<Vec<u8>> {
         v3!("cache reading tpe: {:?}, id: {}", &tpe, &id);
         let data = fs::read(self.path(tpe, id))?;
         v3!("cache hit!");

--- a/src/backend/cache.rs
+++ b/src/backend/cache.rs
@@ -1,0 +1,277 @@
+use std::collections::HashMap;
+use std::fs::{self, File};
+use std::io::{copy, Read, Seek, SeekFrom, Write};
+use std::path::PathBuf;
+
+use anyhow::{anyhow, Result};
+use async_trait::async_trait;
+use dirs::cache_dir;
+use vlog::*;
+use walkdir::WalkDir;
+
+use super::{FileType, Id, ReadBackend, WriteBackend};
+
+#[derive(Clone)]
+pub struct CachedBackend<BE: WriteBackend> {
+    be: BE,
+    cache: Option<Cache>,
+}
+
+impl<BE: WriteBackend> CachedBackend<BE> {
+    pub fn new(be: BE, id: Id, create: bool) -> Self {
+        Self {
+            be,
+            cache: Cache::new(id, create).unwrap(),
+        }
+    }
+}
+
+#[async_trait]
+impl<BE: WriteBackend> ReadBackend for CachedBackend<BE> {
+    fn location(&self) -> &str {
+        self.be.location()
+    }
+
+    async fn list_with_size(&self, tpe: FileType) -> Result<Vec<(Id, u32)>> {
+        let list = self.be.list_with_size(tpe).await?;
+
+        if let Some(cache) = &self.cache {
+            if tpe.is_cacheable() {
+                cache.remove_not_in_list(tpe, &list).await?;
+            }
+        }
+
+        Ok(list)
+    }
+
+    async fn read_full(&self, tpe: FileType, id: &Id) -> Result<Vec<u8>> {
+        match (&self.cache, tpe.is_cacheable()) {
+            (None, _) | (Some(_), false) => self.be.read_full(tpe, id).await,
+            (Some(cache), true) => match cache.read_full(tpe, id).await {
+                Ok(res) => Ok(res),
+                _ => {
+                    let res = self.be.read_full(tpe, id).await;
+                    if let Ok(data) = &res {
+                        let _ = cache.write_bytes(tpe, id, data.clone()).await;
+                    }
+                    res
+                }
+            },
+        }
+    }
+
+    async fn read_partial(
+        &self,
+        tpe: FileType,
+        id: &Id,
+        cacheable: bool,
+        offset: u32,
+        length: u32,
+    ) -> Result<Vec<u8>> {
+        match (&self.cache, cacheable || tpe.is_cacheable()) {
+            (None, _) | (Some(_), false) => {
+                self.be.read_partial(tpe, id, false, offset, length).await
+            }
+            (Some(cache), true) => match cache.read_partial(tpe, id, offset, length).await {
+                Ok(res) => Ok(res),
+                _ => match self.be.read_full(tpe, id).await {
+                    // read full file, save to cache and return partial content from cache
+                    // TODO: - Do not read to memory, but use a (Async)Reader
+                    //       - Don't read from cache, but use the right part of the read content
+                    Ok(data) => {
+                        if cache.write_bytes(tpe, id, data.clone()).await.is_ok() {
+                            cache.read_partial(tpe, id, offset, length).await
+                        } else {
+                            self.be.read_partial(tpe, id, false, offset, length).await
+                        }
+                    }
+                    error => error,
+                },
+            },
+        }
+    }
+}
+
+#[async_trait]
+impl<BE: WriteBackend> WriteBackend for CachedBackend<BE> {
+    async fn create(&self) -> Result<()> {
+        self.be.create().await
+    }
+
+    async fn write_file(&self, tpe: FileType, id: &Id, cacheable: bool, mut f: File) -> Result<()> {
+        if let Some(cache) = &self.cache {
+            if cacheable || tpe.is_cacheable() {
+                let f_cache = f.try_clone()?;
+                let _ = cache.write_file(tpe, id, cacheable, f_cache).await;
+                f.seek(SeekFrom::Start(0))?;
+            }
+        }
+        self.be.write_file(tpe, id, cacheable, f).await
+    }
+
+    async fn write_bytes(&self, tpe: FileType, id: &Id, buf: Vec<u8>) -> Result<()> {
+        if let Some(cache) = &self.cache {
+            if tpe.is_cacheable() {
+                let _ = cache.write_bytes(tpe, id, buf.clone()).await;
+            }
+        }
+        self.be.write_bytes(tpe, id, buf).await
+    }
+
+    async fn remove(&self, tpe: FileType, id: &Id) -> Result<()> {
+        if let Some(cache) = &self.cache {
+            let _ = cache.remove(tpe, id).await;
+        }
+        self.be.remove(tpe, id).await
+    }
+}
+
+#[derive(Clone)]
+struct Cache {
+    path: PathBuf,
+}
+
+impl Cache {
+    pub fn new(id: Id, create: bool) -> Result<Option<Self>> {
+        let mut path = cache_dir().ok_or_else(|| anyhow!("no cache dir"))?;
+        path.push("restic");
+        if create {
+            fs::create_dir_all(&path)?;
+            cachedir::ensure_tag(&path)?;
+        } else if !cachedir::is_tagged(&path)? {
+            return Ok(None);
+        }
+
+        path.push(id.to_hex());
+        if !create && !path.exists() {
+            return Ok(None);
+        }
+
+        Ok(Some(Self { path }))
+    }
+
+    fn dir(&self, tpe: FileType, id: &Id) -> PathBuf {
+        let hex_id = id.to_hex();
+        self.path.join(tpe.name()).join(&hex_id[0..2])
+    }
+
+    fn path(&self, tpe: FileType, id: &Id) -> PathBuf {
+        let hex_id = id.to_hex();
+        self.path.join(tpe.name()).join(&hex_id[0..2]).join(&hex_id)
+    }
+
+    async fn list_with_size(&self, tpe: FileType) -> Result<HashMap<Id, u32>> {
+        let path = self.path.join(tpe.name());
+
+        let walker = WalkDir::new(path)
+            .into_iter()
+            .filter_map(walkdir::Result::ok)
+            .filter(|e| {
+                // only use files with length of 64 which are valid hex
+                e.file_type().is_file()
+                    && e.file_name().len() == 64
+                    && e.file_name().is_ascii()
+                    && e.file_name()
+                        .to_str()
+                        .unwrap()
+                        .chars()
+                        .into_iter()
+                        .all(|c| ('0'..='9').contains(&c) || ('a'..='f').contains(&c))
+            })
+            .map(|e| {
+                (
+                    Id::from_hex(e.file_name().to_str().unwrap()).unwrap(),
+                    // handle errors in metadata by returning a size of 0
+                    e.metadata().map_or(0, |m| m.len().try_into().unwrap_or(0)),
+                )
+            });
+
+        Ok(walker.collect())
+    }
+
+    // TODO: this function is yet only called from list_with_size. This cleans up
+    // index and snapshot files.
+    // It should also be called when reading the index to clean up pack files.
+    pub async fn remove_not_in_list(&self, tpe: FileType, list: &Vec<(Id, u32)>) -> Result<()> {
+        let mut list_cache = self.list_with_size(tpe).await?;
+        // remove present files from the cache list
+        for (id, size) in list {
+            if let Some(cached_size) = list_cache.remove(id) {
+                if &cached_size != size {
+                    // remove cache files with non-matching size
+                    self.remove(tpe, id).await?;
+                }
+            }
+        }
+        // remove all remaining (i.e. not present in repo) cache files
+        for id in list_cache.keys() {
+            self.remove(tpe, id).await?;
+        }
+        Ok(())
+    }
+
+    async fn read_full(&self, tpe: FileType, id: &Id) -> Result<Vec<u8>> {
+        v3!("cache reading tpe: {:?}, id: {}", &tpe, &id);
+        let data = fs::read(self.path(tpe, id))?;
+        v3!("cache hit!");
+        Ok(data)
+    }
+
+    async fn read_partial(
+        &self,
+        tpe: FileType,
+        id: &Id,
+        offset: u32,
+        length: u32,
+    ) -> Result<Vec<u8>> {
+        v3!(
+            "cache reading tpe: {:?}, id: {}, offset: {}",
+            &tpe,
+            &id,
+            &offset
+        );
+        let mut file = File::open(self.path(tpe, id))?;
+        file.seek(SeekFrom::Start(offset as u64))?;
+        let mut vec = vec![0; length as usize];
+        file.read_exact(&mut vec)?;
+        v3!("cache hit!");
+        Ok(vec)
+    }
+
+    async fn write_file(
+        &self,
+        tpe: FileType,
+        id: &Id,
+        _cacheable: bool,
+        mut f: File,
+    ) -> Result<()> {
+        v3!("cache writing tpe: {:?}, id: {}", &tpe, &id);
+        fs::create_dir_all(self.dir(tpe, id))?;
+        let filename = self.path(tpe, id);
+        let mut file = fs::OpenOptions::new()
+            .create(true)
+            .write(true)
+            .open(&filename)?;
+        copy(&mut f, &mut file)?;
+        Ok(())
+    }
+
+    async fn write_bytes(&self, tpe: FileType, id: &Id, buf: Vec<u8>) -> Result<()> {
+        v3!("cache writing tpe: {:?}, id: {}", &tpe, &id);
+        fs::create_dir_all(self.dir(tpe, id))?;
+        let filename = self.path(tpe, id);
+        let mut file = fs::OpenOptions::new()
+            .create(true)
+            .write(true)
+            .open(&filename)?;
+        file.write_all(&buf)?;
+        Ok(())
+    }
+
+    async fn remove(&self, tpe: FileType, id: &Id) -> Result<()> {
+        v3!("cache writing tpe: {:?}, id: {}", &tpe, &id);
+        let filename = self.path(tpe, id);
+        fs::remove_file(filename)?;
+        Ok(())
+    }
+}

--- a/src/backend/choose.rs
+++ b/src/backend/choose.rs
@@ -53,12 +53,13 @@ impl ReadBackend for ChooseBackend {
         &self,
         tpe: FileType,
         id: &Id,
+        cacheable: bool,
         offset: u32,
         length: u32,
     ) -> Result<Vec<u8>> {
         match self {
-            Local(local) => local.read_partial(tpe, id, offset, length).await,
-            Rest(rest) => rest.read_partial(tpe, id, offset, length).await,
+            Local(local) => local.read_partial(tpe, id, cacheable, offset, length).await,
+            Rest(rest) => rest.read_partial(tpe, id, cacheable, offset, length).await,
         }
     }
 }
@@ -72,10 +73,10 @@ impl WriteBackend for ChooseBackend {
         }
     }
 
-    async fn write_file(&self, tpe: FileType, id: &Id, f: File) -> Result<()> {
+    async fn write_file(&self, tpe: FileType, id: &Id, cacheable: bool, f: File) -> Result<()> {
         match self {
-            Local(local) => local.write_file(tpe, id, f).await,
-            Rest(rest) => rest.write_file(tpe, id, f).await,
+            Local(local) => local.write_file(tpe, id, cacheable, f).await,
+            Rest(rest) => rest.write_file(tpe, id, cacheable, f).await,
         }
     }
 

--- a/src/backend/choose.rs
+++ b/src/backend/choose.rs
@@ -1,7 +1,7 @@
 use std::fs::File;
 
+use anyhow::Result;
 use async_trait::async_trait;
-use thiserror::Error;
 
 use super::{FileType, Id, ReadBackend, WriteBackend};
 use super::{LocalBackend, RestBackend};
@@ -26,14 +26,8 @@ impl ChooseBackend {
     }
 }
 
-#[derive(Error, Debug)]
-#[error(transparent)]
-pub struct Error(#[from] anyhow::Error);
-
 #[async_trait]
 impl ReadBackend for ChooseBackend {
-    type Error = Error;
-
     fn location(&self) -> &str {
         match self {
             Local(local) => local.location(),
@@ -41,17 +35,17 @@ impl ReadBackend for ChooseBackend {
         }
     }
 
-    async fn list_with_size(&self, tpe: FileType) -> Result<Vec<(Id, u32)>, Self::Error> {
+    async fn list_with_size(&self, tpe: FileType) -> Result<Vec<(Id, u32)>> {
         match self {
-            Local(local) => local.list_with_size(tpe).await.map_err(|e| Error(e.into())),
-            Rest(rest) => rest.list_with_size(tpe).await.map_err(|e| Error(e.into())),
+            Local(local) => local.list_with_size(tpe).await,
+            Rest(rest) => rest.list_with_size(tpe).await,
         }
     }
 
-    async fn read_full(&self, tpe: FileType, id: &Id) -> Result<Vec<u8>, Self::Error> {
+    async fn read_full(&self, tpe: FileType, id: &Id) -> Result<Vec<u8>> {
         match self {
-            Local(local) => local.read_full(tpe, id).await.map_err(|e| Error(e.into())),
-            Rest(rest) => rest.read_full(tpe, id).await.map_err(|e| Error(e.into())),
+            Local(local) => local.read_full(tpe, id).await,
+            Rest(rest) => rest.read_full(tpe, id).await,
         }
     }
 
@@ -61,59 +55,41 @@ impl ReadBackend for ChooseBackend {
         id: &Id,
         offset: u32,
         length: u32,
-    ) -> Result<Vec<u8>, Self::Error> {
+    ) -> Result<Vec<u8>> {
         match self {
-            Local(local) => local
-                .read_partial(tpe, id, offset, length)
-                .await
-                .map_err(|e| Error(e.into())),
-            Rest(rest) => rest
-                .read_partial(tpe, id, offset, length)
-                .await
-                .map_err(|e| Error(e.into())),
+            Local(local) => local.read_partial(tpe, id, offset, length).await,
+            Rest(rest) => rest.read_partial(tpe, id, offset, length).await,
         }
     }
 }
 
 #[async_trait]
 impl WriteBackend for ChooseBackend {
-    async fn create(&self) -> Result<(), Self::Error> {
+    async fn create(&self) -> Result<()> {
         match self {
-            Local(local) => local.create().await.map_err(|e| Error(e.into())),
-            Rest(rest) => rest.create().await.map_err(|e| Error(e.into())),
+            Local(local) => local.create().await,
+            Rest(rest) => rest.create().await,
         }
     }
 
-    async fn write_file(&self, tpe: FileType, id: &Id, f: File) -> Result<(), Self::Error> {
+    async fn write_file(&self, tpe: FileType, id: &Id, f: File) -> Result<()> {
         match self {
-            Local(local) => local
-                .write_file(tpe, id, f)
-                .await
-                .map_err(|e| Error(e.into())),
-            Rest(rest) => rest
-                .write_file(tpe, id, f)
-                .await
-                .map_err(|e| Error(e.into())),
+            Local(local) => local.write_file(tpe, id, f).await,
+            Rest(rest) => rest.write_file(tpe, id, f).await,
         }
     }
 
-    async fn write_bytes(&self, tpe: FileType, id: &Id, buf: Vec<u8>) -> Result<(), Self::Error> {
+    async fn write_bytes(&self, tpe: FileType, id: &Id, buf: Vec<u8>) -> Result<()> {
         match self {
-            Local(local) => local
-                .write_bytes(tpe, id, buf)
-                .await
-                .map_err(|e| Error(e.into())),
-            Rest(rest) => rest
-                .write_bytes(tpe, id, buf)
-                .await
-                .map_err(|e| Error(e.into())),
+            Local(local) => local.write_bytes(tpe, id, buf).await,
+            Rest(rest) => rest.write_bytes(tpe, id, buf).await,
         }
     }
 
-    async fn remove(&self, tpe: FileType, id: &Id) -> Result<(), Self::Error> {
+    async fn remove(&self, tpe: FileType, id: &Id) -> Result<()> {
         match self {
-            Local(local) => local.remove(tpe, id).await.map_err(|e| Error(e.into())),
-            Rest(rest) => rest.remove(tpe, id).await.map_err(|e| Error(e.into())),
+            Local(local) => local.remove(tpe, id).await,
+            Rest(rest) => rest.remove(tpe, id).await,
         }
     }
 }

--- a/src/backend/decrypt.rs
+++ b/src/backend/decrypt.rs
@@ -180,21 +180,19 @@ impl<R: ReadBackend, C: CryptoKey> DecryptReadBackend for DecryptBackend<R, C> {
 
 #[async_trait]
 impl<R: ReadBackend, C: CryptoKey> ReadBackend for DecryptBackend<R, C> {
-    type Error = R::Error;
-
     fn location(&self) -> &str {
         self.backend.location()
     }
 
-    async fn list(&self, tpe: FileType) -> Result<Vec<Id>, Self::Error> {
+    async fn list(&self, tpe: FileType) -> Result<Vec<Id>> {
         self.backend.list(tpe).await
     }
 
-    async fn list_with_size(&self, tpe: FileType) -> Result<Vec<(Id, u32)>, Self::Error> {
+    async fn list_with_size(&self, tpe: FileType) -> Result<Vec<(Id, u32)>> {
         self.backend.list_with_size(tpe).await
     }
 
-    async fn read_full(&self, tpe: FileType, id: &Id) -> Result<Vec<u8>, Self::Error> {
+    async fn read_full(&self, tpe: FileType, id: &Id) -> Result<Vec<u8>> {
         self.backend.read_full(tpe, id).await
     }
 
@@ -204,30 +202,26 @@ impl<R: ReadBackend, C: CryptoKey> ReadBackend for DecryptBackend<R, C> {
         id: &Id,
         offset: u32,
         length: u32,
-    ) -> Result<Vec<u8>, Self::Error> {
+    ) -> Result<Vec<u8>> {
         self.backend.read_partial(tpe, id, offset, length).await
     }
 }
 
 #[async_trait]
 impl<R: WriteBackend, C: CryptoKey> WriteBackend for DecryptBackend<R, C> {
-    async fn create(&self) -> Result<(), Self::Error> {
-        self.backend.create().await?;
-        Ok(())
+    async fn create(&self) -> Result<()> {
+        self.backend.create().await
     }
 
-    async fn write_file(&self, tpe: FileType, id: &Id, f: File) -> Result<(), Self::Error> {
-        self.backend.write_file(tpe, id, f).await?;
-        Ok(())
+    async fn write_file(&self, tpe: FileType, id: &Id, f: File) -> Result<()> {
+        self.backend.write_file(tpe, id, f).await
     }
 
-    async fn write_bytes(&self, tpe: FileType, id: &Id, buf: Vec<u8>) -> Result<(), Self::Error> {
-        self.backend.write_bytes(tpe, id, buf).await?;
-        Ok(())
+    async fn write_bytes(&self, tpe: FileType, id: &Id, buf: Vec<u8>) -> Result<()> {
+        self.backend.write_bytes(tpe, id, buf).await
     }
 
-    async fn remove(&self, tpe: FileType, id: &Id) -> Result<(), Self::Error> {
-        self.backend.remove(tpe, id).await?;
-        Ok(())
+    async fn remove(&self, tpe: FileType, id: &Id) -> Result<()> {
+        self.backend.remove(tpe, id).await
     }
 }

--- a/src/backend/dry_run.rs
+++ b/src/backend/dry_run.rs
@@ -40,16 +40,15 @@ impl<BE: DecryptFullBackend> DecryptReadBackend for DryRunBackend<BE> {
 
 #[async_trait]
 impl<BE: DecryptFullBackend> ReadBackend for DryRunBackend<BE> {
-    type Error = <BE as ReadBackend>::Error;
     fn location(&self) -> &str {
         self.be.location()
     }
 
-    async fn list_with_size(&self, tpe: FileType) -> Result<Vec<(Id, u32)>, Self::Error> {
+    async fn list_with_size(&self, tpe: FileType) -> Result<Vec<(Id, u32)>> {
         self.be.list_with_size(tpe).await
     }
 
-    async fn read_full(&self, tpe: FileType, id: &Id) -> Result<Vec<u8>, Self::Error> {
+    async fn read_full(&self, tpe: FileType, id: &Id) -> Result<Vec<u8>> {
         self.be.read_full(tpe, id).await
     }
 
@@ -59,7 +58,7 @@ impl<BE: DecryptFullBackend> ReadBackend for DryRunBackend<BE> {
         id: &Id,
         offset: u32,
         length: u32,
-    ) -> Result<Vec<u8>, Self::Error> {
+    ) -> Result<Vec<u8>> {
         self.be.read_partial(tpe, id, offset, length).await
     }
 }
@@ -89,28 +88,28 @@ impl<BE: DecryptFullBackend> DecryptWriteBackend for DryRunBackend<BE> {
 
 #[async_trait]
 impl<BE: DecryptFullBackend> WriteBackend for DryRunBackend<BE> {
-    async fn create(&self) -> Result<(), Self::Error> {
+    async fn create(&self) -> Result<()> {
         match self.dry_run {
             true => Ok(()),
             false => self.be.create().await,
         }
     }
 
-    async fn write_file(&self, tpe: FileType, id: &Id, f: File) -> Result<(), Self::Error> {
+    async fn write_file(&self, tpe: FileType, id: &Id, f: File) -> Result<()> {
         match self.dry_run {
             true => Ok(()),
             false => self.be.write_file(tpe, id, f).await,
         }
     }
 
-    async fn write_bytes(&self, tpe: FileType, id: &Id, buf: Vec<u8>) -> Result<(), Self::Error> {
+    async fn write_bytes(&self, tpe: FileType, id: &Id, buf: Vec<u8>) -> Result<()> {
         match self.dry_run {
             true => Ok(()),
             false => self.be.write_bytes(tpe, id, buf).await,
         }
     }
 
-    async fn remove(&self, tpe: FileType, id: &Id) -> Result<(), Self::Error> {
+    async fn remove(&self, tpe: FileType, id: &Id) -> Result<()> {
         match self.dry_run {
             true => Ok(()),
             false => self.be.remove(tpe, id).await,

--- a/src/backend/dry_run.rs
+++ b/src/backend/dry_run.rs
@@ -29,11 +29,12 @@ impl<BE: DecryptFullBackend> DecryptReadBackend for DryRunBackend<BE> {
         &self,
         tpe: FileType,
         id: &Id,
+        cacheable: bool,
         offset: u32,
         length: u32,
     ) -> Result<Vec<u8>> {
         self.be
-            .read_encrypted_partial(tpe, id, offset, length)
+            .read_encrypted_partial(tpe, id, cacheable, offset, length)
             .await
     }
 }
@@ -56,10 +57,13 @@ impl<BE: DecryptFullBackend> ReadBackend for DryRunBackend<BE> {
         &self,
         tpe: FileType,
         id: &Id,
+        cacheable: bool,
         offset: u32,
         length: u32,
     ) -> Result<Vec<u8>> {
-        self.be.read_partial(tpe, id, offset, length).await
+        self.be
+            .read_partial(tpe, id, cacheable, offset, length)
+            .await
     }
 }
 
@@ -95,10 +99,10 @@ impl<BE: DecryptFullBackend> WriteBackend for DryRunBackend<BE> {
         }
     }
 
-    async fn write_file(&self, tpe: FileType, id: &Id, f: File) -> Result<()> {
+    async fn write_file(&self, tpe: FileType, id: &Id, cacheable: bool, f: File) -> Result<()> {
         match self.dry_run {
             true => Ok(()),
-            false => self.be.write_file(tpe, id, f).await,
+            false => self.be.write_file(tpe, id, cacheable, f).await,
         }
     }
 

--- a/src/backend/local.rs
+++ b/src/backend/local.rs
@@ -101,6 +101,7 @@ impl ReadBackend for LocalBackend {
         &self,
         tpe: FileType,
         id: &Id,
+        _cacheable: bool,
         offset: u32,
         length: u32,
     ) -> Result<Vec<u8>> {
@@ -124,7 +125,13 @@ impl WriteBackend for LocalBackend {
         Ok(())
     }
 
-    async fn write_file(&self, tpe: FileType, id: &Id, mut f: File) -> Result<()> {
+    async fn write_file(
+        &self,
+        tpe: FileType,
+        id: &Id,
+        _cacheable: bool,
+        mut f: File,
+    ) -> Result<()> {
         v3!("writing tpe: {:?}, id: {}", &tpe, &id);
         let filename = self.path(tpe, id);
         let mut file = fs::OpenOptions::new()

--- a/src/backend/local.rs
+++ b/src/backend/local.rs
@@ -4,6 +4,7 @@ use std::os::unix::fs::FileExt;
 use std::os::unix::fs::PermissionsExt;
 use std::path::{Path, PathBuf};
 
+use anyhow::Result;
 use async_trait::async_trait;
 use vlog::*;
 use walkdir::WalkDir;
@@ -32,13 +33,11 @@ impl LocalBackend {
 
 #[async_trait]
 impl ReadBackend for LocalBackend {
-    type Error = std::io::Error;
-
     fn location(&self) -> &str {
         self.path.to_str().unwrap()
     }
 
-    async fn list(&self, tpe: FileType) -> Result<Vec<Id>, Self::Error> {
+    async fn list(&self, tpe: FileType) -> Result<Vec<Id>> {
         if tpe == FileType::Config {
             return Ok(match self.path.join("config").exists() {
                 true => vec![Id::default()],
@@ -55,7 +54,7 @@ impl ReadBackend for LocalBackend {
         Ok(walker.collect())
     }
 
-    async fn list_with_size(&self, tpe: FileType) -> Result<Vec<(Id, u32)>, Self::Error> {
+    async fn list_with_size(&self, tpe: FileType) -> Result<Vec<(Id, u32)>> {
         let path = self.path.join(tpe.name());
 
         if tpe == FileType::Config {
@@ -94,8 +93,8 @@ impl ReadBackend for LocalBackend {
         Ok(walker.collect())
     }
 
-    async fn read_full(&self, tpe: FileType, id: &Id) -> Result<Vec<u8>, Self::Error> {
-        fs::read(self.path(tpe, id))
+    async fn read_full(&self, tpe: FileType, id: &Id) -> Result<Vec<u8>> {
+        Ok(fs::read(self.path(tpe, id))?)
     }
 
     async fn read_partial(
@@ -104,7 +103,7 @@ impl ReadBackend for LocalBackend {
         id: &Id,
         offset: u32,
         length: u32,
-    ) -> Result<Vec<u8>, Self::Error> {
+    ) -> Result<Vec<u8>> {
         let mut file = File::open(self.path(tpe, id))?;
         file.seek(SeekFrom::Start(offset.try_into().unwrap()))?;
         let mut vec = vec![0; length.try_into().unwrap()];
@@ -115,7 +114,7 @@ impl ReadBackend for LocalBackend {
 
 #[async_trait]
 impl WriteBackend for LocalBackend {
-    async fn create(&self) -> Result<(), Self::Error> {
+    async fn create(&self) -> Result<()> {
         for tpe in ALL_FILE_TYPES {
             fs::create_dir_all(self.path.join(tpe.name()))?;
         }
@@ -125,7 +124,7 @@ impl WriteBackend for LocalBackend {
         Ok(())
     }
 
-    async fn write_file(&self, tpe: FileType, id: &Id, mut f: File) -> Result<(), Self::Error> {
+    async fn write_file(&self, tpe: FileType, id: &Id, mut f: File) -> Result<()> {
         v3!("writing tpe: {:?}, id: {}", &tpe, &id);
         let filename = self.path(tpe, id);
         let mut file = fs::OpenOptions::new()
@@ -133,10 +132,11 @@ impl WriteBackend for LocalBackend {
             .write(true)
             .open(&filename)?;
         copy(&mut f, &mut file)?;
-        file.sync_all()
+        file.sync_all()?;
+        Ok(())
     }
 
-    async fn write_bytes(&self, tpe: FileType, id: &Id, buf: Vec<u8>) -> Result<(), Self::Error> {
+    async fn write_bytes(&self, tpe: FileType, id: &Id, buf: Vec<u8>) -> Result<()> {
         v3!("writing tpe: {:?}, id: {}", &tpe, &id);
         let filename = self.path(tpe, id);
         let mut file = fs::OpenOptions::new()
@@ -144,13 +144,15 @@ impl WriteBackend for LocalBackend {
             .write(true)
             .open(&filename)?;
         file.write_all(&buf)?;
-        file.sync_all()
+        file.sync_all()?;
+        Ok(())
     }
 
-    async fn remove(&self, tpe: FileType, id: &Id) -> Result<(), Self::Error> {
+    async fn remove(&self, tpe: FileType, id: &Id) -> Result<()> {
         v3!("writing tpe: {:?}, id: {}", &tpe, &id);
         let filename = self.path(tpe, id);
-        fs::remove_file(filename)
+        fs::remove_file(filename)?;
+        Ok(())
     }
 }
 

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -76,6 +76,7 @@ pub trait ReadBackend: Clone + Send + Sync + 'static {
         &self,
         tpe: FileType,
         id: &Id,
+        cacheable: bool,
         offset: u32,
         length: u32,
     ) -> Result<Vec<u8>>;
@@ -133,7 +134,7 @@ pub trait ReadBackend: Clone + Send + Sync + 'static {
 #[async_trait]
 pub trait WriteBackend: ReadBackend {
     async fn create(&self) -> Result<()>;
-    async fn write_file(&self, tpe: FileType, id: &Id, f: File) -> Result<()>;
+    async fn write_file(&self, tpe: FileType, id: &Id, cacheable: bool, f: File) -> Result<()>;
     async fn write_bytes(&self, tpe: FileType, id: &Id, buf: Vec<u8>) -> Result<()>;
     async fn remove(&self, tpe: FileType, id: &Id) -> Result<()>;
 }

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -8,6 +8,7 @@ use serde::{de::DeserializeOwned, Serialize};
 
 use crate::id::Id;
 
+pub mod cache;
 pub mod choose;
 pub mod decrypt;
 pub mod dry_run;
@@ -17,6 +18,7 @@ pub mod node;
 pub mod rest;
 
 pub use self::ignore::*;
+pub use cache::*;
 pub use choose::*;
 pub use decrypt::*;
 pub use dry_run::*;
@@ -49,6 +51,13 @@ impl FileType {
             FileType::Index => "index",
             FileType::Key => "keys",
             FileType::Pack => "data",
+        }
+    }
+
+    pub fn is_cacheable(&self) -> bool {
+        match self {
+            FileType::Config | FileType::Key => false,
+            FileType::Snapshot | FileType::Index | FileType::Pack => true,
         }
     }
 }

--- a/src/backend/rest.rs
+++ b/src/backend/rest.rs
@@ -107,6 +107,7 @@ impl ReadBackend for RestBackend {
         &self,
         tpe: FileType,
         id: &Id,
+        _cacheable: bool,
         offset: u32,
         length: u32,
     ) -> Result<Vec<u8>> {
@@ -135,7 +136,7 @@ impl WriteBackend for RestBackend {
         Ok(())
     }
 
-    async fn write_file(&self, tpe: FileType, id: &Id, f: File) -> Result<()> {
+    async fn write_file(&self, tpe: FileType, id: &Id, _cacheable: bool, f: File) -> Result<()> {
         v3!("writing tpe: {:?}, id: {}", &tpe, &id);
         self.client
             .post(self.url(tpe, id))

--- a/src/commands/backup.rs
+++ b/src/commands/backup.rs
@@ -13,7 +13,6 @@ use crate::backend::{
     DecryptFullBackend, DecryptWriteBackend, DryRunBackend, LocalSource, LocalSourceOptions,
     ReadSource,
 };
-use crate::id::Id;
 use crate::index::IndexBackend;
 use crate::repo::{ConfigFile, DeleteOption, SnapshotFile, SnapshotSummary, StringList};
 
@@ -53,11 +52,10 @@ pub(super) struct Opts {
 pub(super) async fn execute(
     be: &impl DecryptFullBackend,
     opts: Opts,
-    config_id: &Id,
+    config: ConfigFile,
     command: String,
 ) -> Result<()> {
     let time = Local::now();
-    let config: ConfigFile = be.get_file(config_id).await?;
     let poly = config.poly()?;
     let zstd = match config.version {
         1 => None,

--- a/src/commands/forget.rs
+++ b/src/commands/forget.rs
@@ -6,9 +6,8 @@ use prettytable::{cell, format, row, Table};
 
 use super::{progress_counter, prune};
 use crate::backend::{DecryptFullBackend, FileType};
-use crate::id::Id;
 use crate::repo::{
-    SnapshotFile, SnapshotFilter, SnapshotGroup, SnapshotGroupCriterion, StringList,
+    ConfigFile, SnapshotFile, SnapshotFilter, SnapshotGroup, SnapshotGroupCriterion, StringList,
 };
 
 #[derive(Parser)]
@@ -46,7 +45,7 @@ pub(super) struct Opts {
 pub(super) async fn execute(
     be: &(impl DecryptFullBackend + Unpin),
     mut opts: Opts,
-    config_id: &Id,
+    config: ConfigFile,
 ) -> Result<()> {
     opts.dry_run = opts.prune_opts.dry_run;
     let groups = match opts.ids.is_empty() {
@@ -123,7 +122,7 @@ pub(super) async fn execute(
     }
 
     if opts.prune {
-        prune::execute(be, opts.prune_opts, config_id, forget_snaps).await?;
+        prune::execute(be, opts.prune_opts, config, forget_snaps).await?;
     }
 
     Ok(())

--- a/src/commands/prune.rs
+++ b/src/commands/prune.rs
@@ -730,7 +730,13 @@ impl Pruner {
                                 continue;
                             }
                             let data = be
-                                .read_partial(FileType::Pack, &pack.id, blob.offset, blob.length)
+                                .read_partial(
+                                    FileType::Pack,
+                                    &pack.id,
+                                    blob.tpe.is_cacheable(),
+                                    blob.offset,
+                                    blob.length,
+                                )
                                 .await?;
                             match blob.tpe {
                                 BlobType::Data => &mut data_packer,

--- a/src/commands/prune.rs
+++ b/src/commands/prune.rs
@@ -46,13 +46,12 @@ pub(super) struct Opts {
 pub(super) async fn execute(
     be: &(impl DecryptFullBackend + Unpin),
     opts: Opts,
-    config_id: &Id,
+    config: ConfigFile,
     ignore_snaps: Vec<Id>,
 ) -> Result<()> {
     v1!("reading index...");
     let mut index_files = Vec::new();
 
-    let config: ConfigFile = be.get_file(config_id).await?;
     let zstd = match config.version {
         1 => None,
         2 => Some(0),

--- a/src/commands/restore.rs
+++ b/src/commands/restore.rs
@@ -114,7 +114,7 @@ async fn restore_contents(
             stream.push(spawn(async move {
                 // read pack at blob_offset with length blob_length
                 let data = be
-                    .read_encrypted_partial(FileType::Pack, &pack, bl.offset, bl.length)
+                    .read_encrypted_partial(FileType::Pack, &pack, false, bl.offset, bl.length)
                     .await
                     .unwrap();
 

--- a/src/index/binarysorted.rs
+++ b/src/index/binarysorted.rs
@@ -114,6 +114,7 @@ impl ReadIndex for Index {
         vec.binary_search_by_key(id, |e| e.id).ok().map(|index| {
             let be = &vec[index];
             IndexEntry::new(
+                *tpe,
                 self.packs[be.pack_idx],
                 be.offset,
                 be.length,

--- a/src/index/mod.rs
+++ b/src/index/mod.rs
@@ -24,6 +24,7 @@ pub use indexer::*;
 
 #[derive(Debug, Clone, Constructor, Getters)]
 pub struct IndexEntry {
+    blob_type: BlobType,
     pack: Id,
     offset: u32,
     length: u32,
@@ -33,6 +34,7 @@ pub struct IndexEntry {
 impl IndexEntry {
     pub fn from_index_blob(blob: &IndexBlob, pack: Id) -> Self {
         Self {
+            blob_type: blob.tpe,
             pack,
             offset: blob.offset,
             length: blob.length,
@@ -43,7 +45,13 @@ impl IndexEntry {
     /// Get a blob described by IndexEntry from the backend
     pub async fn read_data<B: DecryptReadBackend>(&self, be: &B) -> Result<Vec<u8>> {
         let data = be
-            .read_encrypted_partial(FileType::Pack, &self.pack, self.offset, self.length)
+            .read_encrypted_partial(
+                FileType::Pack,
+                &self.pack,
+                self.blob_type.is_cacheable(),
+                self.offset,
+                self.length,
+            )
             .await?;
         Ok(match self.uncompressed_length {
             None => data,


### PR DESCRIPTION
Open points are:

- [x] update Readme
- [x] Add checks for cache in `check` command
- [ ] remove unneeded tree packs when reading the index

If a cache base dir is not explicitely given, rustic first tries to find a restic cache dir for the given repo and uses this one exists. If not, it searches for a rustic cache dir.