### PR TITLE
Add config file support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -238,7 +238,7 @@ dependencies = [
  "num-integer",
  "num-traits",
  "serde",
- "time",
+ "time 0.1.44",
  "wasm-bindgen",
  "winapi",
 ]
@@ -375,6 +375,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4529658bdda7fd6769b8614be250cdcfc3aeb0ee72fe66f9e41e5e5eb73eac02"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "649c91bc01e8b1eac09fb91e8dbc7d517684ca6be8ebc75bb9cafc894f9fdb6f"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddfc69c5bfcbd2fc09a0f38451d2daf0e372e367986a83906d1b0dbc88134fb5"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "derivative"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -418,6 +453,15 @@ dependencies = [
  "block-buffer",
  "crypto-common",
  "subtle",
+]
+
+[[package]]
+name = "directories"
+version = "4.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f51c5d4ddabd36886dd3e1438cb358cdcb0d7c499cb99cb4ac2e38e18b5cb210"
+dependencies = [
+ "dirs-sys",
 ]
 
 [[package]]
@@ -853,6 +897,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
 name = "idna"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -889,6 +939,7 @@ checksum = "10a35a97730320ffe8e2d410b5d3b69279b98d2c14bdb8b70ea89ecf7888d41e"
 dependencies = [
  "autocfg",
  "hashbrown",
+ "serde",
 ]
 
 [[package]]
