### PR TITLE
change binary name to rustic

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -90,7 +90,7 @@ jobs:
           cd target/${{ matrix.job.target }}/release
 
           ####### reduce binary size by removing debug symbols #######
-          BINARY_NAME=rustic-rs${{ matrix.job.binary-postfix }}
+          BINARY_NAME=rustic${{ matrix.job.binary-postfix }}
           if [[ ${{ matrix.job.target }} == aarch64-unknown-linux-gnu ]]; then
             GCC_PREFIX="aarch64-linux-gnu-"
           else
@@ -99,7 +99,7 @@ jobs:
           "$GCC_PREFIX"strip $BINARY_NAME
 
           ########## create tar.gz ##########
-          RELEASE_NAME=rustic-rs-${GITHUB_REF_NAME}-${{ matrix.job.target}}
+          RELEASE_NAME=rustic-${GITHUB_REF_NAME}-${{ matrix.job.target}}
           tar czvf $RELEASE_NAME.tar.gz $BINARY_NAME
 
           ########## create sha256 ##########
@@ -134,7 +134,7 @@ jobs:
           mkdir -p $WORKING_DIR/$DEST_DIR
 
           # do the copy
-          cp -a target/${{ matrix.job.target }}/release/rustic-rs-*.tar.gz $WORKING_DIR/$DEST_DIR
+          cp -a target/${{ matrix.job.target }}/release/rustic-*.tar.gz $WORKING_DIR/$DEST_DIR
 
           # create the commit
           cd $WORKING_DIR
@@ -147,7 +147,7 @@ jobs:
         if: startsWith(github.ref, 'refs/tags/')
         with:
           files: |
-            target/${{ matrix.job.target }}/release/rustic-rs-*.tar.gz
+            target/${{ matrix.job.target }}/release/rustic-*.tar.gz
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,9 @@ repository = "https://github.com/rustic-rs/rustic"
 keywords = ["backup", "restic", "deduplication", "encryption", "cli"]
 categories = ["command-line-utilities"]
 
+[[bin]]
+name = "rustic"
+path = "src/main.rs"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]

--- a/examples/local.toml
+++ b/examples/local.toml
@@ -1,7 +1,7 @@
 # rustic config file to backup /home, /etc and /root to a local repository
 #
-# backup usage: "rustic-rs -P local backup
-# cleanup:      "rustic-rs -P local forget --prune
+# backup usage: "rustic -P local backup
+# cleanup:      "rustic -P local forget --prune
 #
 [global]
 repository = "/backup/rustic"

--- a/examples/ovh-hot-cold.toml
+++ b/examples/ovh-hot-cold.toml
@@ -1,7 +1,7 @@
 # rustic config file to backup /home, /etc and /root to a hot/cold repository hosted by OVH
 #
-# backup usage: "rustic-rs -P ovh-hot-cold backup
-# cleanup:      "rustic-rs -P ovh-hot-cold forget --prune
+# backup usage: "rustic -P ovh-hot-cold backup
+# cleanup:      "rustic -P ovh-hot-cold forget --prune
 #
 [global]
 repository = "rclone:ovh:backup-home"

--- a/examples/rustic.toml
+++ b/examples/rustic.toml
@@ -1,7 +1,7 @@
 # Example rustic config file. 
 #
 # This file should be placed in the user's local config dir (~/.config/rustic/)
-# If you save it under NAME.toml, use "rustic-rs -P NAME" to access this profile. 
+# If you save it under NAME.toml, use "rustic -P NAME" to access this profile. 
 #
 # Note that most options can be overwritten by the corresponding command line option.
 
@@ -20,9 +20,9 @@ filter-host = ["myhost"]
 git-ignore = true
 
 # backup options can be given for specific sources. These options only apply
-# when calling "rustic-rs backup SOURCE".
+# when calling "rustic backup SOURCE".
 #
-# Note that if you call "rustic-rs backup" without any source, all sources from this config 
+# Note that if you call "rustic backup" without any source, all sources from this config 
 # file will be processed. 
 [[backup.sources]]
 source = "/data/dir"

--- a/src/commands/self_update.rs
+++ b/src/commands/self_update.rs
@@ -13,7 +13,7 @@ pub(super) async fn execute(opts: Opts) -> Result<()> {
     let status = self_update::backends::github::Update::configure()
         .repo_owner("rustic-rs")
         .repo_name("rustic")
-        .bin_name("rustic-rs")
+        .bin_name("rustic")
         .show_download_progress(true)
         .current_version(cargo_crate_version!())
         .no_confirm(opts.force)


### PR DESCRIPTION
Note that this change break the self-update functionality when starting from previous versions.
However, self-update so far is only contained in release 0.3.0.
I think it's reasonable to have a working self-update starting from the upcoming 0.3.1.