### PR TITLE
snapshots: group by hosts and paths as default

### DIFF
--- a/src/commands/snapshots.rs
+++ b/src/commands/snapshots.rs
@@ -18,7 +18,12 @@ pub(super) struct Opts {
     filter: SnapshotFilter,
 
     /// Group snapshots by any combination of host,paths,tags
-    #[clap(long, short = 'g', value_name = "CRITERION", default_value = "")]
+    #[clap(
+        long,
+        short = 'g',
+        value_name = "CRITERION",
+        default_value = "host,paths"
+    )]
     group_by: SnapshotGroupCriterion,
 
     /// Show detailed information about snapshots


### PR DESCRIPTION
After #170 it is much more convenient to group snapshots by default.