@@ -1033,6 +1084,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "merge"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10bbef93abb1da61525bbc45eeaff6473a41907d19f8f9aa5168d214e10693e9"
+dependencies = [
+ "merge_derive",
+ "num-traits",
+]
+
+[[package]]
+name = "merge_derive"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "209d075476da2e63b4b29e72a2ef627b840589588e71400a25e3565c4f849d07"
+dependencies = [
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "mime"
 version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1099,6 +1172,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19e64526ebdee182341572e50e9ad03965aa510cd94427a4549448f285e957a1"
 dependencies = [
  "hermit-abi",
+ "libc",
+]
+
+[[package]]
+name = "num_threads"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2819ce041d2ee131036f4fc9d6ae7ae125a3a40e97ba64d04fe799ad9dabbb44"
+dependencies = [
  "libc",
 ]
 
@@ -1498,6 +1580,7 @@ dependencies = [
  "derivative",
  "derive-getters",
  "derive_more",
+ "directories",
  "dirs",
  "enum-map",
  "enum-map-derive",
@@ -1511,6 +1594,7 @@ dependencies = [
  "integer-sqrt",
  "itertools",
  "lazy_static",
+ "merge",
  "nix",
  "path-absolutize",
  "prettytable-rs",
@@ -1525,11 +1609,13 @@ dependencies = [
  "serde",
  "serde-aux",
  "serde_json",
+ "serde_with",
  "sha1",
  "sha2",
  "tempfile",
  "thiserror",
  "tokio",
+ "toml",
  "users",
  "vlog",
  "walkdir",
@@ -1693,6 +1779,34 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "serde_with"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89df7a26519371a3cce44fbb914c2819c84d9b897890987fa3ab096491cc0ea8"
+dependencies = [
+ "base64",
+ "chrono",
+ "hex",
+ "indexmap",
+ "serde",
+ "serde_json",
+ "serde_with_macros",
+ "time 0.3.14",
+]
+
+[[package]]
+name = "serde_with_macros"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de337f322382fcdfbb21a014f7c224ee041a23785651db67b9827403178f698f"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1882,6 +1996,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "time"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c3f9a28b618c3a6b9251b6908e9c99e04b9e5c02e6581ccbb67d59c34ef7f9b"
+dependencies = [
+ "itoa",
+ "libc",
+ "num_threads",
+ "serde",
+]
+
+[[package]]
 name = "tinyvec"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1951,6 +2077,15 @@ dependencies = [
  "pin-project-lite",
  "tokio",
  "tracing",
+]
+
+[[package]]
+name = "toml"
+version = "0.5.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d82e1a7758622a465f8cee077614c73484dac5b836c02ff6a40d5d1010324d7"
+dependencies = [
+ "serde",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,6 +67,10 @@ dirs = "4"
 cachedir = "0.3"
 # commands
 clap = { version = "3", features = ["derive", "env"] }
+directories = "4"
+toml = "0.5"
+merge = "0.1"
+serde_with = "2"
 rpassword = "7"
 prettytable-rs = {version = "0.9", default-features = false }
 bytesize = "1"

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Look at the [FAQ][3] or open an issue!
 Improvements:
  * Allows using cold storage (e.g. AWS Glacier) repos which are only read in the `restore` command + supports warm-up
  * Completely lock-free pruning; option `instant-delete` is available
+ * Supports configuration in a config file ([example config files](https://github.com/rustic-rs/rustic/tree/main/examples))
  * Huge decrease in memory requirement
  * Pack size can be customized
  * Already faster than restic for most operations (but not yet fully speed optimized)

--- a/examples/local.toml
+++ b/examples/local.toml
@@ -1,0 +1,31 @@
+# rustic config file to backup /home, /etc and /root to a local repository
+#
+# backup usage: "rustic-rs -P local backup
+# cleanup:      "rustic-rs -P local forget --prune
+#
+[global]
+repository = "/backup/rustic"
+password-file =  "/root/key-rustic"
+no-cache = true # no cache needed for local repository
+
+[forget]
+keep-hourly = 20
+keep-daily = 14
+keep-weekly = 8
+keep-monthly = 24
+keep-yearly = 10
+
+[backup]
+exclude-if-present = [".nobackup", "CACHEDIR.TAG"]
+glob-file = ["/root/rustic-local.glob"]
+one-filesystem = true
+
+[[backup.sources]]
+source = "/home"
+git-ignore = true
+
+[[backup.sources]]
+source = "/etc"
+
+[[backup.sources]]
+source = "/root"

--- a/examples/ovh-hot-cold.toml
+++ b/examples/ovh-hot-cold.toml
@@ -1,0 +1,31 @@
+# rustic config file to backup /home, /etc and /root to a hot/cold repository hosted by OVH
+#
+# backup usage: "rustic-rs -P ovh-hot-cold backup
+# cleanup:      "rustic-rs -P ovh-hot-cold forget --prune
+#
+[global]
+repository = "rclone:ovh:backup-home"
+repo-hot = "rclone:ovh:backup-home-hot"
+password-file =  "/root/key-rustic-ovh"
+cache-dir = "/var/lib/cache/rustic" # explicitely specify cache dir for remote repository 
+
+[forget]
+keep-daily = 8
+keep-weekly = 5
+keep-monthly = 13
+keep-yearly = 10
+
+[backup]
+exclude-if-present = [".nobackup", "CACHEDIR.TAG"]
+glob-file = ["/root/rustic-ovh.glob"]
+one-filesystem = true
+
+[[backup.sources]]
+source = "/home"
+git-ignore = true
+
+[[backup.sources]]
+source = "/etc"
+
+[[backup.sources]]
+source = "/root"

--- a/examples/rustic.toml
+++ b/examples/rustic.toml
@@ -1,0 +1,40 @@
+# Example rustic config file. 
+#
+# This file should be placed in the user's local config dir (~/.config/rustic/)
+# If you save it under NAME.toml, use "rustic-rs -P NAME" to access this profile. 
+#
+# Note that most options can be overwritten by the corresponding command line option.
+
+# global options: These options are used for all commands. 
+[global]
+repository = "/tmp/rustic"
+password = "mySecretPassword" 
+
+# snapshot-filter options: These options appy to the snapshots, tag and forget command.
+[snapshot-filter]
+filter-host = ["myhost"]
+
+# backup options: These options are used for all sources when calling the backup command. 
+# They can be overwritten by source-specific options (see below) or command line options.
+[backup]
+git-ignore = true
+
+# backup options can be given for specific sources. These options only apply
+# when calling "rustic-rs backup SOURCE".
+#
+# Note that if you call "rustic-rs backup" without any source, all sources from this config 
+# file will be processed. 
+[[backup.sources]]
+source = "/data/dir"
+
+[[backup.sources]]
+source = "/home"
+glob = ["!/home/*/Downloads/*"]
+
+# forget options
+[forget]
+filter-host = ["forgethost"] # <- this overwrites the snapshot-filter option defined above
+keep-tags = ["mytag"]
+keep-within-daily = "7 days"
+keep-monthly = 5
+keep-yearly = 2

--- a/src/backend/ignore.rs
+++ b/src/backend/ignore.rs
@@ -7,6 +7,9 @@ use bytesize::ByteSize;
 use chrono::{TimeZone, Utc};
 use clap::Parser;
 use ignore::{overrides::OverrideBuilder, DirEntry, Walk, WalkBuilder};
+use merge::Merge;
+use serde::Deserialize;
+use serde_with::{serde_as, DisplayFromStr};
 use users::{Groups, Users, UsersCache};
 
 use super::{node::Metadata, node::NodeType, Node, ReadSource};
@@ -18,42 +21,53 @@ pub struct LocalSource {
     cache: UsersCache,
 }
 
-#[derive(Clone, Parser)]
+#[serde_as]
+#[derive(Default, Clone, Parser, Deserialize, Merge)]
+#[serde(default, rename_all = "kebab-case")]
 pub struct LocalSourceOptions {
     /// Save access time for files and directories
     #[clap(long)]
+    #[merge(strategy = merge::bool::overwrite_false)]
     with_atime: bool,
 
     /// Glob pattern to exclude/include (can be specified multiple times)
     #[clap(long, short = 'g', help_heading = "EXCLUDE OPTIONS")]
+    #[merge(strategy = merge::vec::overwrite_empty)]
     glob: Vec<String>,
 
     /// Same as --glob pattern but ignores the casing of filenames
     #[clap(long, value_name = "GLOB", help_heading = "EXCLUDE OPTIONS")]
+    #[merge(strategy = merge::vec::overwrite_empty)]
     iglob: Vec<String>,
 
     /// Read glob patterns to exclude/include from this file (can be specified multiple times)
     #[clap(long, value_name = "FILE", help_heading = "EXCLUDE OPTIONS")]
+    #[merge(strategy = merge::vec::overwrite_empty)]
     glob_file: Vec<String>,
 
     /// Same as --glob-file ignores the casing of filenames in patterns
     #[clap(long, value_name = "FILE", help_heading = "EXCLUDE OPTIONS")]
+    #[merge(strategy = merge::vec::overwrite_empty)]
     iglob_file: Vec<String>,
 
     /// Ignore files based on .gitignore files
     #[clap(long, help_heading = "EXCLUDE OPTIONS")]
+    #[merge(strategy = merge::bool::overwrite_false)]
     git_ignore: bool,
 
     /// Exclude contents of directories containing this filename (can be specified multiple times)
     #[clap(long, value_name = "FILE", help_heading = "EXCLUDE OPTIONS")]
+    #[merge(strategy = merge::vec::overwrite_empty)]
     exclude_if_present: Vec<String>,
 
     /// Exclude other file systems, don't cross filesystem boundaries and subvolumes
     #[clap(long, short = 'x', help_heading = "EXCLUDE OPTIONS")]
+    #[merge(strategy = merge::bool::overwrite_false)]
     one_file_system: bool,
 
     /// Maximum size of files to be backuped. Larger files will be excluded.
     #[clap(long, value_name = "SIZE", help_heading = "EXCLUDE OPTIONS")]
+    #[serde_as(as = "Option<DisplayFromStr>")]
     exclude_larger_than: Option<ByteSize>,
 }
 

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -2,6 +2,8 @@ use std::path::PathBuf;
 
 use anyhow::{bail, Result};
 use clap::{Parser, Subcommand};
+use merge::Merge;
+use serde::Deserialize;
 
 use crate::backend::{
     Cache, CachedBackend, ChooseBackend, DecryptBackend, DecryptReadBackend, FileType,
@@ -23,42 +25,48 @@ mod ls;
 mod prune;
 mod repoinfo;
 mod restore;
+mod rustic_config;
 mod self_update;
 mod snapshots;
 mod tag;
 
 use helpers::*;
+use rustic_config::RusticConfig;
 use vlog::*;
 
 #[derive(Parser)]
 #[clap(about, version)]
 struct Opts {
-    /// Repository to use
+    #[clap(flatten, help_heading = "GLOBAL OPTIONS")]
+    global: GlobalOpts,
+
+    /// Config profile to use. This parses the file <PROFILE>.toml in the config directory.
     #[clap(
-        short,
+        short = 'P',
         long,
+        value_name = "PROFILE",
         global = true,
-        env = "RUSTIC_REPOSITORY",
-        help_heading = "GLOBAL OPTIONS"
+        default_value = "rustic"
     )]
+    config_profile: String,
+
+    #[clap(subcommand)]
+    command: Command,
+}
+
+#[derive(Default, Parser, Deserialize, Merge)]
+#[serde(default, rename_all = "kebab-case")]
+struct GlobalOpts {
+    /// Repository to use
+    #[clap(short, long, global = true, env = "RUSTIC_REPOSITORY")]
     repository: Option<String>,
 
     /// Repository to use as hot storage
-    #[clap(
-        long,
-        global = true,
-        env = "RUSTIC_REPO_HOT",
-        help_heading = "GLOBAL OPTIONS"
-    )]
+    #[clap(long, global = true, env = "RUSTIC_REPO_HOT")]
     repo_hot: Option<String>,
 
     /// Password of the repository - WARNING: Using --password can reveal the password in the process list!
-    #[clap(
-        long,
-        global = true,
-        env = "RUSTIC_PASSWORD",
-        help_heading = "GLOBAL OPTIONS"
-    )]
+    #[clap(long, global = true, env = "RUSTIC_PASSWORD")]
     password: Option<String>,
 
     /// File to read the password from
@@ -68,7 +76,6 @@ struct Opts {
         global = true,
         parse(from_os_str),
         env = "RUSTIC_PASSWORD_FILE",
-        help_heading = "GLOBAL OPTIONS",
         conflicts_with = "password"
     )]
     password_file: Option<PathBuf>,
@@ -78,19 +85,13 @@ struct Opts {
         long,
         global = true,
         env = "RUSTIC_PASSWORD_COMMAND",
-        help_heading = "GLOBAL OPTIONS",
         conflicts_with_all = &["password", "password-file"],
     )]
     password_command: Option<String>,
 
     /// Increase verbosity (can be used multiple times)
-    #[clap(
-        long,
-        short = 'v',
-        global = true,
-        parse(from_occurrences),
-        help_heading = "GLOBAL OPTIONS"
-    )]
+    #[clap(long, short = 'v', global = true, parse(from_occurrences))]
+    #[merge(strategy = merge::num::overwrite_zero)]
     verbose: i8,
 
     /// Don't be verbose at all
