### PR TITLE
Don't use temporary files; add retries to rest/rclone backend

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1463,6 +1463,7 @@ dependencies = [
  "backoff",
  "base64",
  "binrw",
+ "bytes",
  "bytesize",
  "cachedir",
  "cdc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -111,6 +111,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
+name = "backoff"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b62ddb9cb1ec0a098ad4bbf9344d0713fa193ae1a80af55febcff2627b6a00c1"
+dependencies = [
+ "futures-core",
+ "getrandom 0.2.7",
+ "instant",
+ "pin-project-lite",
+ "rand",
+ "tokio",
+]
+
+[[package]]
 name = "base64"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1446,6 +1460,7 @@ dependencies = [
  "ambassador",
  "anyhow",
  "async-trait",
+ "backoff",
  "base64",
  "binrw",
  "bytesize",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,6 @@ serde_json = "1"
 serde-aux = "3"
 # other dependencies
 chrono = { version = "0.4", features = ["serde"] }
-tempfile = "3"
 zstd = "0.11"
 enum-map = "2"
 enum-map-derive = "0.10"
@@ -59,6 +58,7 @@ filetime = "0.2"
 reqwest = {version = "0.11", default-features = false, features = ["json", "rustls-tls", "stream"] }
 # rclone backend
 sha1 = "0.10"
+tempfile = "3"
 # cache
 dirs = "4"
 cachedir = "0.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,6 +45,7 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde-aux = "3"
 # other dependencies
+bytes = "1"
 chrono = { version = "0.4", features = ["serde"] }
 zstd = "0.11"
 enum-map = "2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,6 +56,7 @@ nix = "0.24"
 filetime = "0.2"
 # rest backend
 reqwest = {version = "0.11", default-features = false, features = ["json", "rustls-tls", "stream"] }
+backoff = { version = "0.4", features = ["tokio"] }
 # rclone backend
 sha1 = "0.10"
 tempfile = "3"

--- a/src/backend/cache.rs
+++ b/src/backend/cache.rs
@@ -30,6 +30,10 @@ impl<BE: WriteBackend> ReadBackend for CachedBackend<BE> {
         self.be.location()
     }
 
+    fn set_option(&mut self, option: &str, value: &str) -> Result<()> {
+        self.be.set_option(option, value)
+    }
+
     async fn list_with_size(&self, tpe: FileType) -> Result<Vec<(Id, u32)>> {
         let list = self.be.list_with_size(tpe).await?;
 

--- a/src/backend/choose.rs
+++ b/src/backend/choose.rs
@@ -1,5 +1,6 @@
 use anyhow::{bail, Result};
 use async_trait::async_trait;
+use bytes::Bytes;
 
 use super::{FileType, Id, ReadBackend, WriteBackend};
 use super::{LocalBackend, RcloneBackend, RestBackend};
@@ -43,7 +44,7 @@ impl ReadBackend for ChooseBackend {
         }
     }
 
-    async fn read_full(&self, tpe: FileType, id: &Id) -> Result<Vec<u8>> {
+    async fn read_full(&self, tpe: FileType, id: &Id) -> Result<Bytes> {
         match self {
             Local(local) => local.read_full(tpe, id).await,
             Rest(rest) => rest.read_full(tpe, id).await,
@@ -58,7 +59,7 @@ impl ReadBackend for ChooseBackend {
         cacheable: bool,
         offset: u32,
         length: u32,
-    ) -> Result<Vec<u8>> {
+    ) -> Result<Bytes> {
         match self {
             Local(local) => local.read_partial(tpe, id, cacheable, offset, length).await,
             Rest(rest) => rest.read_partial(tpe, id, cacheable, offset, length).await,
@@ -81,13 +82,7 @@ impl WriteBackend for ChooseBackend {
         }
     }
 
-    async fn write_bytes(
-        &self,
-        tpe: FileType,
-        id: &Id,
-        cacheable: bool,
-        buf: Vec<u8>,
-    ) -> Result<()> {
+    async fn write_bytes(&self, tpe: FileType, id: &Id, cacheable: bool, buf: Bytes) -> Result<()> {
         match self {
             Local(local) => local.write_bytes(tpe, id, cacheable, buf).await,
             Rest(rest) => rest.write_bytes(tpe, id, cacheable, buf).await,

--- a/src/backend/choose.rs
+++ b/src/backend/choose.rs
@@ -1,5 +1,3 @@
-use std::fs::File;
-
 use anyhow::{bail, Result};
 use async_trait::async_trait;
 
@@ -83,19 +81,17 @@ impl WriteBackend for ChooseBackend {
         }
     }
 
-    async fn write_file(&self, tpe: FileType, id: &Id, cacheable: bool, f: File) -> Result<()> {
+    async fn write_bytes(
+        &self,
+        tpe: FileType,
+        id: &Id,
+        cacheable: bool,
+        buf: Vec<u8>,
+    ) -> Result<()> {
         match self {
-            Local(local) => local.write_file(tpe, id, cacheable, f).await,
-            Rest(rest) => rest.write_file(tpe, id, cacheable, f).await,
-            Rclone(rclone) => rclone.write_file(tpe, id, cacheable, f).await,
-        }
-    }
-
-    async fn write_bytes(&self, tpe: FileType, id: &Id, buf: Vec<u8>) -> Result<()> {
-        match self {
-            Local(local) => local.write_bytes(tpe, id, buf).await,
-            Rest(rest) => rest.write_bytes(tpe, id, buf).await,
-            Rclone(rclone) => rclone.write_bytes(tpe, id, buf).await,
+            Local(local) => local.write_bytes(tpe, id, cacheable, buf).await,
+            Rest(rest) => rest.write_bytes(tpe, id, cacheable, buf).await,
+            Rclone(rclone) => rclone.write_bytes(tpe, id, cacheable, buf).await,
         }
     }
 

--- a/src/backend/choose.rs
+++ b/src/backend/choose.rs
@@ -36,6 +36,14 @@ impl ReadBackend for ChooseBackend {
         }
     }
 
+    fn set_option(&mut self, option: &str, value: &str) -> Result<()> {
+        match self {
+            Local(local) => local.set_option(option, value),
+            Rest(rest) => rest.set_option(option, value),
+            Rclone(rclone) => rclone.set_option(option, value),
+        }
+    }
+
     async fn list_with_size(&self, tpe: FileType) -> Result<Vec<(Id, u32)>> {
         match self {
             Local(local) => local.list_with_size(tpe).await,

--- a/src/backend/decrypt.rs
+++ b/src/backend/decrypt.rs
@@ -1,4 +1,3 @@
-use std::fs::File;
 use std::num::NonZeroU32;
 
 use anyhow::{bail, Result};
@@ -149,7 +148,7 @@ impl<R: WriteBackend, C: CryptoKey> DecryptWriteBackend for DecryptBackend<R, C>
             None => self.key().encrypt_data(data)?,
         };
         let id = hash(&data);
-        self.write_bytes(tpe, &id, data).await?;
+        self.write_bytes(tpe, &id, false, data).await?;
         Ok(id)
     }
 
@@ -234,12 +233,14 @@ impl<R: WriteBackend, C: CryptoKey> WriteBackend for DecryptBackend<R, C> {
         self.backend.create().await
     }
 
-    async fn write_file(&self, tpe: FileType, id: &Id, cacheable: bool, f: File) -> Result<()> {
-        self.backend.write_file(tpe, id, cacheable, f).await
-    }
-
-    async fn write_bytes(&self, tpe: FileType, id: &Id, buf: Vec<u8>) -> Result<()> {
-        self.backend.write_bytes(tpe, id, buf).await
+    async fn write_bytes(
+        &self,
+        tpe: FileType,
+        id: &Id,
+        cacheable: bool,
+        buf: Vec<u8>,
+    ) -> Result<()> {
+        self.backend.write_bytes(tpe, id, cacheable, buf).await
     }
 
     async fn remove(&self, tpe: FileType, id: &Id, cacheable: bool) -> Result<()> {

--- a/src/backend/decrypt.rs
+++ b/src/backend/decrypt.rs
@@ -2,6 +2,7 @@ use std::num::NonZeroU32;
 
 use anyhow::{bail, Result};
 use async_trait::async_trait;
+use bytes::Bytes;
 use futures::{stream, stream::FuturesUnordered, StreamExt};
 use indicatif::ProgressBar;
 use tokio::{spawn, task::JoinHandle};
@@ -15,7 +16,7 @@ impl<T: DecryptWriteBackend + DecryptReadBackend> DecryptFullBackend for T {}
 
 #[async_trait]
 pub trait DecryptReadBackend: ReadBackend {
-    async fn read_encrypted_full(&self, tpe: FileType, id: &Id) -> Result<Vec<u8>>;
+    async fn read_encrypted_full(&self, tpe: FileType, id: &Id) -> Result<Bytes>;
     async fn read_encrypted_partial(
         &self,
         tpe: FileType,
@@ -24,7 +25,7 @@ pub trait DecryptReadBackend: ReadBackend {
         offset: u32,
         length: u32,
         uncompressed_length: Option<NonZeroU32>,
-    ) -> Result<Vec<u8>>;
+    ) -> Result<Bytes>;
 
     async fn get_file<F: RepoFile>(&self, id: &Id) -> Result<F> {
         let data = self.read_encrypted_full(F::TYPE, id).await?;
@@ -148,7 +149,7 @@ impl<R: WriteBackend, C: CryptoKey> DecryptWriteBackend for DecryptBackend<R, C>
             None => self.key().encrypt_data(data)?,
         };
         let id = hash(&data);
-        self.write_bytes(tpe, &id, false, data).await?;
+        self.write_bytes(tpe, &id, false, data.into()).await?;
         Ok(id)
     }
 
@@ -159,7 +160,7 @@ impl<R: WriteBackend, C: CryptoKey> DecryptWriteBackend for DecryptBackend<R, C>
 
 #[async_trait]
 impl<R: ReadBackend, C: CryptoKey> DecryptReadBackend for DecryptBackend<R, C> {
-    async fn read_encrypted_full(&self, tpe: FileType, id: &Id) -> Result<Vec<u8>> {
+    async fn read_encrypted_full(&self, tpe: FileType, id: &Id) -> Result<Bytes> {
         let decrypted = self
             .key
             .decrypt_data(&self.backend.read_full(tpe, id).await?)?;
@@ -167,7 +168,8 @@ impl<R: ReadBackend, C: CryptoKey> DecryptReadBackend for DecryptBackend<R, C> {
             b'{' | b'[' => decrypted,          // not compressed
             2 => decode_all(&decrypted[1..])?, // 2 indicates compressed data following
             _ => bail!("not supported"),
-        })
+        }
+        .into())
     }
 
     async fn read_encrypted_partial(
@@ -178,7 +180,7 @@ impl<R: ReadBackend, C: CryptoKey> DecryptReadBackend for DecryptBackend<R, C> {
         offset: u32,
         length: u32,
         uncompressed_length: Option<NonZeroU32>,
-    ) -> Result<Vec<u8>> {
+    ) -> Result<Bytes> {
         let mut data = self.key.decrypt_data(
             &self
                 .backend
@@ -191,7 +193,7 @@ impl<R: ReadBackend, C: CryptoKey> DecryptReadBackend for DecryptBackend<R, C> {
                 bail!("length of uncompressed data does not match!");
             }
         }
-        Ok(data)
+        Ok(data.into())
     }
 }
 
@@ -209,7 +211,7 @@ impl<R: ReadBackend, C: CryptoKey> ReadBackend for DecryptBackend<R, C> {
         self.backend.list_with_size(tpe).await
     }
 
-    async fn read_full(&self, tpe: FileType, id: &Id) -> Result<Vec<u8>> {
+    async fn read_full(&self, tpe: FileType, id: &Id) -> Result<Bytes> {
         self.backend.read_full(tpe, id).await
     }
 
@@ -220,7 +222,7 @@ impl<R: ReadBackend, C: CryptoKey> ReadBackend for DecryptBackend<R, C> {
         cacheable: bool,
         offset: u32,
         length: u32,
-    ) -> Result<Vec<u8>> {
+    ) -> Result<Bytes> {
         self.backend
             .read_partial(tpe, id, cacheable, offset, length)
             .await
@@ -233,13 +235,7 @@ impl<R: WriteBackend, C: CryptoKey> WriteBackend for DecryptBackend<R, C> {
         self.backend.create().await
     }
 
-    async fn write_bytes(
-        &self,
-        tpe: FileType,
-        id: &Id,
-        cacheable: bool,
-        buf: Vec<u8>,
-    ) -> Result<()> {
+    async fn write_bytes(&self, tpe: FileType, id: &Id, cacheable: bool, buf: Bytes) -> Result<()> {
         self.backend.write_bytes(tpe, id, cacheable, buf).await
     }
 

--- a/src/backend/decrypt.rs
+++ b/src/backend/decrypt.rs
@@ -203,6 +203,10 @@ impl<R: ReadBackend, C: CryptoKey> ReadBackend for DecryptBackend<R, C> {
         self.backend.location()
     }
 
+    fn set_option(&mut self, option: &str, value: &str) -> Result<()> {
+        self.backend.set_option(option, value)
+    }
+
     async fn list(&self, tpe: FileType) -> Result<Vec<Id>> {
         self.backend.list(tpe).await
     }

--- a/src/backend/dry_run.rs
+++ b/src/backend/dry_run.rs
@@ -47,6 +47,10 @@ impl<BE: DecryptFullBackend> ReadBackend for DryRunBackend<BE> {
         self.be.location()
     }
 
+    fn set_option(&mut self, option: &str, value: &str) -> Result<()> {
+        self.be.set_option(option, value)
+    }
+
     async fn list_with_size(&self, tpe: FileType) -> Result<Vec<(Id, u32)>> {
         self.be.list_with_size(tpe).await
     }

--- a/src/backend/dry_run.rs
+++ b/src/backend/dry_run.rs
@@ -1,4 +1,3 @@
-use std::fs::File;
 use std::num::NonZeroU32;
 
 use anyhow::Result;
@@ -101,17 +100,16 @@ impl<BE: DecryptFullBackend> WriteBackend for DryRunBackend<BE> {
         }
     }
 
-    async fn write_file(&self, tpe: FileType, id: &Id, cacheable: bool, f: File) -> Result<()> {
+    async fn write_bytes(
+        &self,
+        tpe: FileType,
+        id: &Id,
+        cacheable: bool,
+        buf: Vec<u8>,
+    ) -> Result<()> {
         match self.dry_run {
             true => Ok(()),
-            false => self.be.write_file(tpe, id, cacheable, f).await,
-        }
-    }
-
-    async fn write_bytes(&self, tpe: FileType, id: &Id, buf: Vec<u8>) -> Result<()> {
-        match self.dry_run {
-            true => Ok(()),
-            false => self.be.write_bytes(tpe, id, buf).await,
+            false => self.be.write_bytes(tpe, id, cacheable, buf).await,
         }
     }
 

--- a/src/backend/hotcold.rs
+++ b/src/backend/hotcold.rs
@@ -22,6 +22,10 @@ impl<BE: WriteBackend> ReadBackend for HotColdBackend<BE> {
         self.be.location()
     }
 
+    fn set_option(&mut self, option: &str, value: &str) -> Result<()> {
+        self.be.set_option(option, value)
+    }
+
     async fn list_with_size(&self, tpe: FileType) -> Result<Vec<(Id, u32)>> {
         self.be.list_with_size(tpe).await
     }

--- a/src/backend/local.rs
+++ b/src/backend/local.rs
@@ -44,6 +44,10 @@ impl ReadBackend for LocalBackend {
         self.path.to_str().unwrap()
     }
 
+    fn set_option(&mut self, _option: &str, _value: &str) -> Result<()> {
+        Ok(())
+    }
+
     async fn list(&self, tpe: FileType) -> Result<Vec<Id>> {
         if tpe == FileType::Config {
             return Ok(match self.path.join("config").exists() {

--- a/src/backend/local.rs
+++ b/src/backend/local.rs
@@ -1,5 +1,5 @@
 use std::fs::{self, File};
-use std::io::{copy, Read, Seek, SeekFrom, Write};
+use std::io::{Read, Seek, SeekFrom, Write};
 use std::os::unix::fs::{symlink, FileExt, PermissionsExt};
 use std::path::{Path, PathBuf};
 
@@ -131,26 +131,13 @@ impl WriteBackend for LocalBackend {
         Ok(())
     }
 
-    async fn write_file(
+    async fn write_bytes(
         &self,
         tpe: FileType,
         id: &Id,
         _cacheable: bool,
-        mut f: File,
+        buf: Vec<u8>,
     ) -> Result<()> {
-        v3!("writing tpe: {:?}, id: {}", &tpe, &id);
-        let filename = self.path(tpe, id);
-        let mut file = fs::OpenOptions::new()
-            .create(true)
-            .write(true)
-            .open(&filename)?;
-        file.set_len(0)?;
-        copy(&mut f, &mut file)?;
-        file.sync_all()?;
-        Ok(())
-    }
-
-    async fn write_bytes(&self, tpe: FileType, id: &Id, buf: Vec<u8>) -> Result<()> {
         v3!("writing tpe: {:?}, id: {}", &tpe, &id);
         let filename = self.path(tpe, id);
         let mut file = fs::OpenOptions::new()

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -73,6 +73,9 @@ pub trait RepoFile: Serialize + DeserializeOwned + Sized + Send + Sync + 'static
 #[async_trait]
 pub trait ReadBackend: Clone + Send + Sync + 'static {
     fn location(&self) -> &str;
+
+    fn set_option(&mut self, option: &str, value: &str) -> Result<()>;
+
     async fn list_with_size(&self, tpe: FileType) -> Result<Vec<(Id, u32)>>;
 
     async fn list(&self, tpe: FileType) -> Result<Vec<Id>> {

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -1,4 +1,3 @@
-use std::fs::File;
 use std::io::Read;
 use std::path::{Path, PathBuf};
 
@@ -147,8 +146,13 @@ pub trait ReadBackend: Clone + Send + Sync + 'static {
 #[async_trait]
 pub trait WriteBackend: ReadBackend {
     async fn create(&self) -> Result<()>;
-    async fn write_file(&self, tpe: FileType, id: &Id, cacheable: bool, f: File) -> Result<()>;
-    async fn write_bytes(&self, tpe: FileType, id: &Id, buf: Vec<u8>) -> Result<()>;
+    async fn write_bytes(
+        &self,
+        tpe: FileType,
+        id: &Id,
+        cacheable: bool,
+        buf: Vec<u8>,
+    ) -> Result<()>;
     async fn remove(&self, tpe: FileType, id: &Id, cacheable: bool) -> Result<()>;
 }
 

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -3,6 +3,7 @@ use std::path::{Path, PathBuf};
 
 use anyhow::{anyhow, Result};
 use async_trait::async_trait;
+use bytes::Bytes;
 use serde::{de::DeserializeOwned, Serialize};
 
 use crate::id::Id;
@@ -83,7 +84,7 @@ pub trait ReadBackend: Clone + Send + Sync + 'static {
             .collect())
     }
 
-    async fn read_full(&self, tpe: FileType, id: &Id) -> Result<Vec<u8>>;
+    async fn read_full(&self, tpe: FileType, id: &Id) -> Result<Bytes>;
     async fn read_partial(
         &self,
         tpe: FileType,
@@ -91,7 +92,7 @@ pub trait ReadBackend: Clone + Send + Sync + 'static {
         cacheable: bool,
         offset: u32,
         length: u32,
-    ) -> Result<Vec<u8>>;
+    ) -> Result<Bytes>;
 
     async fn find_starts_with(&self, tpe: FileType, vec: &[String]) -> Result<Vec<Result<Id>>> {
         #[derive(Clone, Copy, PartialEq, Eq)]
@@ -146,13 +147,7 @@ pub trait ReadBackend: Clone + Send + Sync + 'static {
 #[async_trait]
 pub trait WriteBackend: ReadBackend {
     async fn create(&self) -> Result<()>;
-    async fn write_bytes(
-        &self,
-        tpe: FileType,
-        id: &Id,
-        cacheable: bool,
-        buf: Vec<u8>,
-    ) -> Result<()>;
+    async fn write_bytes(&self, tpe: FileType, id: &Id, cacheable: bool, buf: Bytes) -> Result<()>;
     async fn remove(&self, tpe: FileType, id: &Id, cacheable: bool) -> Result<()>;
 }
 
@@ -165,5 +160,5 @@ pub trait ReadSource: Iterator<Item = Result<(PathBuf, Node)>> {
 pub trait WriteSource: Clone {
     fn create(&self, path: PathBuf, node: Node);
     fn set_metadata(&self, path: PathBuf, node: Node);
-    fn write_at(&self, path: PathBuf, offset: u64, data: Vec<u8>);
+    fn write_at(&self, path: PathBuf, offset: u64, data: Bytes);
 }

--- a/src/backend/rclone.rs
+++ b/src/backend/rclone.rs
@@ -6,6 +6,7 @@ use std::sync::Arc;
 
 use anyhow::{anyhow, bail, Result};
 use async_trait::async_trait;
+use bytes::Bytes;
 use rand::distributions::{Alphanumeric, DistString};
 use rand::thread_rng;
 use sha1::{Digest, Sha1};
@@ -126,7 +127,7 @@ impl ReadBackend for RcloneBackend {
         self.rest.list_with_size(tpe).await
     }
 
-    async fn read_full(&self, tpe: FileType, id: &Id) -> Result<Vec<u8>> {
+    async fn read_full(&self, tpe: FileType, id: &Id) -> Result<Bytes> {
         self.rest.read_full(tpe, id).await
     }
 
@@ -137,7 +138,7 @@ impl ReadBackend for RcloneBackend {
         cacheable: bool,
         offset: u32,
         length: u32,
-    ) -> Result<Vec<u8>> {
+    ) -> Result<Bytes> {
         self.rest
             .read_partial(tpe, id, cacheable, offset, length)
             .await
@@ -150,13 +151,7 @@ impl WriteBackend for RcloneBackend {
         self.rest.create().await
     }
 
-    async fn write_bytes(
-        &self,
-        tpe: FileType,
-        id: &Id,
-        cacheable: bool,
-        buf: Vec<u8>,
-    ) -> Result<()> {
+    async fn write_bytes(&self, tpe: FileType, id: &Id, cacheable: bool, buf: Bytes) -> Result<()> {
         self.rest.write_bytes(tpe, id, cacheable, buf).await
     }
 

--- a/src/backend/rclone.rs
+++ b/src/backend/rclone.rs
@@ -150,12 +150,14 @@ impl WriteBackend for RcloneBackend {
         self.rest.create().await
     }
 
-    async fn write_file(&self, tpe: FileType, id: &Id, cacheable: bool, f: File) -> Result<()> {
-        self.rest.write_file(tpe, id, cacheable, f).await
-    }
-
-    async fn write_bytes(&self, tpe: FileType, id: &Id, buf: Vec<u8>) -> Result<()> {
-        self.rest.write_bytes(tpe, id, buf).await
+    async fn write_bytes(
+        &self,
+        tpe: FileType,
+        id: &Id,
+        cacheable: bool,
+        buf: Vec<u8>,
+    ) -> Result<()> {
+        self.rest.write_bytes(tpe, id, cacheable, buf).await
     }
 
     async fn remove(&self, tpe: FileType, id: &Id, cacheable: bool) -> Result<()> {

--- a/src/backend/rclone.rs
+++ b/src/backend/rclone.rs
@@ -123,6 +123,10 @@ impl ReadBackend for RcloneBackend {
         self.rest.location()
     }
 
+    fn set_option(&mut self, option: &str, value: &str) -> Result<()> {
+        self.rest.set_option(option, value)
+    }
+
     async fn list_with_size(&self, tpe: FileType) -> Result<Vec<(Id, u32)>> {
         self.rest.list_with_size(tpe).await
     }

--- a/src/backend/rest.rs
+++ b/src/backend/rest.rs
@@ -63,6 +63,10 @@ impl ReadBackend for RestBackend {
         self.url.as_str()
     }
 
+    fn set_option(&mut self, _option: &str, _value: &str) -> Result<()> {
+        Ok(())
+    }
+
     async fn list_with_size(&self, tpe: FileType) -> Result<Vec<(Id, u32)>> {
         Ok(backoff::future::retry_notify(
             self.backoff.clone(),

--- a/src/backend/rest.rs
+++ b/src/backend/rest.rs
@@ -1,4 +1,4 @@
-use std::fs::File;
+use std::time::Duration;
 
 use anyhow::Result;
 use async_trait::async_trait;
@@ -136,17 +136,13 @@ impl WriteBackend for RestBackend {
         Ok(())
     }
 
-    async fn write_file(&self, tpe: FileType, id: &Id, _cacheable: bool, f: File) -> Result<()> {
-        v3!("writing tpe: {:?}, id: {}", &tpe, &id);
-        self.client
-            .post(self.url(tpe, id))
-            .body(tokio::fs::File::from_std(f))
-            .send()
-            .await?;
-        Ok(())
-    }
-
-    async fn write_bytes(&self, tpe: FileType, id: &Id, buf: Vec<u8>) -> Result<()> {
+    async fn write_bytes(
+        &self,
+        tpe: FileType,
+        id: &Id,
+        _cacheable: bool,
+        buf: Vec<u8>,
+    ) -> Result<()> {
         v3!("writing tpe: {:?}, id: {}", &tpe, &id);
         self.client.post(self.url(tpe, id)).body(buf).send().await?;
         Ok(())

--- a/src/blob/packer.rs
+++ b/src/blob/packer.rs
@@ -1,13 +1,10 @@
 use integer_sqrt::IntegerSquareRoot;
-use std::fs::File;
-use std::io::{Seek, SeekFrom, Write};
 use std::num::NonZeroU32;
 use std::time::{Duration, SystemTime};
 
 use anyhow::{anyhow, Result};
 use binrw::{io::Cursor, BinWrite};
 use chrono::Local;
-use tempfile::tempfile;
 use tokio::{spawn, task::JoinHandle};
 use zstd::encode_all;
 
@@ -53,7 +50,7 @@ impl PackSizer {
 pub struct Packer<BE: DecryptWriteBackend> {
     be: BE,
     blob_type: BlobType,
-    file: File,
+    file: Vec<u8>,
     size: u32,
     count: u32,
     created: SystemTime,
@@ -84,7 +81,7 @@ impl<BE: DecryptWriteBackend> Packer<BE> {
         Ok(Self {
             be,
             blob_type,
-            file: tempfile()?,
+            file: Vec::new(),
             size: 0,
             count: 0,
             created: SystemTime::now(),
@@ -104,7 +101,8 @@ impl<BE: DecryptWriteBackend> Packer<BE> {
 
     pub async fn write_data(&mut self, data: &[u8]) -> Result<u32> {
         self.hasher.update(data);
-        let len = self.file.write(data)?.try_into()?;
+        let len = data.len().try_into()?;
+        self.file.extend_from_slice(data);
         self.size += len;
         Ok(len)
     }
@@ -265,7 +263,7 @@ impl<BE: DecryptWriteBackend> Packer<BE> {
 
         // write file to backend
         let index = std::mem::take(&mut self.index);
-        let file = std::mem::replace(&mut self.file, tempfile()?);
+        let file = std::mem::replace(&mut self.file, Vec::new());
         self.file_writer.add(index, file, id).await?;
 
         Ok(())
@@ -284,13 +282,12 @@ struct FileWriter<BE: DecryptWriteBackend> {
 }
 
 impl<BE: DecryptWriteBackend> FileWriter<BE> {
-    async fn add(&mut self, mut index: IndexPack, mut file: File, id: Id) -> Result<()> {
+    async fn add(&mut self, mut index: IndexPack, file: Vec<u8>, id: Id) -> Result<()> {
         let be = self.be.clone();
         let indexer = self.indexer.clone();
         let cacheable = self.cacheable;
         let new_future = spawn(async move {
-            file.seek(SeekFrom::Start(0))?;
-            be.write_file(FileType::Pack, &id, cacheable, file).await?;
+            be.write_bytes(FileType::Pack, &id, cacheable, file).await?;
             index.time = Some(Local::now());
             indexer.write().await.add(index).await?;
             Ok(())

--- a/src/commands/cat.rs
+++ b/src/commands/cat.rs
@@ -57,7 +57,7 @@ pub(super) async fn execute(be: &impl DecryptReadBackend, opts: Opts) -> Result<
 async fn cat_file(be: &impl DecryptReadBackend, tpe: FileType, opt: IdOpt) -> Result<()> {
     let id = be.find_id(tpe, &opt.id).await?;
     let data = be.read_encrypted_full(tpe, &id).await?;
-    println!("{}", String::from_utf8(data)?);
+    println!("{}", String::from_utf8(data.to_vec())?);
 
     Ok(())
 }
@@ -68,7 +68,7 @@ async fn cat_blob(be: &impl DecryptReadBackend, tpe: BlobType, opt: IdOpt) -> Re
         .await?
         .blob_from_backend(&tpe, &id)
         .await?;
-    print!("{}", String::from_utf8(data)?);
+    print!("{}", String::from_utf8(data.to_vec())?);
 
     Ok(())
 }
@@ -79,7 +79,7 @@ async fn cat_tree(be: &impl DecryptReadBackend, opts: TreeOpts) -> Result<()> {
     let index = IndexBackend::new(be, progress_counter()).await?;
     let id = Tree::subtree_id(&index, snap.tree, Path::new(path)).await?;
     let data = index.blob_from_backend(&BlobType::Tree, &id).await?;
-    println!("{}", String::from_utf8(data)?);
+    println!("{}", String::from_utf8(data.to_vec())?);
 
     Ok(())
 }

--- a/src/commands/init.rs
+++ b/src/commands/init.rs
@@ -63,11 +63,12 @@ pub(super) async fn execute(
     let data = serde_json::to_vec(&keyfile)?;
     let id = hash(&data);
     be.create().await?;
-    be.write_bytes(FileType::Key, &id, data.clone()).await?;
+    be.write_bytes(FileType::Key, &id, false, data.clone())
+        .await?;
 
     if let Some(hot_be) = hot_be {
         hot_be.create().await?;
-        hot_be.write_bytes(FileType::Key, &id, data).await?;
+        hot_be.write_bytes(FileType::Key, &id, false, data).await?;
     }
     println!("key {} successfully added.", id);
 

--- a/src/commands/init.rs
+++ b/src/commands/init.rs
@@ -2,6 +2,7 @@ use std::fs::File;
 use std::io::BufReader;
 
 use anyhow::{bail, Result};
+use bytes::Bytes;
 use clap::Parser;
 use rpassword::{prompt_password, read_password_from_bufread};
 
@@ -60,7 +61,7 @@ pub(super) async fn execute(
         key_opts.username,
         key_opts.with_created,
     )?;
-    let data = serde_json::to_vec(&keyfile)?;
+    let data: Bytes = serde_json::to_vec(&keyfile)?.into();
     let id = hash(&data);
     be.create().await?;
     be.write_bytes(FileType::Key, &id, false, data.clone())

--- a/src/commands/key.rs
+++ b/src/commands/key.rs
@@ -56,7 +56,8 @@ async fn add_key(be: &impl WriteBackend, key: Key, opts: AddOpts) -> Result<()> 
     let keyfile = KeyFile::generate(key, &pass, opts.hostname, opts.username, opts.with_created)?;
     let data = serde_json::to_vec(&keyfile)?;
     let id = hash(&data);
-    be.write_bytes(FileType::Key, &id, false, data).await?;
+    be.write_bytes(FileType::Key, &id, false, data.into())
+        .await?;
 
     println!("key {} successfully added.", id);
     Ok(())

--- a/src/commands/key.rs
+++ b/src/commands/key.rs
@@ -56,7 +56,7 @@ async fn add_key(be: &impl WriteBackend, key: Key, opts: AddOpts) -> Result<()> 
     let keyfile = KeyFile::generate(key, &pass, opts.hostname, opts.username, opts.with_created)?;
     let data = serde_json::to_vec(&keyfile)?;
     let id = hash(&data);
-    be.write_bytes(FileType::Key, &id, data).await?;
+    be.write_bytes(FileType::Key, &id, false, data).await?;
 
     println!("key {} successfully added.", id);
     Ok(())

--- a/src/commands/restore.rs
+++ b/src/commands/restore.rs
@@ -251,6 +251,8 @@ fn warm_up_command(file_infos: FileInfos, command: &str) -> Result<()> {
 
 async fn warm_up(be: &impl DecryptReadBackend, file_infos: FileInfos) -> Result<()> {
     let packs = file_infos.into_packs();
+    let mut be = be.clone();
+    be.set_option("retry", "false")?;
 
     let p = progress_counter();
     p.set_length(packs.len() as u64);

--- a/src/index/mod.rs
+++ b/src/index/mod.rs
@@ -4,6 +4,7 @@ use std::sync::Arc;
 use ambassador::{delegatable_trait, Delegate};
 use anyhow::{anyhow, Result};
 use async_trait::async_trait;
+use bytes::Bytes;
 use derive_getters::Getters;
 use derive_more::Constructor;
 use futures::StreamExt;
@@ -42,7 +43,7 @@ impl IndexEntry {
     }
 
     /// Get a blob described by IndexEntry from the backend
-    pub async fn read_data<B: DecryptReadBackend>(&self, be: &B) -> Result<Vec<u8>> {
+    pub async fn read_data<B: DecryptReadBackend>(&self, be: &B) -> Result<Bytes> {
         let data = be
             .read_encrypted_partial(
                 FileType::Pack,
@@ -96,7 +97,7 @@ pub trait IndexedBackend: ReadIndex + Clone + Sync + Send + 'static {
 
     fn be(&self) -> &Self::Backend;
 
-    async fn blob_from_backend(&self, tpe: &BlobType, id: &Id) -> Result<Vec<u8>> {
+    async fn blob_from_backend(&self, tpe: &BlobType, id: &Id) -> Result<Bytes> {
         match self.get_id(tpe, id) {
             None => Err(anyhow!("blob not found in index")),
             Some(ie) => ie.read_data(self.be()).await,


### PR DESCRIPTION
This PR does a bit of refactoring in the backend:
- uses `Bytes` instead of `Vec<u8>` (this allows to cheaply `clone()` data and saves memory)
- Save unfinished pack files in-memory (in the Bytes struct) instead of using a temporary file. This should make the packing even faster. However, it will increase the memory usage by the size of the pack file. As most modern distributions already use a tmpfs for `/tmp`, the overall memory consumption is however not changed in that case.
- Allows to set options for backends.
- Add retries for remote backends (actually the two upper changes are prerequisites for this change)

TODOs:
- [x] save unfinished pack file in memory instead of in temp file
- [ ] Add warning about pack sizes
- [x] Use backoff crate
- [x] Disable backoff for warm-up

closes #86 