### PR TITLE
restore: add --delete option

### DIFF
--- a/src/backend/local.rs
+++ b/src/backend/local.rs
@@ -170,26 +170,13 @@ impl WriteBackend for LocalBackend {
 }
 
 impl LocalBackend {
-    /*
-        pub fn walker(&self) -> impl Iterator<Item = PathBuf> {
-            let path = self.path.clone();
-            WalkDir::new(path.clone())
-                .min_depth(1)
-                .into_iter()
-                .filter_map(walkdir::Result::ok)
-                .map(move |e| e.path().strip_prefix(path.clone()).unwrap().into())
-        }
+    pub fn remove_dir(&self, dirname: impl AsRef<Path>) -> Result<()> {
+        Ok(fs::remove_dir(dirname)?)
+    }
 
-        pub fn remove_dir(&self, item: impl AsRef<Path>) {
-            let dirname = self.path.join(item);
-            fs::remove_dir(&dirname).unwrap();
-        }
-
-        pub fn remove_file(&self, item: impl AsRef<Path>) {
-            let filename = self.path.join(item);
-            fs::remove_file(&filename).unwrap();
-        }
-    */
+    pub fn remove_file(&self, filename: impl AsRef<Path>) -> Result<()> {
+        Ok(fs::remove_file(&filename)?)
+    }
 
     pub fn create_dir(&self, item: impl AsRef<Path>) -> Result<()> {
         let dirname = self.path.join(item);


### PR DESCRIPTION
This PR adds the `restore --delete` option which removes existing contents in the destination which are not present in the snapshot/dir to restore.

see #92 

Note: this PR does NOT change the behavior/bug described in #105 