### PR TITLE
fix repair index

### DIFF
--- a/src/commands/repair.rs
+++ b/src/commands/repair.rs
@@ -118,7 +118,7 @@ async fn repair_index(be: &impl DecryptFullBackend, opts: IndexOpts) -> Result<(
         match (changed, opts.dry_run) {
             (true, true) => info!("would have modified index file {index_id}"),
             (true, false) => {
-                if !new_index.packs.is_empty() && !new_index.packs_to_delete.is_empty() {
+                if !new_index.packs.is_empty() || !new_index.packs_to_delete.is_empty() {
                     be.save_file(&new_index).await?;
                 }
                 be.remove(FileType::Index, &index_id, true).await?;


### PR DESCRIPTION
`repair index` saved the modified index only if both packs and packs-to-delete in this index remain. It was due to an logic error.

This is fixed by this PR.