### PR TITLE
Allow to specify upper limits for packfile sizes

### DIFF
--- a/src/blob/packer.rs
+++ b/src/blob/packer.rs
@@ -26,21 +26,24 @@ const MAX_AGE: Duration = Duration::from_secs(300);
 struct PackSizer {
     default_size: u32,
     grow_factor: u32,
+    size_limit: u32,
     current_size: u64,
 }
 
 impl PackSizer {
     pub fn from_config(config: &ConfigFile, blob_type: BlobType, current_size: u64) -> Self {
-        let (default_size, grow_factor) = config.packsize(blob_type);
+        let (default_size, grow_factor, size_limit) = config.packsize(blob_type);
         Self {
             default_size,
             grow_factor,
+            size_limit,
             current_size,
         }
     }
 
     pub fn pack_size(&self) -> u32 {
         (self.current_size.integer_sqrt() as u32 * self.grow_factor + self.default_size)
+            .min(self.size_limit)
             .min(MAX_SIZE)
     }
 

--- a/src/commands/config.rs
+++ b/src/commands/config.rs
@@ -55,6 +55,12 @@ pub(super) struct ConfigOpts {
     #[clap(long, value_name = "SIZE")]
     pub set_treepack_size: Option<ByteSize>,
 
+    /// Set upper limit for default packsize for tree packs.
+    /// Note that packs actually can get up to some MiBs larger.
+    /// If not set, pack sizes can grow up to approximately 4 GiB.
+    #[clap(long, value_name = "SIZE")]
+    pub set_treepack_size_limit: Option<ByteSize>,
+
     /// Set grow factor for tree packs. The default packsize grows by the square root of the reposize
     /// multiplied with this factor. This means 32 kiB times this factor per square root of reposize in GiB.
     /// Defaults to 32 (= 1MB per sqare root of reposize in GiB) if not set.
@@ -72,6 +78,12 @@ pub(super) struct ConfigOpts {
     /// Defaults to 32 (= 1MB per sqare root of reposize in GiB) if not set.
     #[clap(long, value_name = "FACTOR")]
     pub set_datapack_growfactor: Option<u32>,
+
+    /// Set upper limit for default packsize for tree packs.
+    /// Note that packs actually can get up to some MiBs larger.
+    /// If not set, pack sizes can grow up to approximately 4 GiB.
+    #[clap(long, value_name = "SIZE")]
+    pub set_datapack_size_limit: Option<ByteSize>,
 }
 
 impl ConfigOpts {
@@ -113,11 +125,18 @@ impl ConfigOpts {
         if let Some(factor) = self.set_treepack_growfactor {
             config.treepack_growfactor = Some(factor);
         }
+        if let Some(size) = self.set_treepack_size_limit {
+            config.treepack_size_limit = Some(size.as_u64().try_into()?);
+        }
+
         if let Some(size) = self.set_datapack_size {
             config.datapack_size = Some(size.as_u64().try_into()?);
         }
-        if let Some(factor) = self.set_treepack_growfactor {
+        if let Some(factor) = self.set_datapack_growfactor {
             config.datapack_growfactor = Some(factor);
+        }
+        if let Some(size) = self.set_datapack_size_limit {
+            config.datapack_size_limit = Some(size.as_u64().try_into()?);
         }
 
         Ok(())

--- a/src/repo/configfile.rs
+++ b/src/repo/configfile.rs
@@ -19,9 +19,13 @@ pub struct ConfigFile {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub treepack_growfactor: Option<u32>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub treepack_size_limit: Option<u32>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub datapack_size: Option<u32>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub datapack_growfactor: Option<u32>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub datapack_size_limit: Option<u32>,
 }
 
 impl RepoFile for ConfigFile {
@@ -36,6 +40,7 @@ const DEFAULT_DATA_SIZE: u32 = 32 * MB;
 // the default factor used for repo-size dependent pack size.
 // 32 * sqrt(reposize in bytes) = 1 MB * sqrt(reposize in GB)
 const DEFAULT_GROW_FACTOR: u32 = 32;
+const DEFAULT_SIZE_LIMIT: u32 = u32::MAX;
 
 impl ConfigFile {
     pub fn new(version: u32, id: Id, poly: u64) -> Self {
@@ -47,8 +52,10 @@ impl ConfigFile {
             compression: None,
             treepack_size: None,
             treepack_growfactor: None,
+            treepack_size_limit: None,
             datapack_size: None,
             datapack_growfactor: None,
+            datapack_size_limit: None,
         }
     }
 
@@ -65,15 +72,17 @@ impl ConfigFile {
         }
     }
 
-    pub fn packsize(&self, blob: BlobType) -> (u32, u32) {
+    pub fn packsize(&self, blob: BlobType) -> (u32, u32, u32) {
         match blob {
             BlobType::Tree => (
                 self.treepack_size.unwrap_or(DEFAULT_TREE_SIZE),
                 self.treepack_growfactor.unwrap_or(DEFAULT_GROW_FACTOR),
+                self.treepack_size_limit.unwrap_or(DEFAULT_SIZE_LIMIT),
             ),
             BlobType::Data => (
                 self.datapack_size.unwrap_or(DEFAULT_DATA_SIZE),
                 self.datapack_growfactor.unwrap_or(DEFAULT_GROW_FACTOR),
+                self.datapack_size_limit.unwrap_or(DEFAULT_SIZE_LIMIT),
             ),
         }
     }


### PR DESCRIPTION
Also fixes a typo which did automatically set the grow factor for data packs as the one for tree packs.