### PR TITLE
Allow specifying snapshot with path for some commands

### DIFF
--- a/src/commands/cat.rs
+++ b/src/commands/cat.rs
@@ -1,4 +1,4 @@
-use std::path::PathBuf;
+use std::path::Path;
 
 use anyhow::Result;
 use clap::{Parser, Subcommand};
@@ -36,11 +36,9 @@ struct IdOpt {
 
 #[derive(Parser)]
 struct TreeOpts {
-    /// snapshot id
-    id: String,
-
-    /// path within snapshot
-    path: PathBuf,
+    /// snapshot/path to restore
+    #[clap(value_name = "SNAPSHOT[:PATH]")]
+    snap: String,
 }
 
 pub(super) async fn execute(be: &impl DecryptReadBackend, opts: Opts) -> Result<()> {
@@ -76,9 +74,10 @@ async fn cat_blob(be: &impl DecryptReadBackend, tpe: BlobType, opt: IdOpt) -> Re
 }
 
 async fn cat_tree(be: &impl DecryptReadBackend, opts: TreeOpts) -> Result<()> {
-    let snap = SnapshotFile::from_str(be, &opts.id, |_| true, progress_counter()).await?;
+    let (id, path) = opts.snap.split_once(':').unwrap_or((&opts.snap, ""));
+    let snap = SnapshotFile::from_str(be, id, |_| true, progress_counter()).await?;
     let index = IndexBackend::new(be, progress_counter()).await?;
-    let id = Tree::subtree_id(&index, snap.tree, &opts.path).await?;
+    let id = Tree::subtree_id(&index, snap.tree, Path::new(path)).await?;
     let data = index.blob_from_backend(&BlobType::Tree, &id).await?;
     println!("{}", String::from_utf8(data)?);
 

--- a/src/commands/ls.rs
+++ b/src/commands/ls.rs
@@ -1,24 +1,28 @@
 use anyhow::Result;
 use clap::Parser;
 use futures::StreamExt;
+use std::path::Path;
 
 use super::progress_counter;
 use crate::backend::DecryptReadBackend;
-use crate::blob::NodeStreamer;
+use crate::blob::{NodeStreamer, Tree};
 use crate::index::IndexBackend;
 use crate::repo::SnapshotFile;
 
 #[derive(Parser)]
 pub(super) struct Opts {
-    /// snapshot to ls
-    id: String,
+    /// snapshot/path to ls
+    #[clap(value_name = "SNAPSHOT[:PATH]")]
+    snap: String,
 }
 
 pub(super) async fn execute(be: &(impl DecryptReadBackend + Unpin), opts: Opts) -> Result<()> {
-    let snap = SnapshotFile::from_str(be, &opts.id, |_| true, progress_counter()).await?;
+    let (id, path) = opts.snap.split_once(':').unwrap_or((&opts.snap, ""));
+    let snap = SnapshotFile::from_str(be, id, |_| true, progress_counter()).await?;
     let index = IndexBackend::new(be, progress_counter()).await?;
+    let tree = Tree::subtree_id(&index, snap.tree, Path::new(path)).await?;
 
-    let mut tree_streamer = NodeStreamer::new(index, snap.tree).await?;
+    let mut tree_streamer = NodeStreamer::new(index, tree).await?;
     while let Some(item) = tree_streamer.next().await {
         let (path, _) = item?;
         println!("{:?} ", path);


### PR DESCRIPTION
Allows additionally using `SNAP:PATH`for some commands which so far needed `SNAP`.
For instance you can now use `rustic-rs ls latest:/home`.

This is added for `ls`, `cat`, `diff` and `restore`.

For `restore` this is especially useful as it allows to in-place restore subpaths, e.g.
`rustic-rs restore snap:/home /home`

This PR is also a requirement for #92 