### PR TITLE
prune: fix repo corruption with compressed blobs

### DIFF
--- a/src/backend/dry_run.rs
+++ b/src/backend/dry_run.rs
@@ -1,4 +1,5 @@
 use std::fs::File;
+use std::num::NonZeroU32;
 
 use anyhow::Result;
 use async_trait::async_trait;
@@ -32,9 +33,10 @@ impl<BE: DecryptFullBackend> DecryptReadBackend for DryRunBackend<BE> {
         cacheable: bool,
         offset: u32,
         length: u32,
+        uncompressed_length: Option<NonZeroU32>,
     ) -> Result<Vec<u8>> {
         self.be
-            .read_encrypted_partial(tpe, id, cacheable, offset, length)
+            .read_encrypted_partial(tpe, id, cacheable, offset, length, uncompressed_length)
             .await
     }
 }

--- a/src/blob/packer.rs
+++ b/src/blob/packer.rs
@@ -359,6 +359,7 @@ impl<BE: DecryptFullBackend> Repacker<BE> {
                 blob.tpe.is_cacheable(),
                 blob.offset,
                 blob.length,
+                blob.uncompressed_length,
             )
             .await?;
         self.packer

--- a/src/index/mod.rs
+++ b/src/index/mod.rs
@@ -9,7 +9,6 @@ use derive_more::Constructor;
 use futures::StreamExt;
 use indicatif::ProgressBar;
 use vlog::*;
-use zstd::decode_all;
 
 use crate::backend::{DecryptReadBackend, FileType};
 use crate::blob::BlobType;
@@ -51,12 +50,10 @@ impl IndexEntry {
                 self.blob_type.is_cacheable(),
                 self.offset,
                 self.length,
+                self.uncompressed_length,
             )
             .await?;
-        Ok(match self.uncompressed_length {
-            None => data,
-            Some(_) => decode_all(&*data)?,
-        })
+        Ok(data)
     }
 
     pub fn data_length(&self) -> u32 {


### PR DESCRIPTION
Only happens when compressed blobs are repacked and if --repack-fast is
not given.

The cause for the bug was, that compressed blobs were not decompressed before re-compressing and storing them again. This PR adds the decompression at the point of decrypting the data, such that it can't be forgotten if it is again used in other parts.

closes #88 