@@ -99,18 +100,14 @@ struct Opts {
         short = 'q',
         global = true,
         parse(from_occurrences),
-        conflicts_with = "verbose",
-        help_heading = "GLOBAL OPTIONS"
+        conflicts_with = "verbose"
     )]
+    #[merge(strategy = merge::num::overwrite_zero)]
     quiet: i8,
 
     /// Don't use a cache.
-    #[clap(
-        long,
-        global = true,
-        env = "RUSTIC_NO_CACHE",
-        help_heading = "GLOBAL OPTIONS"
-    )]
+    #[clap(long, global = true, env = "RUSTIC_NO_CACHE")]
+    #[merge(strategy = merge::bool::overwrite_false)]
     no_cache: bool,
 
     /// Use this dir as cache dir instead of the standard cache dir
@@ -119,13 +116,9 @@ struct Opts {
         global = true,
         parse(from_os_str),
         conflicts_with = "no-cache",
-        env = "RUSTIC_CACHE_DIR",
-        help_heading = "GLOBAL OPTIONS"
+        env = "RUSTIC_CACHE_DIR"
     )]
     cache_dir: Option<PathBuf>,
-
-    #[clap(subcommand)]
-    command: Command,
 }
 
 #[derive(Subcommand)]
@@ -183,6 +176,11 @@ pub async fn execute() -> Result<()> {
     let command: Vec<_> = std::env::args_os().into_iter().collect();
     let args = Opts::parse_from(&command);
 
+    let config_file = RusticConfig::new(&args.config_profile)?;
+
+    let mut opts = args.global;
+    config_file.merge_into("global", &mut opts)?;
+
     if let Command::SelfUpdate(opts) = args.command {
         self_update::execute(opts).await?;
         return Ok(());
@@ -194,15 +192,15 @@ pub async fn execute() -> Result<()> {
         .collect::<Vec<_>>()
         .join(" ");
 
-    let verbosity = (1 + args.verbose - args.quiet).clamp(0, 3);
+    let verbosity = (1 + opts.verbose - opts.quiet).clamp(0, 3);
     set_verbosity_level(verbosity as usize);
 
-    let be = match &args.repository {
+    let be = match &opts.repository {
         Some(repo) => ChooseBackend::from_url(repo)?,
         None => bail!("No repository given. Please use the --repository option."),
     };
 
-    let be_hot = args
+    let be_hot = opts
         .repo_hot
         .map(|repo| ChooseBackend::from_url(&repo))
         .transpose()?;
@@ -225,9 +223,9 @@ pub async fn execute() -> Result<()> {
 
             let key = get_key(
                 &be,
-                args.password.as_deref(),
-                args.password_file.as_deref(),
-                args.password_command.as_deref(),
+                opts.password.as_deref(),
+                opts.password_file.as_deref(),
+                opts.password_command.as_deref(),
             )
             .await?;
             ve1!("password is correct.");
@@ -239,8 +237,8 @@ pub async fn execute() -> Result<()> {
                 (false, true) => bail!("repo-hot is not a hot repository! Aborting."),
                 _ => {}
             }
-            let cache = (!args.no_cache)
-                .then(|| Cache::new(config.id, args.cache_dir).ok())
+            let cache = (!opts.no_cache)
+                .then(|| Cache::new(config.id, opts.cache_dir).ok())
                 .flatten();
             match &cache {
                 None => v1!("using no cache"),
@@ -255,22 +253,22 @@ pub async fn execute() -> Result<()> {
     };
 
     match cmd {
-        Command::Backup(opts) => backup::execute(&dbe, opts, config, command).await?,
+        Command::Backup(opts) => backup::execute(&dbe, opts, config, config_file, command).await?,
         Command::Config(opts) => config::execute(&dbe, &be_hot, opts, config).await?,
         Command::Cat(opts) => cat::execute(&dbe, opts).await?,
         Command::Check(opts) => check::execute(&dbe, &cache, &be_hot, &be, opts).await?,
         Command::Diff(opts) => diff::execute(&dbe, opts).await?,
-        Command::Forget(opts) => forget::execute(&dbe, cache, opts, config).await?,
+        Command::Forget(opts) => forget::execute(&dbe, cache, opts, config, config_file).await?,
         Command::Init(_) => {} // already handled above
         Command::Key(opts) => key::execute(&dbe, key, opts).await?,
         Command::List(opts) => list::execute(&dbe, opts).await?,
         Command::Ls(opts) => ls::execute(&dbe, opts).await?,
         Command::SelfUpdate(_) => {} // already handled above
-        Command::Snapshots(opts) => snapshots::execute(&dbe, opts).await?,
+        Command::Snapshots(opts) => snapshots::execute(&dbe, opts, config_file).await?,
         Command::Prune(opts) => prune::execute(&dbe, cache, opts, config, vec![]).await?,
         Command::Restore(opts) => restore::execute(&dbe, opts).await?,
         Command::Repoinfo(opts) => repoinfo::execute(&dbe, &be_hot, opts).await?,
-        Command::Tag(opts) => tag::execute(&dbe, opts).await?,
+        Command::Tag(opts) => tag::execute(&dbe, opts, config_file).await?,
     };
 
     Ok(())

--- a/src/commands/rustic_config.rs
+++ b/src/commands/rustic_config.rs
@@ -1,0 +1,60 @@
+use std::path::Path;
+
+use anyhow::Result;
+use directories::ProjectDirs;
+use merge::Merge;
+use serde::Deserialize;
+use toml::Value;
+
+pub struct RusticConfig(Value);
+
+impl RusticConfig {
+    pub fn new(profile: &str) -> Result<Self> {
+        let mut path = match ProjectDirs::from("", "", "rustic") {
+            Some(path) => path.config_dir().to_path_buf(),
+            None => Path::new(".").to_path_buf(),
+        };
+        if !path.exists() {
+            path = Path::new(".").to_path_buf();
+        };
+        let path = path.join(profile.to_string() + ".toml");
+
+        let config = if path.exists() {
+            eprintln!("using config {}", path.display());
+            let data = std::fs::read_to_string(path)?;
+            toml::from_str(&data)?
+        } else {
+            toml::from_str("")?
+        };
+
+        Ok(RusticConfig(config))
+    }
+
+    fn get_value(&self, section: &str) -> Option<&Value> {
+        // loop over subsections separated by '.'
+        section
+            .split('.')
+            .fold(Some(&self.0), |acc, x| acc.and_then(|value| value.get(x)))
+    }
+
+    pub fn merge_into<'de, Opts>(&self, section: &str, opts: &mut Opts) -> Result<()>
+    where
+        Opts: Merge + Deserialize<'de>,
+    {
+        if let Some(value) = self.get_value(section) {
+            let config: Opts = value.clone().try_into()?;
+            opts.merge(config);
+        }
+        Ok(())
+    }
+
+    pub fn get<'de, Opts>(&self, section: &str) -> Result<Opts>
+    where
+        Opts: Default + Deserialize<'de>,
+    {
+        match self.get_value(section) {
+            Some(value) => Ok(value.clone().try_into()?),
+            None => Ok(Opts::default()),
+        }
+    }
+}

--- a/src/commands/snapshots.rs
+++ b/src/commands/snapshots.rs
@@ -6,7 +6,7 @@ use humantime::format_duration;
 use itertools::Itertools;
 use prettytable::{format, row, Table};
 
-use super::bytes;
+use super::{bytes, RusticConfig};
 use crate::backend::DecryptReadBackend;
 use crate::repo::{
     DeleteOption, SnapshotFile, SnapshotFilter, SnapshotGroup, SnapshotGroupCriterion,
@@ -39,7 +39,13 @@ pub(super) struct Opts {
     ids: Vec<String>,
 }
 
-pub(super) async fn execute(be: &impl DecryptReadBackend, opts: Opts) -> Result<()> {
+pub(super) async fn execute(
+    be: &impl DecryptReadBackend,
+    mut opts: Opts,
+    config_file: RusticConfig,
+) -> Result<()> {
+    config_file.merge_into("snapshot-filter", &mut opts.filter)?;
+
     let groups = match &opts.ids[..] {
         [] => SnapshotFile::group_from_backend(be, &opts.filter, &opts.group_by).await?,
         [id] if id == "latest" => {

--- a/src/commands/tag.rs
+++ b/src/commands/tag.rs
@@ -2,7 +2,7 @@ use anyhow::Result;
 use chrono::{Duration, Local};
 use clap::{AppSettings, Parser};
 
-use super::progress_counter;
+use super::{progress_counter, RusticConfig};
 use crate::backend::{DecryptFullBackend, FileType};
 use crate::repo::{DeleteOption, SnapshotFile, SnapshotFilter, StringList};
 
@@ -67,7 +67,13 @@ pub(super) struct Opts {
     ids: Vec<String>,
 }
 
-pub(super) async fn execute(be: &impl DecryptFullBackend, opts: Opts) -> Result<()> {
+pub(super) async fn execute(
+    be: &impl DecryptFullBackend,
+    mut opts: Opts,
+    config_file: RusticConfig,
+) -> Result<()> {
+    config_file.merge_into("snapshot-filter", &mut opts.filter)?;
+
     let snapshots = match opts.ids.is_empty() {
         true => SnapshotFile::all_from_backend(be, &opts.filter).await?,
         false => SnapshotFile::from_ids(be, &opts.ids).await?,


### PR DESCRIPTION
TODOs:
- [x] Config file location(s)
- [x] Allow to specify config file location 
- [x] Allow config profiles
- [x] Read config file
- [x] merge general options from config file
- [x] merge backup options from config file
- [x] add support for individual backup options for different backup sources
- [x] merge forget options from config file
- [x] merge filter options (used in snapshots, forget, tag) from config file 
- [x] Make and publish example config files
- [x] Update README

Will stay open for follow-up PRs

- [ ] merge prune options from config file?? (Or maybe add them to the `config` command?)
- [ ] Others missing?
