### PR TITLE
Allow to customize pack size

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -847,6 +847,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "integer-sqrt"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "276ec31bcb4a9ee45f58bec6f9ec700ae4cf4f4f8f2fa7e06cb406bd5ffdd770"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1373,6 +1382,7 @@ dependencies = [
  "humantime",
  "ignore",
  "indicatif",
+ "integer-sqrt",
  "itertools",
  "lazy_static",
  "nix",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -463,6 +463,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "enum-map"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ddfe61e8040145222887d0d32a939c70c8cae681490d72fb868305e9b40ced8"
+dependencies = [
+ "enum-map-derive",
+]
+
+[[package]]
+name = "enum-map-derive"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00d1c54e25a57236a790ecf051c2befbb57740c9b86c4273eac378ba84d620d6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "fastrand"
 version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1375,6 +1395,8 @@ dependencies = [
  "derive-getters",
  "derive_more",
  "dirs 4.0.0",
+ "enum-map",
+ "enum-map-derive",
  "filetime",
  "futures",
  "gethostname",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,8 +34,9 @@ aes256ctr_poly1305aes = "0.1"
 sha2 = "0.10"
 rand = "0.8"
 scrypt = { version = "0.10", default-features = false }
-# chunker
+# chunker / packer
 cdc = "0.1"
+integer-sqrt = "0.1"
 # serialization
 base64 = "0.13"
 binrw = "0.9"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,6 +48,8 @@ serde-aux = "3"
 chrono = { version = "0.4", features = ["serde"] }
 tempfile = "3"
 zstd = "0.11"
+enum-map = "2"
+enum-map-derive = "0.9"
 # local backend
 walkdir = "2"
 ignore = "0.4"

--- a/src/archiver/archiver_impl.rs
+++ b/src/archiver/archiver_impl.rs
@@ -10,7 +10,7 @@ use tokio::spawn;
 use vlog::*;
 
 use crate::backend::DecryptWriteBackend;
-use crate::blob::{BlobType, Metadata, Node, NodeType, Packer, Tree, DEFAULT_TREE_SIZE};
+use crate::blob::{BlobType, Metadata, Node, NodeType, Packer, Tree};
 use crate::chunker::ChunkIter;
 use crate::crypto::hash;
 use crate::id::Id;
@@ -42,7 +42,6 @@ impl<BE: DecryptWriteBackend, I: IndexedBackend> Archiver<BE, I> {
         parent: Parent<I>,
         mut snap: SnapshotFile,
         zstd: Option<i32>,
-        default_data_size: u32,
     ) -> Result<Self> {
         let indexer = Indexer::new(be.clone()).into_shared();
         let mut summary = snap.summary.take().unwrap();
@@ -53,7 +52,6 @@ impl<BE: DecryptWriteBackend, I: IndexedBackend> Archiver<BE, I> {
             BlobType::Data,
             indexer.clone(),
             zstd,
-            default_data_size,
             index.total_size(&BlobType::Data),
         )?;
         let tree_packer = Packer::new(
@@ -61,7 +59,6 @@ impl<BE: DecryptWriteBackend, I: IndexedBackend> Archiver<BE, I> {
             BlobType::Tree,
             indexer.clone(),
             zstd,
-            DEFAULT_TREE_SIZE,
             index.total_size(&BlobType::Tree),
         )?;
         Ok(Self {

--- a/src/archiver/archiver_impl.rs
+++ b/src/archiver/archiver_impl.rs
@@ -15,7 +15,7 @@ use crate::chunker::ChunkIter;
 use crate::crypto::hash;
 use crate::id::Id;
 use crate::index::{IndexedBackend, Indexer, SharedIndexer};
-use crate::repo::{SnapshotFile, SnapshotSummary};
+use crate::repo::{ConfigFile, SnapshotFile, SnapshotSummary};
 
 use super::{Parent, ParentResult};
 
@@ -38,27 +38,27 @@ impl<BE: DecryptWriteBackend, I: IndexedBackend> Archiver<BE, I> {
     pub fn new(
         be: BE,
         index: I,
-        poly: u64,
+        config: &ConfigFile,
         parent: Parent<I>,
         mut snap: SnapshotFile,
-        zstd: Option<i32>,
     ) -> Result<Self> {
         let indexer = Indexer::new(be.clone()).into_shared();
         let mut summary = snap.summary.take().unwrap();
         summary.backup_start = Local::now();
+        let poly = config.poly()?;
 
         let data_packer = Packer::new(
             be.clone(),
             BlobType::Data,
             indexer.clone(),
-            zstd,
+            config,
             index.total_size(&BlobType::Data),
         )?;
         let tree_packer = Packer::new(
             be.clone(),
             BlobType::Tree,
             indexer.clone(),
-            zstd,
+            config,
             index.total_size(&BlobType::Tree),
         )?;
         Ok(Self {

--- a/src/blob/mod.rs
+++ b/src/blob/mod.rs
@@ -5,11 +5,14 @@ pub use packer::*;
 pub use tree::*;
 
 use derive_more::Constructor;
+use enum_map::{Enum, EnumMap};
 use serde::{Deserialize, Serialize};
 
 use crate::id::Id;
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[derive(
+    Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize, Enum,
+)]
 pub enum BlobType {
     #[serde(rename = "tree")]
     Tree,
@@ -25,6 +28,8 @@ impl BlobType {
         }
     }
 }
+
+pub type BlobTypeMap<T> = EnumMap<BlobType, T>;
 
 #[derive(Debug, PartialEq, Clone, Constructor)]
 pub struct Blob {

--- a/src/commands/backup.rs
+++ b/src/commands/backup.rs
@@ -1,7 +1,6 @@
 use std::path::PathBuf;
 
 use anyhow::{anyhow, Result};
-use bytesize::ByteSize;
 use chrono::{Duration, Local};
 use clap::Parser;
 use gethostname::gethostname;
@@ -42,11 +41,6 @@ pub(super) struct Opts {
     /// Mark snapshot to be deleted after given duration (e.g. 10d)
     #[clap(long, value_name = "DURATION")]
     delete_after: Option<humantime::Duration>,
-
-    /// Default packsize. rustic tries to always produce packs greater than this value.
-    /// Note that for large repos, packs can get even larger. Does only apply to data packs.
-    #[clap(long, value_name = "SIZE", default_value = "50M")]
-    default_packsize: ByteSize,
 
     #[clap(flatten)]
     ignore_opts: LocalSourceOptions,
@@ -135,10 +129,8 @@ pub(super) async fn execute(
     } else {
         0
     };
-    let default_packsize = opts.default_packsize.as_u64().try_into()?;
-
     v1!("starting backup...");
-    let mut archiver = Archiver::new(be, index, poly, parent, snap, zstd, default_packsize)?;
+    let mut archiver = Archiver::new(be, index, poly, parent, snap, zstd)?;
     let p = progress_bytes();
     p.set_length(size);
     for item in src {

--- a/src/commands/backup.rs
+++ b/src/commands/backup.rs
@@ -1,6 +1,7 @@
 use std::path::PathBuf;
 
 use anyhow::{anyhow, Result};
+use bytesize::ByteSize;
 use chrono::{Duration, Local};
 use clap::Parser;
 use gethostname::gethostname;
@@ -41,6 +42,11 @@ pub(super) struct Opts {
     /// Mark snapshot to be deleted after given duration (e.g. 10d)
     #[clap(long, value_name = "DURATION")]
     delete_after: Option<humantime::Duration>,
+
+    /// Default packsize. rustic tries to always produce packs greater than this value.
+    /// Note that for large repos, packs can get even larger. Does only apply to data packs.
+    #[clap(long, value_name = "SIZE", default_value = "50M")]
+    default_packsize: ByteSize,
 
     #[clap(flatten)]
     ignore_opts: LocalSourceOptions,
@@ -129,9 +135,10 @@ pub(super) async fn execute(
     } else {
         0
     };
+    let default_packsize = opts.default_packsize.as_u64().try_into()?;
 
     v1!("starting backup...");
-    let mut archiver = Archiver::new(be, index, poly, parent, snap, zstd)?;
+    let mut archiver = Archiver::new(be, index, poly, parent, snap, zstd, default_packsize)?;
     let p = progress_bytes();
     p.set_length(size);
     for item in src {

--- a/src/commands/backup.rs
+++ b/src/commands/backup.rs
@@ -56,7 +56,6 @@ pub(super) async fn execute(
     command: String,
 ) -> Result<()> {
     let time = Local::now();
-    let poly = config.poly()?;
     let zstd = config.zstd()?;
     let mut be = DryRunBackend::new(be.clone(), opts.dry_run);
     be.set_zstd(zstd);
@@ -130,7 +129,7 @@ pub(super) async fn execute(
         0
     };
     v1!("starting backup...");
-    let mut archiver = Archiver::new(be, index, poly, parent, snap, zstd)?;
+    let mut archiver = Archiver::new(be, index, &config, parent, snap)?;
     let p = progress_bytes();
     p.set_length(size);
     for item in src {

--- a/src/commands/config.rs
+++ b/src/commands/config.rs
@@ -1,4 +1,5 @@
 use anyhow::{bail, Result};
+use bytesize::ByteSize;
 use clap::Parser;
 
 use crate::backend::DecryptFullBackend;
@@ -36,6 +37,30 @@ pub(super) struct ConfigOpts {
     /// set repository version
     #[clap(long, value_name = "VERSION")]
     pub set_version: Option<u32>,
+
+    /// Set default packsize for tree packs. rustic tries to always produce packs greater than this value.
+    /// Note that for large repos, this value is grown by the grown factor.
+    /// Defaults to 4 MiB if not set.
+    #[clap(long, value_name = "SIZE")]
+    pub set_treepack_size: Option<ByteSize>,
+
+    /// Set grow factor for tree packs. The default packsize grows by the square root of the reposize
+    /// multiplied with this factor. This means 32 kiB times this factor per square root of reposize in GiB.
+    /// Defaults to 32 (= 1MB per sqare root of reposize in GiB) if not set.
+    #[clap(long, value_name = "FACTOR")]
+    pub set_treepack_growfactor: Option<u32>,
+
+    /// Set default packsize for data packs. rustic tries to always produce packs greater than this value.
+    /// Note that for large repos, this value is grown by the grown factor.
+    /// Defaults to 32 MiB if not set.
+    #[clap(long, value_name = "SIZE")]
+    pub set_datapack_size: Option<ByteSize>,
+
+    /// set grow factor for data packs. The default packsize grows by the square root of the reposize
+    /// multiplied with this factor. This means 32 kiB times this factor per square root of reposize in GiB.
+    /// Defaults to 32 (= 1MB per sqare root of reposize in GiB) if not set.
+    #[clap(long, value_name = "FACTOR")]
+    pub set_datapack_growfactor: Option<u32>,
 }
 
 impl ConfigOpts {
@@ -69,6 +94,19 @@ impl ConfigOpts {
                 );
             }
             config.compression = Some(compression);
+        }
+
+        if let Some(size) = self.set_treepack_size {
+            config.treepack_size = Some(size.as_u64().try_into()?);
+        }
+        if let Some(factor) = self.set_treepack_growfactor {
+            config.treepack_growfactor = Some(factor);
+        }
+        if let Some(size) = self.set_datapack_size {
+            config.datapack_size = Some(size.as_u64().try_into()?);
+        }
+        if let Some(factor) = self.set_treepack_growfactor {
+            config.datapack_growfactor = Some(factor);
         }
 
         Ok(())

--- a/src/commands/prune.rs
+++ b/src/commands/prune.rs
@@ -753,7 +753,7 @@ impl Pruner {
             be.clone(),
             BlobType::Tree,
             indexer.clone(),
-            zstd,
+            &config,
             tree_size_after_prune,
         )?;
 
@@ -761,7 +761,7 @@ impl Pruner {
             be.clone(),
             BlobType::Data,
             indexer.clone(),
-            zstd,
+            &config,
             data_size_after_prune,
         )?;
 

--- a/src/index/binarysorted.rs
+++ b/src/index/binarysorted.rs
@@ -29,6 +29,8 @@ pub(crate) struct IndexCollector {
     packs: Vec<Id>,
     tree: Vec<SortedEntry>,
     data: SortedHashSetMap,
+    total_tree_size: u64,
+    total_data_size: u64,
 }
 
 impl IndexCollector {
@@ -42,6 +44,8 @@ impl IndexCollector {
             packs: Vec::new(),
             tree: Vec::new(),
             data,
+            total_tree_size: 0,
+            total_data_size: 0,
         }
     }
 
@@ -56,6 +60,8 @@ impl IndexCollector {
             packs: self.packs,
             tree: self.tree,
             data: self.data,
+            total_tree_size: self.total_tree_size,
+            total_data_size: self.total_data_size,
         }
     }
 }
@@ -69,6 +75,12 @@ impl Extend<IndexPack> for IndexCollector {
             let idx = self.packs.len();
             self.packs.push(p.id);
             let len = p.blobs.len();
+            let blob_type = p.blob_type();
+
+            match blob_type {
+                BlobType::Tree => self.total_tree_size += p.pack_size() as u64,
+                BlobType::Data => self.total_data_size += p.pack_size() as u64,
+            }
 
             match (p.blob_type(), &mut self.data) {
                 (BlobType::Tree, _) => self.tree.reserve(len),
@@ -100,6 +112,8 @@ pub struct Index {
     packs: Vec<Id>,
     tree: Vec<SortedEntry>,
     data: SortedHashSetMap,
+    total_tree_size: u64,
+    total_data_size: u64,
 }
 
 impl ReadIndex for Index {
@@ -121,6 +135,13 @@ impl ReadIndex for Index {
                 be.uncompressed_length,
             )
         })
+    }
+
+    fn total_size(&self, tpe: &BlobType) -> u64 {
+        match tpe {
+            BlobType::Tree => self.total_tree_size,
+            BlobType::Data => self.total_data_size,
+        }
     }
 
     fn has(&self, tpe: &BlobType, id: &Id) -> bool {

--- a/src/index/mod.rs
+++ b/src/index/mod.rs
@@ -70,6 +70,7 @@ impl IndexEntry {
 #[delegatable_trait]
 pub trait ReadIndex {
     fn get_id(&self, tpe: &BlobType, id: &Id) -> Option<IndexEntry>;
+    fn total_size(&self, tpe: &BlobType) -> u64;
 
     fn get_tree(&self, id: &Id) -> Option<IndexEntry> {
         self.get_id(&BlobType::Tree, id)

--- a/src/repo/configfile.rs
+++ b/src/repo/configfile.rs
@@ -2,6 +2,7 @@ use anyhow::{bail, Result};
 use serde::{Deserialize, Serialize};
 
 use crate::backend::{FileType, RepoFile};
+use crate::blob::BlobType;
 use crate::id::Id;
 
 #[derive(Debug, Default, Clone, PartialEq, Serialize, Deserialize)]
@@ -13,11 +14,28 @@ pub struct ConfigFile {
     pub is_hot: Option<bool>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub compression: Option<i32>, // note that Some(0) means no compression.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub treepack_size: Option<u32>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub treepack_growfactor: Option<u32>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub datapack_size: Option<u32>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub datapack_growfactor: Option<u32>,
 }
 
 impl RepoFile for ConfigFile {
     const TYPE: FileType = FileType::Config;
 }
+
+const KB: u32 = 1024;
+const MB: u32 = 1024 * KB;
+// default pack size
+const DEFAULT_TREE_SIZE: u32 = 4 * MB;
+const DEFAULT_DATA_SIZE: u32 = 32 * MB;
+// the default factor used for repo-size dependent pack size.
+// 32 * sqrt(reposize in bytes) = 1 MB * sqrt(reposize in GB)
+const DEFAULT_GROW_FACTOR: u32 = 32;
 
 impl ConfigFile {
     pub fn new(version: u32, id: Id, poly: u64) -> Self {
@@ -27,6 +45,10 @@ impl ConfigFile {
             chunker_polynomial: format!("{:x}", poly),
             is_hot: None,
             compression: None,
+            treepack_size: None,
+            treepack_growfactor: None,
+            datapack_size: None,
+            datapack_growfactor: None,
         }
     }
 
@@ -40,6 +62,19 @@ impl ConfigFile {
             (2, None) => Ok(Some(0)), // use default (=0) zstd compression
             (2, Some(c)) => Ok(Some(c)),
             _ => bail!("config version not supported!"),
+        }
+    }
+
+    pub fn packsize(&self, blob: BlobType) -> (u32, u32) {
+        match blob {
+            BlobType::Tree => (
+                self.treepack_size.unwrap_or(DEFAULT_TREE_SIZE),
+                self.treepack_growfactor.unwrap_or(DEFAULT_GROW_FACTOR),
+            ),
+            BlobType::Data => (
+                self.datapack_size.unwrap_or(DEFAULT_DATA_SIZE),
+                self.datapack_growfactor.unwrap_or(DEFAULT_GROW_FACTOR),
+            ),
         }
     }
 }


### PR DESCRIPTION
closes #51

Checklist:
- [x] determine current tree and data size from index
- [x] add default size to packer
- [x] add size depending on current repo size to packer
- [x] add option `--default-packsize` to backup
- [x] backup: use dynamic pack size
- [x] add option `--default-packsize` to backup
- [x] prune: specify pack size for repacked packs
- [x] prune: determine correct tree and pack size after pruning
- [x] prune: use correct  tree and pack size after pruning for pack size
- [ ] prune: mark too small and too large packs for repacking
- [ ] prune: add customizing options to select "small" and "large" packs
- [x] repoinfo: Add info about pack sizes
- [x] add pack size options to config file