### PR TITLE
Simplify rclone backend (using rclone > 1.52.2)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1593,14 +1593,13 @@ dependencies = [
  "rstest",
  "scrypt",
  "self_update",
+ "semver",
  "serde",
  "serde-aux",
  "serde_json",
  "serde_with",
- "sha1",
  "sha2",
  "simplelog",
- "tempfile",
  "thiserror",
  "tokio",
  "toml",
@@ -1794,17 +1793,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
-]
-
-[[package]]
-name = "sha1"
-version = "0.10.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f04293dc80c3993519f2d7f6f511707ee7094fe0c6d3406feb330cdb3540eba3"
-dependencies = [
- "cfg-if",
- "cpufeatures",
- "digest",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,8 +67,7 @@ filetime = "0.2"
 reqwest = {version = "0.11", default-features = false, features = ["json", "rustls-tls", "stream"] }
 backoff = { version = "0.4", features = ["tokio"] }
 # rclone backend
-sha1 = "0.10"
-tempfile = "3"
+semver = "1"
 # cache
 dirs = "4"
 cachedir = "0.3"


### PR DESCRIPTION
Currently, rustic saves a `.htpasswd` at `/tmp` to use as rclone authentication.
This PR uses the environmental variables introduced in rclone 1.52.2. This simplifies the code and removes build dependencies.

This change also makes rustic independent from a `/tmp` directory.