### PR TITLE
Add rclone Backend

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1385,6 +1385,7 @@ dependencies = [
  "serde",
  "serde-aux",
  "serde_json",
+ "sha1",
  "sha2",
  "tempfile",
  "thiserror",
@@ -1526,6 +1527,17 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "sha1"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c77f4e7f65455545c2153c1253d25056825e77ee2533f0e41deb65a93a34852f"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,6 +54,8 @@ nix = "0.24"
 filetime = "0.2"
 # rest backend
 reqwest = {version = "0.11", default-features = false, features = ["json", "rustls-tls", "stream"] }
+# rclone backend
+sha1 = "0.10"
 # cache
 dirs = "4"
 cachedir = "0.3"

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -16,6 +16,7 @@ pub mod hotcold;
 pub mod ignore;
 pub mod local;
 pub mod node;
+pub mod rclone;
 pub mod rest;
 
 pub use self::ignore::*;
@@ -26,6 +27,7 @@ pub use dry_run::*;
 pub use hotcold::*;
 pub use local::*;
 use node::Node;
+pub use rclone::*;
 pub use rest::*;
 
 /// All FileTypes which are located in separated directories

--- a/src/backend/rclone.rs
+++ b/src/backend/rclone.rs
@@ -1,0 +1,152 @@
+use std::fs::File;
+use std::io::{BufRead, BufReader, Write};
+use std::path::PathBuf;
+use std::process::{Child, Command, Stdio};
+use std::sync::Arc;
+
+use anyhow::{anyhow, bail, Result};
+use async_trait::async_trait;
+use rand::distributions::{Alphanumeric, DistString};
+use rand::thread_rng;
+use sha1::{Digest, Sha1};
+use tempfile::{Builder, TempDir};
+use vlog::*;
+
+use super::{FileType, Id, ReadBackend, RestBackend, WriteBackend};
+
+// create a .htpasswd file with random user/password
+fn htpasswd() -> Result<(TempDir, PathBuf, String, String)> {
+    let dir = Builder::new().prefix("rustic").tempdir()?;
+
+    let file_path = dir.path().join(".htpasswd");
+    let mut file = File::create(&file_path)?;
+
+    let user = Alphanumeric.sample_string(&mut thread_rng(), 12);
+    let password = Alphanumeric.sample_string(&mut thread_rng(), 12);
+
+    let mut hasher = Sha1::new();
+    hasher.update(password.as_bytes());
+    let pass = base64::encode(hasher.finalize());
+
+    writeln!(file, "{}:{{SHA}}{}", user, pass)?;
+
+    Ok((dir, file_path, user, password))
+}
+
+struct ChildToKill(Child);
+impl Drop for ChildToKill {
+    fn drop(&mut self) {
+        v3!("killing rclone.");
+        self.0.kill().unwrap();
+    }
+}
+
+#[derive(Clone)]
+pub struct RcloneBackend {
+    rest: RestBackend,
+    _child_data: Arc<(ChildToKill, TempDir)>,
+}
+
+impl RcloneBackend {
+    pub fn new(url: &str) -> Result<Self> {
+        let (tmp_dir, file, user, pass) = htpasswd()?;
+
+        let args = [
+            "serve",
+            "restic",
+            url,
+            "--addr",
+            "localhost:0",
+            "--htpasswd",
+            file.to_str().unwrap(),
+        ];
+        v3!("starting rclone with args {args:?}");
+        let mut child = Command::new("rclone")
+            .args(args)
+            .stderr(Stdio::piped())
+            .spawn()?;
+
+        let mut stderr = BufReader::new(
+            child
+                .stderr
+                .take()
+                .ok_or_else(|| anyhow!("cannot get stdout of rclone"))?,
+        );
+        let url = loop {
+            if let Some(status) = child.try_wait()? {
+                bail!("rclone exited with {status}");
+            }
+            let mut line = String::new();
+            stderr.read_line(&mut line)?;
+            const SEARCHSTRING: &str = "Serving restic REST API on ";
+            match line.find(SEARCHSTRING) {
+                Some(result) => {
+                    if let Some(url) = line.get(result + SEARCHSTRING.len()..) {
+                        break url.to_string();
+                    }
+                }
+                None if !line.is_empty() => v1!("rclone output: {line}"),
+                _ => {}
+            }
+        };
+        if !url.starts_with("http://") {
+            bail!("url must start with http://! url: {url}");
+        }
+
+        let url = "http://".to_string() + &user + ":" + &pass + "@" + &url[7..];
+
+        v3!("using REST backend with url {url}.");
+        let rest = RestBackend::new(&url);
+        Ok(Self {
+            _child_data: Arc::new((ChildToKill(child), tmp_dir)),
+            rest,
+        })
+    }
+}
+
+#[async_trait]
+impl ReadBackend for RcloneBackend {
+    fn location(&self) -> &str {
+        self.rest.location()
+    }
+
+    async fn list_with_size(&self, tpe: FileType) -> Result<Vec<(Id, u32)>> {
+        self.rest.list_with_size(tpe).await
+    }
+
+    async fn read_full(&self, tpe: FileType, id: &Id) -> Result<Vec<u8>> {
+        self.rest.read_full(tpe, id).await
+    }
+
+    async fn read_partial(
+        &self,
+        tpe: FileType,
+        id: &Id,
+        cacheable: bool,
+        offset: u32,
+        length: u32,
+    ) -> Result<Vec<u8>> {
+        self.rest
+            .read_partial(tpe, id, cacheable, offset, length)
+            .await
+    }
+}
+
+#[async_trait]
+impl WriteBackend for RcloneBackend {
+    async fn create(&self) -> Result<()> {
+        self.rest.create().await
+    }
+
+    async fn write_file(&self, tpe: FileType, id: &Id, cacheable: bool, f: File) -> Result<()> {
+        self.rest.write_file(tpe, id, cacheable, f).await
+    }
+
+    async fn write_bytes(&self, tpe: FileType, id: &Id, buf: Vec<u8>) -> Result<()> {
+        self.rest.write_bytes(tpe, id, buf).await
+    }
+
+    async fn remove(&self, tpe: FileType, id: &Id, cacheable: bool) -> Result<()> {
+        self.rest.remove(tpe, id, cacheable).await
+    }
+}

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -125,8 +125,11 @@ pub async fn execute() -> Result<()> {
     let verbosity = (1 + args.verbose - args.quiet).clamp(0, 3);
     set_verbosity_level(verbosity as usize);
 
-    let be = ChooseBackend::from_url(&args.repository);
-    let be_hot = args.repo_hot.map(|repo| ChooseBackend::from_url(&repo));
+    let be = ChooseBackend::from_url(&args.repository)?;
+    let be_hot = args
+        .repo_hot
+        .map(|repo| ChooseBackend::from_url(&repo))
+        .transpose()?;
 
     let config_ids = be.list(FileType::Config).await?;
 


### PR DESCRIPTION
Adds the rclone backend. 
Note that different to the restic rclone backend implementation, this starts an `rclone` to listen on http://localhost and connects via TCP.

closes #68 

Checklist:
- [x] add rclone backend
- [x] handle case of failing rclone initialization
- [x] secure localhost connection with username/password