### PR TITLE
fix index has method

### DIFF
--- a/src/index/mod.rs
+++ b/src/index/mod.rs
@@ -66,6 +66,7 @@ impl IndexEntry {
 pub trait ReadIndex {
     fn get_id(&self, tpe: &BlobType, id: &Id) -> Option<IndexEntry>;
     fn total_size(&self, tpe: &BlobType) -> u64;
+    fn has(&self, tpe: &BlobType, id: &Id) -> bool;
 
     fn get_tree(&self, id: &Id) -> Option<IndexEntry> {
         self.get_id(&BlobType::Tree, id)
@@ -73,10 +74,6 @@ pub trait ReadIndex {
 
     fn get_data(&self, id: &Id) -> Option<IndexEntry> {
         self.get_id(&BlobType::Data, id)
-    }
-
-    fn has(&self, tpe: &BlobType, id: &Id) -> bool {
-        self.get_id(tpe, id).is_some()
     }
 
     fn has_tree(&self, id: &Id) -> bool {
@@ -115,6 +112,9 @@ impl<BE: DecryptReadBackend> ReadIndex for IndexBackend<BE> {
 
     fn total_size(&self, tpe: &BlobType) -> u64 {
         self.index.total_size(tpe)
+    }
+    fn has(&self, tpe: &BlobType, id: &Id) -> bool {
+        self.index.has(tpe, id)
     }
 }
 

--- a/test-bats/simple.bats
+++ b/test-bats/simple.bats
@@ -51,6 +51,8 @@ teardown () {
 
    run $RUSTIC check --read-data
    assert_success
+   refute_output -p "ERROR"
+   refute_output -p "WARN"
 }
 
 @test "backup and restore" {


### PR DESCRIPTION
#260 introduced a subtle bug: the method `has` had a blanket trait implementation; however ambassador did not use it, but propagated the method directly to the index. The index however had a special implementation which yielded the correct result even if the index was not fully saved, but only existing IDs.
As a result, `check` reported wrong errors about missing blobs.

This PR fixes the problems and removes the blanket implementation for the index `has` method.
It also adds a check in the CI tests which would have detected the problem.