### PR TITLE
prune: repack packs which are too small or too large

### DIFF
--- a/src/commands/config.rs
+++ b/src/commands/config.rs
@@ -84,6 +84,17 @@ pub(super) struct ConfigOpts {
     /// If not set, pack sizes can grow up to approximately 4 GiB.
     #[clap(long, value_name = "SIZE")]
     pub set_datapack_size_limit: Option<ByteSize>,
+
+    /// Set minimum tolerated packsize in percent of the targeted packsize.
+    /// Defaults to 30 if not set.
+    #[clap(long, value_name = "PERCENT")]
+    pub set_min_packsize_tolerate_percent: Option<u32>,
+
+    /// Set maximum tolerated packsize in percent of the targeted packsize
+    /// A value of 0 means packs larger than the targeted packsize are always
+    /// tolerated. Default if not set: larger packfiles are always tolerated.
+    #[clap(long, value_name = "PERCENT")]
+    pub set_max_packsize_tolerate_percent: Option<u32>,
 }
 
 impl ConfigOpts {
@@ -137,6 +148,20 @@ impl ConfigOpts {
         }
         if let Some(size) = self.set_datapack_size_limit {
             config.datapack_size_limit = Some(size.as_u64().try_into()?);
+        }
+
+        if let Some(percent) = self.set_min_packsize_tolerate_percent {
+            if percent > 100 {
+                bail!("set_min_packsize_tolerate_percent must be <= 100");
+            }
+            config.min_packsize_tolerate_percent = Some(percent);
+        }
+
+        if let Some(percent) = self.set_max_packsize_tolerate_percent {
+            if percent < 100 && percent > 0 {
+                bail!("set_max_packsize_tolerate_percent must be >= 100 or 0");
+            }
+            config.max_packsize_tolerate_percent = Some(percent);
         }
 
         Ok(())

--- a/src/commands/prune.rs
+++ b/src/commands/prune.rs
@@ -12,9 +12,9 @@ use vlog::*;
 
 use super::{bytes, no_progress, progress_bytes, progress_counter, wait, warm_up, warm_up_command};
 use crate::backend::{Cache, DecryptFullBackend, DecryptReadBackend, FileType};
-use crate::blob::{BlobType, BlobTypeMap, NodeType, Repacker, TreeStreamerOnce};
+use crate::blob::{BlobType, BlobTypeMap, NodeType, PackSizer, Repacker, TreeStreamerOnce};
 use crate::id::Id;
-use crate::index::{IndexBackend, IndexCollector, IndexType, IndexedBackend, Indexer};
+use crate::index::{IndexBackend, IndexCollector, IndexType, IndexedBackend, Indexer, ReadIndex};
 use crate::repo::{ConfigFile, IndexBlob, IndexFile, IndexPack, SnapshotFile};
 
 #[derive(Parser)]
@@ -117,9 +117,12 @@ pub(super) async fn execute(
         _ => {}
     }
 
-    let used_ids = {
-        let indexed_be = IndexBackend::new_from_index(&be.clone(), index_collector.into_index());
-        find_used_blobs(&indexed_be, ignore_snaps).await?
+    let (used_ids, total_size) = {
+        let index = index_collector.into_index();
+        let total_size = BlobTypeMap::<()>::default().map(|tpe, _| index.total_size(&tpe));
+        let indexed_be = IndexBackend::new_from_index(&be.clone(), index);
+        let used_ids = find_used_blobs(&indexed_be, ignore_snaps).await?;
+        (used_ids, total_size)
     };
 
     // list existing pack files
@@ -136,11 +139,13 @@ pub(super) async fn execute(
     let repack_cacheable_only = opts
         .repack_cacheable_only
         .unwrap_or_else(|| config.is_hot == Some(true));
+    let pack_sizer = total_size.map(|tpe, size| PackSizer::from_config(&config, tpe, size));
     pruner.decide_packs(
         Duration::from_std(*opts.keep_pack)?,
         Duration::from_std(*opts.keep_delete)?,
         repack_cacheable_only,
         opts.repack_uncompressed,
+        &pack_sizer,
     )?;
     pruner.decide_repack(&opts.max_repack, &opts.max_unused, opts.repack_uncompressed);
     pruner.check_existing_packs()?;
@@ -259,7 +264,7 @@ impl PruneIndex {
     }
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum PackToDo {
     Undecided,
     Keep,
@@ -372,11 +377,19 @@ impl PrunePack {
     }
 }
 
+#[derive(PartialEq, Eq)]
+enum RepackReason {
+    PartlyUsed,
+    ToCompress,
+    SizeMismatch,
+}
+use RepackReason::*;
+
 struct Pruner {
     time: DateTime<Local>,
     used_ids: HashMap<Id, u8>,
     existing_packs: HashMap<Id, u32>,
-    repack_candidates: Vec<(PackInfo, usize, usize)>,
+    repack_candidates: Vec<(PackInfo, RepackReason, usize, usize)>,
     index_files: Vec<PruneIndex>,
     stats: PruneStats,
 }
@@ -482,6 +495,7 @@ impl Pruner {
         keep_delete: Duration,
         repack_cacheable_only: bool,
         repack_uncompressed: bool,
+        pack_sizer: &BlobTypeMap<PackSizer>,
     ) -> Result<()> {
         // first process all marked packs then the unmarked ones:
         // - first processed packs are more likely to have all blobs seen as unused
@@ -496,7 +510,13 @@ impl Pruner {
                     .filter(|(_, p)| p.delete_mark == mark_case)
                 {
                     let pi = PackInfo::from_pack(pack, &mut self.used_ids);
+
+                    // Various checks to determine if packs need to be kept
                     let too_young = pack.time > Some(self.time - keep_pack);
+                    let keep_uncacheable = repack_cacheable_only && !pack.blob_type.is_cacheable();
+
+                    let to_compress = repack_uncompressed && !pack.is_compressed();
+                    let size_mismatch = !pack_sizer[pack.blob_type].size_ok(pack.size);
 
                     match (pack.delete_mark, pi.used_blobs, pi.unused_blobs) {
                         (false, 0, _) => {
@@ -512,14 +532,20 @@ impl Pruner {
                         (false, 1.., 0) => {
                             // used pack
                             self.stats.packs.used += 1;
-                            if too_young
-                                || !repack_uncompressed
-                                || pack.is_compressed()
-                                || repack_cacheable_only && !pack.blob_type.is_cacheable()
-                            {
+                            if too_young || keep_uncacheable {
                                 pack.set_todo(PackToDo::Keep, &pi, &mut self.stats);
+                            } else if to_compress {
+                                self.repack_candidates
+                                    .push((pi, ToCompress, index_num, pack_num));
+                            } else if size_mismatch {
+                                self.repack_candidates.push((
+                                    pi,
+                                    SizeMismatch,
+                                    index_num,
+                                    pack_num,
+                                ));
                             } else {
-                                self.repack_candidates.push((pi, index_num, pack_num));
+                                pack.set_todo(PackToDo::Keep, &pi, &mut self.stats);
                             }
                         }
 
@@ -527,13 +553,13 @@ impl Pruner {
                             // partly used pack
                             self.stats.packs.partly_used += 1;
 
-                            if too_young || repack_cacheable_only && !pack.blob_type.is_cacheable()
-                            {
+                            if too_young || keep_uncacheable {
                                 // keep packs which are too young and non-cacheable packs if requested
                                 pack.set_todo(PackToDo::Keep, &pi, &mut self.stats);
                             } else {
                                 // other partly used pack => candidate for repacking
-                                self.repack_candidates.push((pi, index_num, pack_num))
+                                self.repack_candidates
+                                    .push((pi, PartlyUsed, index_num, pack_num))
                             }
                         }
                         (true, 0, _) => {
@@ -580,23 +606,40 @@ impl Pruner {
         };
 
         self.repack_candidates.sort_unstable_by_key(|rc| rc.0);
+        let mut resize_packs: BlobTypeMap<Vec<_>> = Default::default();
+        let mut do_repack: BlobTypeMap<bool> = Default::default();
 
-        for (pi, index_num, pack_num) in std::mem::take(&mut self.repack_candidates) {
+        for (pi, repack_reason, index_num, pack_num) in std::mem::take(&mut self.repack_candidates)
+        {
             let pack = &mut self.index_files[index_num].packs[pack_num];
 
             let repack_size_new =
                 self.stats.total_size().repack + (pi.unused_size + pi.used_size) as u64;
             if repack_size_new >= max_repack
-                || (pi.blob_type != BlobType::Tree
-                    && self.stats.total_size().unused_after_prune() < max_unused)
+                || (self.stats.total_size().unused_after_prune() < max_unused
+                    && repack_reason == PartlyUsed
+                    && pi.blob_type == BlobType::Data)
             {
                 pack.set_todo(PackToDo::Keep, &pi, &mut self.stats);
+            } else if repack_reason == SizeMismatch {
+                resize_packs[pack.blob_type].push((pi, index_num, pack_num));
             } else {
                 pack.set_todo(PackToDo::Repack, &pi, &mut self.stats);
+                do_repack[pack.blob_type] = true;
             }
         }
-        self.repack_candidates.clear();
-        self.repack_candidates.shrink_to_fit();
+        // resize_packs are only repacked if at least two packs of the blob_type are repacked
+        for (blob_type, resize_packs) in resize_packs {
+            let todo = if do_repack[blob_type] || resize_packs.len() > 1 {
+                PackToDo::Repack
+            } else {
+                PackToDo::Keep
+            };
+            for (pi, index_num, pack_num) in resize_packs {
+                let pack = &mut self.index_files[index_num].packs[pack_num];
+                pack.set_todo(todo, &pi, &mut self.stats);
+            }
+        }
     }
 
     fn check_existing_packs(&mut self) -> Result<()> {

--- a/src/repo/configfile.rs
+++ b/src/repo/configfile.rs
@@ -26,6 +26,10 @@ pub struct ConfigFile {
     pub datapack_growfactor: Option<u32>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub datapack_size_limit: Option<u32>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub min_packsize_tolerate_percent: Option<u32>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub max_packsize_tolerate_percent: Option<u32>,
 }
 
 impl RepoFile for ConfigFile {
@@ -48,14 +52,7 @@ impl ConfigFile {
             version,
             id,
             chunker_polynomial: format!("{:x}", poly),
-            is_hot: None,
-            compression: None,
-            treepack_size: None,
-            treepack_growfactor: None,
-            treepack_size_limit: None,
-            datapack_size: None,
-            datapack_growfactor: None,
-            datapack_size_limit: None,
+            ..Self::default()
         }
     }
 
@@ -85,5 +82,15 @@ impl ConfigFile {
                 self.datapack_size_limit.unwrap_or(DEFAULT_SIZE_LIMIT),
             ),
         }
+    }
+
+    pub fn packsize_ok_percents(&self) -> (u32, u32) {
+        (
+            self.min_packsize_tolerate_percent.unwrap_or(30),
+            match self.max_packsize_tolerate_percent {
+                None | Some(0) => u32::MAX,
+                Some(percent) => percent,
+            },
+        )
     }
 }


### PR DESCRIPTION
This PR repacks packs which are too small or too large.
By default a tolerated pack size is 30%..unlmited of the targeted pack size.

Note that during backup or repacks larger or smaller pack files than the targeted pack size are regularly generated:
- larger pack sizes as blobs are added as long as the pack size is smaller than the targeted pack size. This means that packs can be up to 1 blob larger than the targeted pack size
- smaller pack sizes if generation of pack files ends but the targeted pack size is not yet reached. This means that packs can contain only 1 blob (which could contain only 1 byte data) + encryption + header.

The lower and upper toleration limits can be configured using the `config` command.
To deactive this feature, use
```
rustic-rs config --set-min-packsize-tolerate-percent 0
rustic-rs config --set-max-packsize-tolerate-percent 0
```
 (max = 0  means no upper limit)

closes #77