### PR TITLE
CI: fix typo

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -31,7 +31,7 @@ jobs:
         with:
           profile: minimal
           toolchain: stable
-          overrideo: true
+          override: true
           target: x86_64-apple-darwin
       - uses: Swatinem/rust-cache@v2
       - uses: actions-rs/cargo@v1


### PR DESCRIPTION
fixes a typo in the MacOs tests which resulted in a warning