### PR TITLE
WIP: remove async code and parallelize using threads

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -357,6 +357,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-channel"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2dd04ddaf88237dc3b8d8f9a3c1004b506b54b3313403944054d23c0870c521"
+dependencies = [
+ "cfg-if",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "715e8152b692bba2d374b53d4875445368fdf21a94751410af607a5ac677d1fc"
+dependencies = [
+ "cfg-if",
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f916dfc5d356b0ed9dae65f1db9fc9770aa2851d2662b988ccf4fe3516e86348"
+dependencies = [
+ "autocfg",
+ "cfg-if",
+ "crossbeam-utils",
+ "memoffset",
+ "scopeguard",
+]
+
+[[package]]
 name = "crossbeam-utils"
 version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1408,6 +1442,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "rayon"
+version = "1.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd99e5772ead8baa5215278c9b15bf92087709e9c1b2d1f97cdb5a183c933a7d"
+dependencies = [
+ "autocfg",
+ "crossbeam-deque",
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "258bcdb5ac6dad48491bb2992db6b7cf74878b0384908af124823d118c99683f"
+dependencies = [
+ "crossbeam-channel",
+ "crossbeam-deque",
+ "crossbeam-utils",
+ "num_cpus",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1570,6 +1628,7 @@ dependencies = [
  "chrono",
  "clap",
  "clap_complete",
+ "crossbeam-channel",
  "derivative",
  "derive-getters",
  "derive_more",
@@ -1595,6 +1654,7 @@ dependencies = [
  "quickcheck",
  "quickcheck_macros",
  "rand",
+ "rayon",
  "reqwest",
  "rpassword",
  "rstest",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -119,12 +119,9 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b62ddb9cb1ec0a098ad4bbf9344d0713fa193ae1a80af55febcff2627b6a00c1"
 dependencies = [
- "futures-core",
  "getrandom",
  "instant",
- "pin-project-lite",
  "rand",
- "tokio",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -357,6 +357,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2801af0d36612ae591caa9568261fddce32ce6e08a7275ea334a06a4ad021a2c"
+dependencies = [
+ "cfg-if",
+ "crossbeam-channel",
+ "crossbeam-deque",
+ "crossbeam-epoch",
+ "crossbeam-queue",
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-channel"
 version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -388,6 +402,16 @@ dependencies = [
  "crossbeam-utils",
  "memoffset",
  "scopeguard",
+]
+
+[[package]]
+name = "crossbeam-queue"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1cd42583b04998a5363558e5f9291ee5a5ff6b49944332103f251e7479a82aa7"
+dependencies = [
+ "cfg-if",
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -1241,6 +1265,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1b04fb49957986fdce4d6ee7a65027d55d4b6d2265e5848bbb507b58ccfdb6f"
 
 [[package]]
+name = "pariter"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "324a62b9e7b5f270c0acc92a2040f8028bb643f959f9c068f11a7864f327e3d9"
+dependencies = [
+ "crossbeam",
+ "crossbeam-channel",
+ "num_cpus",
+]
+
+[[package]]
 name = "parking_lot"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1649,6 +1684,7 @@ dependencies = [
  "log",
  "merge",
  "nix",
+ "pariter",
  "path-absolutize",
  "prettytable-rs",
  "quickcheck",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -75,28 +75,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfb6d71005dc22a708c7496eee5c8dc0300ee47355de6256c3b35b12b5fef596"
 
 [[package]]
-name = "async-recursion"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2cda8f4bcc10624c4e85bc66b3f452cca98cfa5ca002dc83a16aad2367641bea"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "async-trait"
-version = "0.1.58"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e805d94e6b5001b651426cf4cd446b1ab5f319d27bab5c644f61de0a804360c"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -180,9 +158,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.11.0"
+version = "3.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1ad822118d20d2c234f427000d5acc36eabe1e29a348c89b63dd60b13f28e5d"
+checksum = "572f695136211188308f16ad2ca5c851a712c464060ae6974944458eb83880ba"
 
 [[package]]
 name = "bytemuck"
@@ -313,14 +291,24 @@ dependencies = [
 ]
 
 [[package]]
-name = "console"
-version = "0.15.1"
+name = "codespan-reporting"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89eab4d20ce20cea182308bca13088fecea9c05f6776cf287205d41a0ed3c847"
+checksum = "3538270d33cc669650c4b093848450d380def10c331d38c768e34cac80576e6e"
+dependencies = [
+ "termcolor",
+ "unicode-width",
+]
+
+[[package]]
+name = "console"
+version = "0.15.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c050367d967ced717c04b65d8c619d863ef9292ce0c5760028655a2fb298718c"
 dependencies = [
  "encode_unicode 0.3.6",
+ "lazy_static",
  "libc",
- "once_cell",
  "terminal_size",
  "unicode-width",
  "winapi",
@@ -416,12 +404,11 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.11"
+version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51887d4adc7b564537b15adcfb307936f8075dfcd5f00dde9a9f1d29383682bc"
+checksum = "edbafec5fa1f196ca66527c1b12c2ec4745ca14b50f1ad8f9f6f720b55d11fac"
 dependencies = [
  "cfg-if",
- "once_cell",
 ]
 
 [[package]]
@@ -441,6 +428,50 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "049bb91fb4aaf0e3c7efa6cd5ef877dbbbd15b39dad06d9948de4ec8a75761ea"
 dependencies = [
  "cipher 0.3.0",
+]
+
+[[package]]
+name = "cxx"
+version = "1.0.80"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b7d4e43b25d3c994662706a1d4fcfc32aaa6afd287502c111b237093bb23f3a"
+dependencies = [
+ "cc",
+ "cxxbridge-flags",
+ "cxxbridge-macro",
+ "link-cplusplus",
+]
+
+[[package]]
+name = "cxx-build"
+version = "1.0.80"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84f8829ddc213e2c1368e51a2564c552b65a8cb6a28f31e576270ac81d5e5827"
+dependencies = [
+ "cc",
+ "codespan-reporting",
+ "once_cell",
+ "proc-macro2",
+ "quote",
+ "scratch",
+ "syn",
+]
+
+[[package]]
+name = "cxxbridge-flags"
+version = "1.0.80"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e72537424b474af1460806647c41d4b6d35d09ef7fe031c5c2fa5766047cc56a"
+
+[[package]]
+name = "cxxbridge-macro"
+version = "1.0.80"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "309e4fb93eed90e1e14bea0da16b209f81813ba9fc7830c20ed151dd7bc0a4d7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -679,9 +710,9 @@ dependencies = [
 
 [[package]]
 name = "futures"
-version = "0.3.24"
+version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f21eda599937fba36daeb58a22e8f5cee2d14c4a17b5b7739c7c8e5e3b8230c"
+checksum = "38390104763dc37a5145a53c29c63c1290b5d316d6086ec32c293f6736051bb0"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -694,9 +725,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.24"
+version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30bdd20c28fadd505d0fd6712cdfcb0d4b5648baf45faef7f852afb2399bb050"
+checksum = "52ba265a92256105f45b719605a571ffe2d1f0fea3807304b522c1d778f79eed"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -704,15 +735,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.24"
+version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e5aa3de05362c3fb88de6531e6296e85cde7739cccad4b9dfeeb7f6ebce56bf"
+checksum = "04909a7a7e4633ae6c4a9ab280aeb86da1236243a77b694a49eacd659a4bd3ac"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.24"
+version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ff63c23854bee61b6e9cd331d523909f238fc7636290b96826e9cfa5faa00ab"
+checksum = "7acc85df6714c176ab5edf386123fafe217be88c0840ec11f199441134a074e2"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -721,15 +752,15 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.24"
+version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbf4d2a7a308fd4578637c0b17c7e1c7ba127b8f6ba00b29f717e9655d85eb68"
+checksum = "00f5fb52a06bdcadeb54e8d3671f8888a39697dcb0b81b23b55174030427f4eb"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.24"
+version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42cd15d1c7456c04dbdf7e88bcd69760d74f3a798d6444e16974b505b0e62f17"
+checksum = "bdfb8ce053d86b91919aad980c220b1fb8401a9394410e1c289ed7e66b61835d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -738,15 +769,15 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.24"
+version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21b20ba5a92e727ba30e72834706623d94ac93a725410b6a6b6fbc1b07f7ba56"
+checksum = "39c15cf1a4aa79df40f1bb462fb39676d0ad9e366c2a33b590d7c66f4f81fcf9"
 
 [[package]]
 name = "futures-task"
-version = "0.3.24"
+version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6508c467c73851293f390476d4491cf4d227dbabcd4170f3bb6044959b294f1"
+checksum = "2ffb393ac5d9a6eaa9d3fdf37ae2776656b706e200c8e16b1bdb227f5198e6ea"
 
 [[package]]
 name = "futures-timer"
@@ -756,9 +787,9 @@ checksum = "e64b03909df88034c26dc1547e8970b91f98bdb65165d6a4e9110d94263dbb2c"
 
 [[package]]
 name = "futures-util"
-version = "0.3.24"
+version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44fb6cb1be61cc1d2e43b262516aafcf63b241cffdb1d3fa115f91d9c7b09c90"
+checksum = "197676987abd2f9cadff84926f410af1c183608d36641465df73ae8211dc65d6"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -794,9 +825,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.7"
+version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4eb1a864a501629691edf6c15a593b7a51eebaa1e8468e9ddc623de7c9b58ec6"
+checksum = "c05aeb6a22b8f62540c194aac980f2115af067bfe15a0734d7277a768d396b31"
 dependencies = [
  "cfg-if",
  "libc",
@@ -953,16 +984,26 @@ dependencies = [
 
 [[package]]
 name = "iana-time-zone"
-version = "0.1.48"
+version = "0.1.51"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "237a0714f28b1ee39ccec0770ccb544eb02c9ef2c82bb096230eefcffa6468b0"
+checksum = "f5a6ef98976b22b3b7f2f3a806f858cb862044cfa66805aa3ad84cb3d3b785ed"
 dependencies = [
  "android_system_properties",
  "core-foundation-sys",
+ "iana-time-zone-haiku",
  "js-sys",
- "once_cell",
  "wasm-bindgen",
  "winapi",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0703ae284fc167426161c2e3f1da3ea71d94b21bedbcc9494e92b28e334e3dca"
+dependencies = [
+ "cxx",
+ "cxx-build",
 ]
 
 [[package]]
@@ -1065,15 +1106,15 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c8af84674fe1f223a982c933a0ee1086ac4d4052aa0fb8060c12c6ad838e754"
+checksum = "4217ad341ebadf8d8e724e264f13e593e0648f5b3e94b3896a5df283be015ecc"
 
 [[package]]
 name = "jobserver"
-version = "0.1.24"
+version = "0.1.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af25a77299a7f711a01975c35a6a424eb6862092cc2d6c72c4ed6cbc56dfc1fa"
+checksum = "068b1ee6743e4d11fb9c6a1e6064b3693a1b600e7f5f5988047d98b3dc9fb90b"
 dependencies = [
  "libc",
 ]
@@ -1095,18 +1136,17 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.132"
+version = "0.2.135"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8371e4e5341c3a96db127eb2465ac681ced4c433e01dd0e938adbef26ba93ba5"
+checksum = "68783febc7782c6c5cb401fbda4de5a9898be1762314da0bb2c10ced61f18b0c"
 
 [[package]]
-name = "lock_api"
-version = "0.4.8"
+name = "link-cplusplus"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f80bf5aacaf25cbfc8210d1cfb718f2bf3b11c4c54e5afe36c236853a8ec390"
+checksum = "9272ab7b96c9046fbc5bc56c06c117cb639fe2d509df0c421cad82d2915cf369"
 dependencies = [
- "autocfg",
- "scopeguard",
+ "cc",
 ]
 
 [[package]]
@@ -1242,9 +1282,9 @@ checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
 
 [[package]]
 name = "once_cell"
-version = "1.14.0"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f7254b99e31cad77da24b08ebf628882739a608578bb1bcdfc1f9c21260d7c0"
+checksum = "e82dad04139b71a90c080c8463fe0dc7902db5192d939bd0950f074d014339e1"
 
 [[package]]
 name = "opaque-debug"
@@ -1273,29 +1313,6 @@ dependencies = [
  "crossbeam",
  "crossbeam-channel",
  "num_cpus",
-]
-
-[[package]]
-name = "parking_lot"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3742b2c103b9f06bc9fff0a37ff4912935851bee6d36f3c02bcc755bcfec228f"
-dependencies = [
- "lock_api",
- "parking_lot_core",
-]
-
-[[package]]
-name = "parking_lot_core"
-version = "0.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09a279cbf25cb0757810394fbc1e359949b59e348145c643a939a525692e6929"
-dependencies = [
- "cfg-if",
- "libc",
- "redox_syscall",
- "smallvec",
- "windows-sys 0.36.1",
 ]
 
 [[package]]
@@ -1399,9 +1416,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.43"
+version = "1.0.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a2ca2c61bc9f3d74d2886294ab7b9853abd9c1ad903a3ac7815c58989bb7bab"
+checksum = "5ea3d908b0e36316caf9e9e2c4625cdde190a7e6f440d794667ed17a1855e725"
 dependencies = [
  "unicode-ident",
 ]
@@ -1469,9 +1486,9 @@ dependencies = [
 
 [[package]]
 name = "rand_core"
-version = "0.6.3"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d34f1408f55294453790c48b2f1ebbb1c5b4b7563eb1f418bcfcfdbb06ebb4e7"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom",
 ]
@@ -1651,8 +1668,6 @@ version = "0.3.2-dev"
 dependencies = [
  "aes256ctr_poly1305aes",
  "anyhow",
- "async-recursion",
- "async-trait",
  "backoff",
  "base64",
  "binrw",
@@ -1672,7 +1687,6 @@ dependencies = [
  "enum-map",
  "enum-map-derive",
  "filetime",
- "futures",
  "gethostname",
  "hex",
  "humantime",
@@ -1704,7 +1718,6 @@ dependencies = [
  "sha2",
  "simplelog",
  "thiserror",
- "tokio",
  "toml",
  "users",
  "walkdir",
@@ -1713,9 +1726,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.20.6"
+version = "0.20.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5aab8ee6c7097ed6057f43c187a62418d0c05a4bd5f18b3571db50ee0f9ce033"
+checksum = "539a2bfe908f471bfa933876bd1eb6a19cf2176d375f82ef7f99530a40e48c2c"
 dependencies = [
  "log",
  "ring",
@@ -1767,6 +1780,12 @@ name = "scopeguard"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
+
+[[package]]
+name = "scratch"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c8132065adcfd6e02db789d9285a0deb2f3fcb04002865ab67d5fb103533898"
 
 [[package]]
 name = "scrypt"
@@ -1910,15 +1929,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "signal-hook-registry"
-version = "1.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e51e73328dc4ac0c7ccbda3a494dfa03df1de2f46018127f60c693f2648455b0"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "simplelog"
 version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1937,12 +1947,6 @@ checksum = "4614a76b2a8be0058caa9dbbaf66d988527d86d003c11a94fbd335d7661edcef"
 dependencies = [
  "autocfg",
 ]
-
-[[package]]
-name = "smallvec"
-version = "1.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fd0db749597d91ff862fd1d55ea87f7855a744a8425a64695b6fca237d1dad1"
 
 [[package]]
 name = "socket2"
@@ -1974,9 +1978,9 @@ checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
 
 [[package]]
 name = "syn"
-version = "1.0.99"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58dbef6ec655055e20b86b15a8cc6d439cca19b667537ac6a1369572d151ab13"
+checksum = "a864042229133ada95abf3b54fdc62ef5ccabe9515b64717bcb9a1919e59445d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2075,9 +2079,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.14"
+version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c3f9a28b618c3a6b9251b6908e9c99e04b9e5c02e6581ccbb67d59c34ef7f9b"
+checksum = "d634a985c4d4238ec39cacaed2e7ae552fbd3c476b552c1deac3021b7d7eaf0c"
 dependencies = [
  "itoa",
  "libc",
@@ -2119,23 +2123,9 @@ dependencies = [
  "memchr",
  "mio",
  "num_cpus",
- "parking_lot",
  "pin-project-lite",
- "signal-hook-registry",
  "socket2",
- "tokio-macros",
  "winapi",
-]
-
-[[package]]
-name = "tokio-macros"
-version = "1.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9724f9a975fb987ef7a3cd9be0350edcbe130698af5b8f7a631e23d42d052484"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]
@@ -2180,9 +2170,9 @@ checksum = "b6bc1c9ce2b5135ac7f93c72918fc37feb872bdc6a5533a8b85eb4b86bfdae52"
 
 [[package]]
 name = "tracing"
-version = "0.1.36"
+version = "0.1.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fce9567bd60a67d08a16488756721ba392f24f29006402881e43b19aac64307"
+checksum = "8ce8c33a8d48bd45d624a6e523445fd21ec13d3653cd51f681abf67418f54eb8"
 dependencies = [
  "cfg-if",
  "pin-project-lite",
@@ -2191,9 +2181,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.29"
+version = "0.1.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5aeea4303076558a00714b823f9ad67d58a3bbda1df83d8827d21193156e22f7"
+checksum = "24eb03ba0eab1fd845050058ce5e616558e8f8d8fca633e6b163fe25c797213a"
 dependencies = [
  "once_cell",
 ]
@@ -2218,15 +2208,15 @@ checksum = "099b7128301d285f79ddd55b9a83d5e6b9e97c92e0ea0daebee7263e932de992"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.4"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcc811dc4066ac62f84f11307873c4850cb653bfa9b1719cee2bd2204a4bc5dd"
+checksum = "6ceab39d59e4c9499d4e5a8ee0e2735b891bb7308ac83dfb4e80cad195c9f6f3"
 
 [[package]]
 name = "unicode-normalization"
-version = "0.1.21"
+version = "0.1.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "854cbdc4f7bc6ae19c820d44abdc3277ac3e1b2b93db20a636825d9322fb60e6"
+checksum = "5c5713f0fc4b5db668a2ac63cdb7bb4469d8c9fed047b1d0292cc7b0ce2ba921"
 dependencies = [
  "tinyvec",
 ]
@@ -2395,9 +2385,9 @@ dependencies = [
 
 [[package]]
 name = "webpki-roots"
-version = "0.22.4"
+version = "0.22.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1c760f0d366a6c24a02ed7816e23e691f5d92291f94d15e836006fd11b04daf"
+checksum = "368bfe657969fb01238bb756d351dcade285e0f6fcbd36dcb23359a5169975be"
 dependencies = [
  "webpki",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,8 +64,8 @@ ignore = "0.4"
 nix = "0.25"
 filetime = "0.2"
 # rest backend
-reqwest = {version = "0.11", default-features = false, features = ["json", "rustls-tls", "stream"] }
-backoff = { version = "0.4", features = ["tokio"] }
+reqwest = {version = "0.11", default-features = false, features = ["json", "rustls-tls", "stream", "blocking"] }
+backoff = "0.4"
 # rclone backend
 semver = "1"
 # cache

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,9 @@ derivative = "2"
 derive-getters = "0.2"
 lazy_static = "1"
 log = "0.4"
+# parallelize
+crossbeam-channel = "0.5"
+rayon = "1"
 # async
 tokio = { version = "1", features = ["full"] }
 futures = "0.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,7 @@ log = "0.4"
 # parallelize
 crossbeam-channel = "0.5"
 rayon = "1"
+pariter = "0.5"
 # async
 tokio = { version = "1", features = ["full"] }
 futures = "0.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,8 +23,6 @@ strip = true
 
 [dependencies]
 # macros
-async-trait = "0.1"
-async-recursion = "1"
 anyhow = "1"
 thiserror = "1"
 derive_more = "0.99"
@@ -36,9 +34,6 @@ log = "0.4"
 crossbeam-channel = "0.5"
 rayon = "1"
 pariter = "0.5"
-# async
-tokio = { version = "1", features = ["full"] }
-futures = "0.3"
 #crypto
 aes256ctr_poly1305aes = "0.1"
 sha2 = "0.10"

--- a/src/archiver/archiver_impl.rs
+++ b/src/archiver/archiver_impl.rs
@@ -122,13 +122,13 @@ impl<BE: DecryptWriteBackend, I: IndexedBackend> Archiver<BE, I> {
             let tree = std::mem::replace(&mut self.tree, Tree::new());
             if self.path == path {
                 // use Node and return
-                let new_parent = self.parent.sub_parent(&node).await?;
+                let new_parent = self.parent.sub_parent(&node)?;
                 let parent = std::mem::replace(&mut self.parent, new_parent);
                 self.stack.push((node, tree, parent));
                 return Ok(());
             } else {
                 let node = Node::new_node(p, NodeType::Dir, Metadata::default());
-                let new_parent = self.parent.sub_parent(&node).await?;
+                let new_parent = self.parent.sub_parent(&node)?;
                 let parent = std::mem::replace(&mut self.parent, new_parent);
                 self.stack.push((node, tree, parent));
             };
@@ -294,7 +294,7 @@ impl<BE: DecryptWriteBackend, I: IndexedBackend> Archiver<BE, I> {
         self.tree_packer.finalize().await?;
         {
             let indexer = self.indexer.write().await;
-            indexer.finalize().await?;
+            indexer.finalize()?;
         }
         let end_time = Local::now();
         self.summary.backup_duration = (end_time - self.summary.backup_start)
@@ -303,7 +303,7 @@ impl<BE: DecryptWriteBackend, I: IndexedBackend> Archiver<BE, I> {
         self.summary.total_duration = (end_time - self.snap.time).to_std()?.as_secs_f64();
         self.summary.backup_end = end_time;
         self.snap.summary = Some(self.summary);
-        let id = self.be.save_file(&self.snap).await?;
+        let id = self.be.save_file(&self.snap)?;
         self.snap.id = id;
 
         Ok(self.snap)

--- a/src/archiver/archiver_impl.rs
+++ b/src/archiver/archiver_impl.rs
@@ -5,10 +5,9 @@ use std::path::{Path, PathBuf};
 use anyhow::{anyhow, Result};
 use bytesize::ByteSize;
 use chrono::Local;
-use futures::{stream::FuturesOrdered, StreamExt};
 use indicatif::ProgressBar;
 use log::*;
-use tokio::spawn;
+use pariter::IteratorExt;
 
 use crate::backend::DecryptWriteBackend;
 use crate::blob::{BlobType, Metadata, Node, NodeType, Packer, Tree};
@@ -105,7 +104,7 @@ impl<BE: DecryptWriteBackend, I: IndexedBackend> Archiver<BE, I> {
         self.summary.total_dirsize_processed += size;
     }
 
-    pub async fn add_entry(&mut self, path: &Path, node: Node, p: ProgressBar) -> Result<()> {
+    pub fn add_entry(&mut self, path: &Path, node: Node, p: ProgressBar) -> Result<()> {
         let basepath = if node.is_dir() {
             path
         } else {
@@ -113,7 +112,7 @@ impl<BE: DecryptWriteBackend, I: IndexedBackend> Archiver<BE, I> {
                 .ok_or_else(|| anyhow!("file path should have a parent!"))?
         };
 
-        self.finish_trees(basepath).await?;
+        self.finish_trees(basepath)?;
 
         let missing_dirs = basepath.strip_prefix(&self.path)?;
         for p in missing_dirs.iter() {
@@ -136,7 +135,7 @@ impl<BE: DecryptWriteBackend, I: IndexedBackend> Archiver<BE, I> {
 
         match node.node_type() {
             NodeType::File => {
-                self.backup_file(path, node, p).await?;
+                self.backup_file(path, node, p)?;
             }
             NodeType::Dir => {}          // is already handled, see above
             _ => self.add_file(node, 0), // all other cases: just save the given node
@@ -144,7 +143,7 @@ impl<BE: DecryptWriteBackend, I: IndexedBackend> Archiver<BE, I> {
         Ok(())
     }
 
-    pub async fn finish_trees(&mut self, path: &Path) -> Result<()> {
+    pub fn finish_trees(&mut self, path: &Path) -> Result<()> {
         while !path.starts_with(&self.path) {
             // save tree and go back to parent dir
             let (chunk, id) = self.tree.serialize()?;
@@ -158,13 +157,13 @@ impl<BE: DecryptWriteBackend, I: IndexedBackend> Archiver<BE, I> {
             self.tree = tree;
             self.parent = parent;
 
-            self.backup_tree(node, chunk).await?;
+            self.backup_tree(node, chunk)?;
             self.path.pop();
         }
         Ok(())
     }
 
-    pub async fn backup_tree(&mut self, node: Node, chunk: Vec<u8>) -> Result<()> {
+    pub fn backup_tree(&mut self, node: Node, chunk: Vec<u8>) -> Result<()> {
         let dirsize = chunk.len() as u64;
         let dirsize_bytes = ByteSize(dirsize).to_string_as(true);
         let id = node.subtree().unwrap();
@@ -203,7 +202,7 @@ impl<BE: DecryptWriteBackend, I: IndexedBackend> Archiver<BE, I> {
         Ok(())
     }
 
-    pub async fn backup_file(&mut self, path: &Path, node: Node, p: ProgressBar) -> Result<()> {
+    pub fn backup_file(&mut self, path: &Path, node: Node, p: ProgressBar) -> Result<()> {
         if let ParentResult::Matched(p_node) = self.parent.is_parent(&node) {
             if p_node.content().iter().all(|id| self.index.has_data(id)) {
                 let size = *p_node.meta().size();
@@ -220,37 +219,37 @@ impl<BE: DecryptWriteBackend, I: IndexedBackend> Archiver<BE, I> {
             }
         }
         let f = File::open(path)?;
-        self.backup_reader(f, node, p).await
+        self.backup_reader(f, node, p)
     }
 
-    pub async fn backup_reader(&mut self, r: impl Read, node: Node, p: ProgressBar) -> Result<()> {
+    pub fn backup_reader(
+        &mut self,
+        r: impl Read + 'static,
+        node: Node,
+        p: ProgressBar,
+    ) -> Result<()> {
         let chunk_iter = ChunkIter::new(r, *node.meta().size() as usize, &self.poly);
         let mut content = Vec::new();
         let mut filesize: u64 = 0;
 
-        let mut queue = FuturesOrdered::new();
-
-        for chunk in chunk_iter {
-            let chunk = chunk?;
-            let size = chunk.len() as u64;
-            filesize += size;
-
-            queue.push_back(spawn(async move {
+        chunk_iter
+            .into_iter()
+            // TODO: This parallelization works pretty well for big files. For small files this produces a lot of
+            // unneccessary overhead. Maybe use a parallel hashing actor?
+            .parallel_map(|chunk| {
+                let chunk = chunk?;
                 let id = hash(&chunk);
-                (id, chunk, size)
-            }));
+                Ok((chunk, id))
+            })
+            .try_for_each(|data: Result<_>| -> Result<_> {
+                let (chunk, id) = data?;
+                let size = chunk.len() as u64;
+                filesize += size;
 
-            if queue.len() > 8 {
-                let (id, chunk, size) = queue.next().await.unwrap()?;
-                self.process_data_junk(id, &chunk, size, &p)?;
                 content.push(id);
-            }
-        }
-
-        while let Some(Ok((id, chunk, size))) = queue.next().await {
-            self.process_data_junk(id, &chunk, size, &p)?;
-            content.push(id);
-        }
+                self.process_data_junk(id, &chunk, size, &p)?;
+                Ok(())
+            })?;
 
         let mut node = node;
         node.set_content(content);
@@ -281,8 +280,8 @@ impl<BE: DecryptWriteBackend, I: IndexedBackend> Archiver<BE, I> {
         Ok(())
     }
 
-    pub async fn finalize_snapshot(mut self) -> Result<SnapshotFile> {
-        self.finish_trees(&PathBuf::from("/")).await?;
+    pub fn finalize_snapshot(mut self) -> Result<SnapshotFile> {
+        self.finish_trees(&PathBuf::from("/"))?;
 
         let (chunk, id) = self.tree.serialize()?;
         if !self.index.has_tree(&id) {

--- a/src/archiver/parent.rs
+++ b/src/archiver/parent.rs
@@ -21,12 +21,12 @@ pub enum ParentResult<T> {
 }
 
 impl<BE: IndexedBackend> Parent<BE> {
-    pub async fn new(be: &BE, tree_id: Option<Id>, ignore_ctime: bool, ignore_inode: bool) -> Self {
+    pub fn new(be: &BE, tree_id: Option<Id>, ignore_ctime: bool, ignore_inode: bool) -> Self {
         // if tree_id is given, load tree from backend. Turn errors into None.
         // TODO: print warning when loading failed
         let tree = match tree_id {
             None => None,
-            Some(id) => Tree::from_backend(be, id).await.ok(),
+            Some(id) => Tree::from_backend(be, id).ok(),
         };
         Self {
             tree,
@@ -85,14 +85,14 @@ impl<BE: IndexedBackend> Parent<BE> {
         }
     }
 
-    pub async fn sub_parent(&mut self, node: &Node) -> Result<Self> {
+    pub fn sub_parent(&mut self, node: &Node) -> Result<Self> {
         let tree = match self.p_node(node) {
             None => None,
             Some(p_node) => {
                 if p_node.node_type() == node.node_type() {
                     // TODO: print warning when loading failed
                     let tree = p_node.subtree.unwrap();
-                    Some(Tree::from_backend(&self.be, tree).await.ok()).flatten()
+                    Some(Tree::from_backend(&self.be, tree).ok()).flatten()
                 } else {
                     None
                 }

--- a/src/backend/choose.rs
+++ b/src/backend/choose.rs
@@ -1,5 +1,4 @@
 use anyhow::{bail, Result};
-use async_trait::async_trait;
 use bytes::Bytes;
 
 use super::{FileType, Id, ReadBackend, WriteBackend};
@@ -26,7 +25,6 @@ impl ChooseBackend {
     }
 }
 
-#[async_trait]
 impl ReadBackend for ChooseBackend {
     fn location(&self) -> &str {
         match self {
@@ -44,23 +42,23 @@ impl ReadBackend for ChooseBackend {
         }
     }
 
-    async fn list_with_size(&self, tpe: FileType) -> Result<Vec<(Id, u32)>> {
+    fn list_with_size(&self, tpe: FileType) -> Result<Vec<(Id, u32)>> {
         match self {
-            Local(local) => local.list_with_size(tpe).await,
-            Rest(rest) => rest.list_with_size(tpe).await,
-            Rclone(rclone) => rclone.list_with_size(tpe).await,
+            Local(local) => local.list_with_size(tpe),
+            Rest(rest) => rest.list_with_size(tpe),
+            Rclone(rclone) => rclone.list_with_size(tpe),
         }
     }
 
-    async fn read_full(&self, tpe: FileType, id: &Id) -> Result<Bytes> {
+    fn read_full(&self, tpe: FileType, id: &Id) -> Result<Bytes> {
         match self {
-            Local(local) => local.read_full(tpe, id).await,
-            Rest(rest) => rest.read_full(tpe, id).await,
-            Rclone(rclone) => rclone.read_full(tpe, id).await,
+            Local(local) => local.read_full(tpe, id),
+            Rest(rest) => rest.read_full(tpe, id),
+            Rclone(rclone) => rclone.read_full(tpe, id),
         }
     }
 
-    async fn read_partial(
+    fn read_partial(
         &self,
         tpe: FileType,
         id: &Id,
@@ -69,40 +67,35 @@ impl ReadBackend for ChooseBackend {
         length: u32,
     ) -> Result<Bytes> {
         match self {
-            Local(local) => local.read_partial(tpe, id, cacheable, offset, length).await,
-            Rest(rest) => rest.read_partial(tpe, id, cacheable, offset, length).await,
-            Rclone(rclone) => {
-                rclone
-                    .read_partial(tpe, id, cacheable, offset, length)
-                    .await
-            }
+            Local(local) => local.read_partial(tpe, id, cacheable, offset, length),
+            Rest(rest) => rest.read_partial(tpe, id, cacheable, offset, length),
+            Rclone(rclone) => rclone.read_partial(tpe, id, cacheable, offset, length),
         }
     }
 }
 
-#[async_trait]
 impl WriteBackend for ChooseBackend {
-    async fn create(&self) -> Result<()> {
+    fn create(&self) -> Result<()> {
         match self {
-            Local(local) => local.create().await,
-            Rest(rest) => rest.create().await,
-            Rclone(rclone) => rclone.create().await,
+            Local(local) => local.create(),
+            Rest(rest) => rest.create(),
+            Rclone(rclone) => rclone.create(),
         }
     }
 
-    async fn write_bytes(&self, tpe: FileType, id: &Id, cacheable: bool, buf: Bytes) -> Result<()> {
+    fn write_bytes(&self, tpe: FileType, id: &Id, cacheable: bool, buf: Bytes) -> Result<()> {
         match self {
-            Local(local) => local.write_bytes(tpe, id, cacheable, buf).await,
-            Rest(rest) => rest.write_bytes(tpe, id, cacheable, buf).await,
-            Rclone(rclone) => rclone.write_bytes(tpe, id, cacheable, buf).await,
+            Local(local) => local.write_bytes(tpe, id, cacheable, buf),
+            Rest(rest) => rest.write_bytes(tpe, id, cacheable, buf),
+            Rclone(rclone) => rclone.write_bytes(tpe, id, cacheable, buf),
         }
     }
 
-    async fn remove(&self, tpe: FileType, id: &Id, cacheable: bool) -> Result<()> {
+    fn remove(&self, tpe: FileType, id: &Id, cacheable: bool) -> Result<()> {
         match self {
-            Local(local) => local.remove(tpe, id, cacheable).await,
-            Rest(rest) => rest.remove(tpe, id, cacheable).await,
-            Rclone(rclone) => rclone.remove(tpe, id, cacheable).await,
+            Local(local) => local.remove(tpe, id, cacheable),
+            Rest(rest) => rest.remove(tpe, id, cacheable),
+            Rclone(rclone) => rclone.remove(tpe, id, cacheable),
         }
     }
 }

--- a/src/backend/dry_run.rs
+++ b/src/backend/dry_run.rs
@@ -1,5 +1,4 @@
 use anyhow::Result;
-use async_trait::async_trait;
 use bytes::Bytes;
 
 use super::{
@@ -19,14 +18,12 @@ impl<BE: DecryptFullBackend> DryRunBackend<BE> {
     }
 }
 
-#[async_trait]
 impl<BE: DecryptFullBackend> DecryptReadBackend for DryRunBackend<BE> {
     fn decrypt(&self, data: &[u8]) -> Result<Vec<u8>> {
         self.be.decrypt(data)
     }
 }
 
-#[async_trait]
 impl<BE: DecryptFullBackend> ReadBackend for DryRunBackend<BE> {
     fn location(&self) -> &str {
         self.be.location()
@@ -36,15 +33,15 @@ impl<BE: DecryptFullBackend> ReadBackend for DryRunBackend<BE> {
         self.be.set_option(option, value)
     }
 
-    async fn list_with_size(&self, tpe: FileType) -> Result<Vec<(Id, u32)>> {
-        self.be.list_with_size(tpe).await
+    fn list_with_size(&self, tpe: FileType) -> Result<Vec<(Id, u32)>> {
+        self.be.list_with_size(tpe)
     }
 
-    async fn read_full(&self, tpe: FileType, id: &Id) -> Result<Bytes> {
-        self.be.read_full(tpe, id).await
+    fn read_full(&self, tpe: FileType, id: &Id) -> Result<Bytes> {
+        self.be.read_full(tpe, id)
     }
 
-    async fn read_partial(
+    fn read_partial(
         &self,
         tpe: FileType,
         id: &Id,
@@ -52,13 +49,10 @@ impl<BE: DecryptFullBackend> ReadBackend for DryRunBackend<BE> {
         offset: u32,
         length: u32,
     ) -> Result<Bytes> {
-        self.be
-            .read_partial(tpe, id, cacheable, offset, length)
-            .await
+        self.be.read_partial(tpe, id, cacheable, offset, length)
     }
 }
 
-#[async_trait]
 impl<BE: DecryptFullBackend> DecryptWriteBackend for DryRunBackend<BE> {
     type Key = <BE as DecryptWriteBackend>::Key;
 
@@ -66,10 +60,10 @@ impl<BE: DecryptFullBackend> DecryptWriteBackend for DryRunBackend<BE> {
         self.be.key()
     }
 
-    async fn hash_write_full(&self, tpe: FileType, data: &[u8]) -> Result<Id> {
+    fn hash_write_full(&self, tpe: FileType, data: &[u8]) -> Result<Id> {
         match self.dry_run {
             true => Ok(Id::default()),
-            false => self.be.hash_write_full(tpe, data).await,
+            false => self.be.hash_write_full(tpe, data),
         }
     }
 
@@ -81,26 +75,25 @@ impl<BE: DecryptFullBackend> DecryptWriteBackend for DryRunBackend<BE> {
     }
 }
 
-#[async_trait]
 impl<BE: DecryptFullBackend> WriteBackend for DryRunBackend<BE> {
-    async fn create(&self) -> Result<()> {
+    fn create(&self) -> Result<()> {
         match self.dry_run {
             true => Ok(()),
-            false => self.be.create().await,
+            false => self.be.create(),
         }
     }
 
-    async fn write_bytes(&self, tpe: FileType, id: &Id, cacheable: bool, buf: Bytes) -> Result<()> {
+    fn write_bytes(&self, tpe: FileType, id: &Id, cacheable: bool, buf: Bytes) -> Result<()> {
         match self.dry_run {
             true => Ok(()),
-            false => self.be.write_bytes(tpe, id, cacheable, buf).await,
+            false => self.be.write_bytes(tpe, id, cacheable, buf),
         }
     }
 
-    async fn remove(&self, tpe: FileType, id: &Id, cacheable: bool) -> Result<()> {
+    fn remove(&self, tpe: FileType, id: &Id, cacheable: bool) -> Result<()> {
         match self.dry_run {
             true => Ok(()),
-            false => self.be.remove(tpe, id, cacheable).await,
+            false => self.be.remove(tpe, id, cacheable),
         }
     }
 }

--- a/src/blob/packer.rs
+++ b/src/blob/packer.rs
@@ -258,9 +258,9 @@ impl<BE: DecryptWriteBackend> FileWriter<BE> {
         let indexer = self.indexer.clone();
         let cacheable = self.cacheable;
         let new_future = spawn(async move {
-            be.write_bytes(FileType::Pack, &id, cacheable, file).await?;
+            be.write_bytes(FileType::Pack, &id, cacheable, file)?;
             index.time = Some(Local::now());
-            indexer.write().await.add(index).await?;
+            indexer.write().await.add(index)?;
             Ok(())
         });
 
@@ -302,16 +302,13 @@ impl<BE: DecryptFullBackend> Repacker<BE> {
     }
 
     pub async fn add_fast(&mut self, pack_id: &Id, blob: &IndexBlob) -> Result<()> {
-        let data = self
-            .be
-            .read_partial(
-                FileType::Pack,
-                pack_id,
-                blob.tpe.is_cacheable(),
-                blob.offset,
-                blob.length,
-            )
-            .await?;
+        let data = self.be.read_partial(
+            FileType::Pack,
+            pack_id,
+            blob.tpe.is_cacheable(),
+            blob.offset,
+            blob.length,
+        )?;
         self.packer
             .add_raw(&data, &blob.id, blob.uncompressed_length, self.size_limit)
             .await?;
@@ -319,17 +316,14 @@ impl<BE: DecryptFullBackend> Repacker<BE> {
     }
 
     pub async fn add(&mut self, pack_id: &Id, blob: &IndexBlob) -> Result<()> {
-        let data = self
-            .be
-            .read_encrypted_partial(
-                FileType::Pack,
-                pack_id,
-                blob.tpe.is_cacheable(),
-                blob.offset,
-                blob.length,
-                blob.uncompressed_length,
-            )
-            .await?;
+        let data = self.be.read_encrypted_partial(
+            FileType::Pack,
+            pack_id,
+            blob.tpe.is_cacheable(),
+            blob.offset,
+            blob.length,
+            blob.uncompressed_length,
+        )?;
         self.packer
             .add_with_sizelimit(&data, &blob.id, self.size_limit)
             .await?;

--- a/src/commands/backup.rs
+++ b/src/commands/backup.rs
@@ -201,21 +201,19 @@ pub(super) async fn execute(
         let snap = if backup_stdin {
             let mut archiver = Archiver::new(be, index, &config, parent, snap)?;
             let p = progress_bytes("starting backup from stdin...");
-            archiver
-                .backup_reader(
-                    std::io::stdin(),
-                    Node::new(
-                        backup_path_str,
-                        NodeType::File,
-                        Metadata::default(),
-                        None,
-                        None,
-                    ),
-                    p.clone(),
-                )
-                .await?;
+            archiver.backup_reader(
+                std::io::stdin(),
+                Node::new(
+                    backup_path_str,
+                    NodeType::File,
+                    Metadata::default(),
+                    None,
+                    None,
+                ),
+                p.clone(),
+            )?;
 
-            let snap = archiver.finalize_snapshot().await?;
+            let snap = archiver.finalize_snapshot()?;
             p.finish_with_message("done");
             snap
         } else {
@@ -234,13 +232,13 @@ pub(super) async fn execute(
                         warn!("ignoring error {}\n", e)
                     }
                     Ok((path, node)) => {
-                        if let Err(e) = archiver.add_entry(&path, node, p.clone()).await {
+                        if let Err(e) = archiver.add_entry(&path, node, p.clone()) {
                             warn!("ignoring error {} for {:?}\n", e, path);
                         }
                     }
                 }
             }
-            let snap = archiver.finalize_snapshot().await?;
+            let snap = archiver.finalize_snapshot()?;
             p.finish_with_message("done");
             snap
         };

--- a/src/commands/backup.rs
+++ b/src/commands/backup.rs
@@ -91,7 +91,7 @@ pub(super) struct Opts {
     source: String,
 }
 
-pub(super) async fn execute(
+pub(super) fn execute(
     be: &impl DecryptFullBackend,
     opts: Opts,
     config: ConfigFile,

--- a/src/commands/backup.rs
+++ b/src/commands/backup.rs
@@ -163,7 +163,7 @@ pub(super) async fn execute(
             )
             .await
             .ok(),
-            (false, false, Some(parent)) => SnapshotFile::from_id(&be, &parent).await.ok(),
+            (false, false, Some(parent)) => SnapshotFile::from_id(&be, &parent).ok(),
         };
 
         let parent_tree = match &parent {
@@ -197,7 +197,7 @@ pub(super) async fn execute(
         snap.paths.add(backup_path_str.clone());
         snap.set_tags(opts.tag.clone());
 
-        let parent = Parent::new(&index, parent_tree, opts.ignore_ctime, opts.ignore_inode).await;
+        let parent = Parent::new(&index, parent_tree, opts.ignore_ctime, opts.ignore_inode);
 
         let snap = if backup_stdin {
             let mut archiver = Archiver::new(be, index, &config, parent, snap)?;

--- a/src/commands/backup.rs
+++ b/src/commands/backup.rs
@@ -116,7 +116,7 @@ pub(super) async fn execute(
         }
     };
 
-    let index = IndexBackend::only_full_trees(&be.clone(), progress_counter("")).await?;
+    let index = IndexBackend::only_full_trees(&be.clone(), progress_counter(""))?;
 
     for source in sources {
         let mut opts = opts.clone();
@@ -161,7 +161,6 @@ pub(super) async fn execute(
                 |snap| snap.hostname == hostname && snap.paths.contains(&backup_path_str),
                 progress_counter(""),
             )
-            .await
             .ok(),
             (false, false, Some(parent)) => SnapshotFile::from_id(&be, &parent).ok(),
         };

--- a/src/commands/cat.rs
+++ b/src/commands/cat.rs
@@ -46,16 +46,16 @@ struct TreeOpts {
     snap: String,
 }
 
-pub(super) async fn execute(be: &impl DecryptReadBackend, opts: Opts) -> Result<()> {
+pub(super) fn execute(be: &impl DecryptReadBackend, opts: Opts) -> Result<()> {
     match opts.command {
         Command::Config => cat_file(be, FileType::Config, IdOpt::default()),
         Command::Index(opt) => cat_file(be, FileType::Index, opt),
         Command::Snapshot(opt) => cat_file(be, FileType::Snapshot, opt),
         // special treatment for catingg blobs: read the index and use it to locate the blob
-        Command::TreeBlob(opt) => cat_blob(be, BlobType::Tree, opt).await,
-        Command::DataBlob(opt) => cat_blob(be, BlobType::Data, opt).await,
+        Command::TreeBlob(opt) => cat_blob(be, BlobType::Tree, opt),
+        Command::DataBlob(opt) => cat_blob(be, BlobType::Data, opt),
         // special treatment for cating a tree within a snapshot
-        Command::Tree(opts) => cat_tree(be, opts).await,
+        Command::Tree(opts) => cat_tree(be, opts),
     }
 }
 
@@ -67,20 +67,18 @@ fn cat_file(be: &impl DecryptReadBackend, tpe: FileType, opt: IdOpt) -> Result<(
     Ok(())
 }
 
-async fn cat_blob(be: &impl DecryptReadBackend, tpe: BlobType, opt: IdOpt) -> Result<()> {
+fn cat_blob(be: &impl DecryptReadBackend, tpe: BlobType, opt: IdOpt) -> Result<()> {
     let id = Id::from_hex(&opt.id)?;
-    let data = IndexBackend::new(be, ProgressBar::hidden())
-        .await?
-        .blob_from_backend(&tpe, &id)?;
+    let data = IndexBackend::new(be, ProgressBar::hidden())?.blob_from_backend(&tpe, &id)?;
     print!("{}", String::from_utf8(data.to_vec())?);
 
     Ok(())
 }
 
-async fn cat_tree(be: &impl DecryptReadBackend, opts: TreeOpts) -> Result<()> {
+fn cat_tree(be: &impl DecryptReadBackend, opts: TreeOpts) -> Result<()> {
     let (id, path) = opts.snap.split_once(':').unwrap_or((&opts.snap, ""));
-    let snap = SnapshotFile::from_str(be, id, |_| true, progress_counter("")).await?;
-    let index = IndexBackend::new(be, progress_counter("")).await?;
+    let snap = SnapshotFile::from_str(be, id, |_| true, progress_counter(""))?;
+    let index = IndexBackend::new(be, progress_counter(""))?;
     let id = Tree::subtree_id(&index, snap.tree, Path::new(path))?;
     let data = index.blob_from_backend(&BlobType::Tree, &id)?;
     println!("{}", String::from_utf8(data.to_vec())?);

--- a/src/commands/config.rs
+++ b/src/commands/config.rs
@@ -11,7 +11,7 @@ pub(super) struct Opts {
     config_opts: ConfigOpts,
 }
 
-pub(super) async fn execute(
+pub(super) fn execute(
     be: &impl DecryptFullBackend,
     hot_be: &Option<impl WriteBackend>,
     opts: Opts,
@@ -22,13 +22,13 @@ pub(super) async fn execute(
     if new_config != config {
         new_config.is_hot = None;
         // for hot/cold backend, this only saves the config to the cold repo.
-        be.save_file(&new_config).await?;
+        be.save_file(&new_config)?;
 
         if let Some(hot_be) = hot_be {
             // save config to hot repo
             let dbe = DecryptBackend::new(hot_be, be.key().clone());
             new_config.is_hot = Some(true);
-            dbe.save_file(&new_config).await?;
+            dbe.save_file(&new_config)?;
         }
 
         println!("saved new config");

--- a/src/commands/diff.rs
+++ b/src/commands/diff.rs
@@ -28,12 +28,12 @@ pub(super) async fn execute(be: &(impl DecryptReadBackend + Unpin), opts: Opts) 
 
     let p = progress_spinner("getting snapshots...");
     p.finish();
-    let snaps = SnapshotFile::from_ids(be, &[id1.to_string(), id2.to_string()]).await?;
+    let snaps = SnapshotFile::from_ids(be, &[id1.to_string(), id2.to_string()])?;
 
     let snap1 = &snaps[0];
     let snap2 = &snaps[1];
 
-    let index = IndexBackend::new(be, progress_counter("")).await?;
+    let index = IndexBackend::new(be, progress_counter(""))?;
     let id1 = Tree::subtree_id(&index, snap1.tree, Path::new(path1))?;
     let id2 = Tree::subtree_id(&index, snap2.tree, Path::new(path2))?;
 

--- a/src/commands/diff.rs
+++ b/src/commands/diff.rs
@@ -34,11 +34,11 @@ pub(super) async fn execute(be: &(impl DecryptReadBackend + Unpin), opts: Opts) 
     let snap2 = &snaps[1];
 
     let index = IndexBackend::new(be, progress_counter("")).await?;
-    let id1 = Tree::subtree_id(&index, snap1.tree, Path::new(path1)).await?;
-    let id2 = Tree::subtree_id(&index, snap2.tree, Path::new(path2)).await?;
+    let id1 = Tree::subtree_id(&index, snap1.tree, Path::new(path1))?;
+    let id2 = Tree::subtree_id(&index, snap2.tree, Path::new(path2))?;
 
-    let mut tree_streamer1 = NodeStreamer::new(index.clone(), id1).await?;
-    let mut tree_streamer2 = NodeStreamer::new(index, id2).await?;
+    let mut tree_streamer1 = NodeStreamer::new(index.clone(), id1)?;
+    let mut tree_streamer2 = NodeStreamer::new(index, id2)?;
 
     let mut item1 = tree_streamer1.next().await.transpose()?;
     let mut item2 = tree_streamer2.next().await.transpose()?;

--- a/src/commands/forget.rs
+++ b/src/commands/forget.rs
@@ -74,10 +74,10 @@ pub(super) async fn execute(
         .unwrap_or_else(|| SnapshotGroupCriterion::from_str("host,paths").unwrap());
 
     let groups = match opts.ids.is_empty() {
-        true => SnapshotFile::group_from_backend(be, &opts.config.filter, &group_by).await?,
+        true => SnapshotFile::group_from_backend(be, &opts.config.filter, &group_by)?,
         false => vec![(
             SnapshotGroup::default(),
-            SnapshotFile::from_ids(be, &opts.ids).await?,
+            SnapshotFile::from_ids(be, &opts.ids)?,
         )],
     };
     let mut forget_snaps = Vec::new();
@@ -146,8 +146,7 @@ pub(super) async fn execute(
         ),
         (false, false) => {
             let p = progress_counter("removing snapshots...");
-            be.delete_list(FileType::Snapshot, true, forget_snaps.clone(), p)
-                .await?;
+            be.delete_list(FileType::Snapshot, true, forget_snaps.clone(), p)?;
         }
     }
 

--- a/src/commands/forget.rs
+++ b/src/commands/forget.rs
@@ -55,7 +55,7 @@ struct ConfigOpts {
     keep: KeepOptions,
 }
 
-pub(super) async fn execute(
+pub(super) fn execute(
     be: &(impl DecryptFullBackend + Unpin),
     cache: Option<Cache>,
     mut opts: Opts,
@@ -151,7 +151,7 @@ pub(super) async fn execute(
     }
 
     if opts.prune {
-        prune::execute(be, cache, opts.prune_opts, config, forget_snaps).await?;
+        prune::execute(be, cache, opts.prune_opts, config, forget_snaps)?;
     }
 
     Ok(())

--- a/src/commands/helpers.rs
+++ b/src/commands/helpers.rs
@@ -23,16 +23,15 @@ pub fn bytes(b: u64) -> String {
     ByteSize(b).to_string_as(true)
 }
 
-pub async fn get_key(be: &impl ReadBackend, password: Option<String>) -> Result<Key> {
+pub fn get_key(be: &impl ReadBackend, password: Option<String>) -> Result<Key> {
     for _ in 0..MAX_PASSWORD_RETRIES {
         match &password {
             // if password is given, directly return the result of find_key_in_backend and don't retry
-            Some(pass) => return find_key_in_backend(be, pass, None).await,
+            Some(pass) => return find_key_in_backend(be, pass, None),
             None => {
                 // TODO: Differentiate between wrong password and other error!
                 if let Ok(key) =
                     find_key_in_backend(be, &prompt_password("enter repository password: ")?, None)
-                        .await
                 {
                     return Ok(key);
                 }
@@ -125,7 +124,7 @@ pub async fn warm_up(
         let be = be.clone();
         stream.push(spawn(async move {
             // ignore errors as they are expected from the warm-up
-            _ = be.read_partial(FileType::Pack, &pack, false, 0, 1).await;
+            _ = be.read_partial(FileType::Pack, &pack, false, 0, 1);
             p.inc(1);
         }))
     }

--- a/src/commands/init.rs
+++ b/src/commands/init.rs
@@ -20,7 +20,7 @@ pub(super) struct Opts {
     config_opts: ConfigOpts,
 }
 
-pub(super) async fn execute(
+pub(super) fn execute(
     be: &impl WriteBackend,
     hot_be: &Option<impl WriteBackend>,
     opts: Opts,
@@ -59,24 +59,23 @@ pub(super) async fn execute(
     )?;
     let data: Bytes = serde_json::to_vec(&keyfile)?.into();
     let id = hash(&data);
-    be.create().await?;
-    be.write_bytes(FileType::Key, &id, false, data.clone())
-        .await?;
+    be.create()?;
+    be.write_bytes(FileType::Key, &id, false, data.clone())?;
 
     if let Some(hot_be) = hot_be {
-        hot_be.create().await?;
-        hot_be.write_bytes(FileType::Key, &id, false, data).await?;
+        hot_be.create()?;
+        hot_be.write_bytes(FileType::Key, &id, false, data)?;
     }
     println!("key {} successfully added.", id);
 
     // save config
     let dbe = DecryptBackend::new(be, key.clone());
-    dbe.save_file(&config).await?;
+    dbe.save_file(&config)?;
 
     if let Some(hot_be) = hot_be {
         let dbe = DecryptBackend::new(hot_be, key);
         config.is_hot = Some(true);
-        dbe.save_file(&config).await?;
+        dbe.save_file(&config)?;
     }
     println!("repository {} successfully created.", repo_id);
 

--- a/src/commands/key.rs
+++ b/src/commands/key.rs
@@ -47,13 +47,13 @@ pub(crate) struct KeyOpts {
     pub(crate) with_created: bool,
 }
 
-pub(super) async fn execute(be: &impl WriteBackend, key: Key, opts: Opts) -> Result<()> {
+pub(super) fn execute(be: &impl WriteBackend, key: Key, opts: Opts) -> Result<()> {
     match opts.command {
-        Command::Add(opt) => add_key(be, key, opt).await,
+        Command::Add(opt) => add_key(be, key, opt),
     }
 }
 
-async fn add_key(be: &impl WriteBackend, key: Key, opts: AddOpts) -> Result<()> {
+fn add_key(be: &impl WriteBackend, key: Key, opts: AddOpts) -> Result<()> {
     let pass = match opts.new_password_file {
         Some(file) => {
             let mut file = BufReader::new(File::open(file)?);
@@ -65,8 +65,7 @@ async fn add_key(be: &impl WriteBackend, key: Key, opts: AddOpts) -> Result<()> 
     let keyfile = KeyFile::generate(key, &pass, ko.hostname, ko.username, ko.with_created)?;
     let data = serde_json::to_vec(&keyfile)?;
     let id = hash(&data);
-    be.write_bytes(FileType::Key, &id, false, data.into())
-        .await?;
+    be.write_bytes(FileType::Key, &id, false, data.into())?;
 
     println!("key {} successfully added.", id);
     Ok(())

--- a/src/commands/list.rs
+++ b/src/commands/list.rs
@@ -34,7 +34,7 @@ pub(super) async fn execute(be: &impl DecryptReadBackend, opts: Opts) -> Result<
         t => bail!("invalid type: {}", t),
     };
 
-    for id in be.list(tpe).await? {
+    for id in be.list(tpe)? {
         println!("{}", id.to_hex());
     }
 

--- a/src/commands/ls.rs
+++ b/src/commands/ls.rs
@@ -18,8 +18,8 @@ pub(super) struct Opts {
 
 pub(super) async fn execute(be: &(impl DecryptReadBackend + Unpin), opts: Opts) -> Result<()> {
     let (id, path) = opts.snap.split_once(':').unwrap_or((&opts.snap, ""));
-    let snap = SnapshotFile::from_str(be, id, |_| true, progress_counter("")).await?;
-    let index = IndexBackend::new(be, progress_counter("")).await?;
+    let snap = SnapshotFile::from_str(be, id, |_| true, progress_counter(""))?;
+    let index = IndexBackend::new(be, progress_counter(""))?;
     let tree = Tree::subtree_id(&index, snap.tree, Path::new(path))?;
 
     let mut tree_streamer = NodeStreamer::new(index, tree)?;

--- a/src/commands/ls.rs
+++ b/src/commands/ls.rs
@@ -20,9 +20,9 @@ pub(super) async fn execute(be: &(impl DecryptReadBackend + Unpin), opts: Opts) 
     let (id, path) = opts.snap.split_once(':').unwrap_or((&opts.snap, ""));
     let snap = SnapshotFile::from_str(be, id, |_| true, progress_counter("")).await?;
     let index = IndexBackend::new(be, progress_counter("")).await?;
-    let tree = Tree::subtree_id(&index, snap.tree, Path::new(path)).await?;
+    let tree = Tree::subtree_id(&index, snap.tree, Path::new(path))?;
 
-    let mut tree_streamer = NodeStreamer::new(index, tree).await?;
+    let mut tree_streamer = NodeStreamer::new(index, tree)?;
     while let Some(item) = tree_streamer.next().await {
         let (path, _) = item?;
         println!("{:?} ", path);

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -220,7 +220,7 @@ pub async fn execute() -> Result<()> {
     }
 
     if let Command::SelfUpdate(opts) = args.command {
-        self_update::execute(opts).await?;
+        self_update::execute(opts)?;
         return Ok(());
     }
 
@@ -305,17 +305,17 @@ pub async fn execute() -> Result<()> {
     };
 
     match cmd {
-        Command::Backup(opts) => backup::execute(&dbe, opts, config, config_file, command).await?,
+        Command::Backup(opts) => backup::execute(&dbe, opts, config, config_file, command)?,
         Command::Config(opts) => config::execute(&dbe, &be_hot, opts, config)?,
         Command::Cat(opts) => cat::execute(&dbe, opts)?,
-        Command::Check(opts) => check::execute(&dbe, &cache, &be_hot, &be, opts).await?,
+        Command::Check(opts) => check::execute(&dbe, &cache, &be_hot, &be, opts)?,
         Command::Completions(_) => {} // already handled above
-        Command::Diff(opts) => diff::execute(&dbe, opts).await?,
+        Command::Diff(opts) => diff::execute(&dbe, opts)?,
         Command::Forget(opts) => forget::execute(&dbe, cache, opts, config, config_file).await?,
         Command::Init(_) => {} // already handled above
         Command::Key(opts) => key::execute(&dbe, key, opts)?,
         Command::List(opts) => list::execute(&dbe, opts)?,
-        Command::Ls(opts) => ls::execute(&dbe, opts).await?,
+        Command::Ls(opts) => ls::execute(&dbe, opts)?,
         Command::SelfUpdate(_) => {} // already handled above
         Command::Snapshots(opts) => snapshots::execute(&dbe, opts, config_file)?,
         Command::Prune(opts) => prune::execute(&dbe, cache, opts, config, vec![]).await?,

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -311,16 +311,16 @@ pub async fn execute() -> Result<()> {
         Command::Check(opts) => check::execute(&dbe, &cache, &be_hot, &be, opts)?,
         Command::Completions(_) => {} // already handled above
         Command::Diff(opts) => diff::execute(&dbe, opts)?,
-        Command::Forget(opts) => forget::execute(&dbe, cache, opts, config, config_file).await?,
+        Command::Forget(opts) => forget::execute(&dbe, cache, opts, config, config_file)?,
         Command::Init(_) => {} // already handled above
         Command::Key(opts) => key::execute(&dbe, key, opts)?,
         Command::List(opts) => list::execute(&dbe, opts)?,
         Command::Ls(opts) => ls::execute(&dbe, opts)?,
         Command::SelfUpdate(_) => {} // already handled above
         Command::Snapshots(opts) => snapshots::execute(&dbe, opts, config_file)?,
-        Command::Prune(opts) => prune::execute(&dbe, cache, opts, config, vec![]).await?,
-        Command::Restore(opts) => restore::execute(&dbe, opts).await?,
-        Command::Repair(opts) => repair::execute(&dbe, opts, config_file, &config).await?,
+        Command::Prune(opts) => prune::execute(&dbe, cache, opts, config, vec![])?,
+        Command::Restore(opts) => restore::execute(&dbe, opts)?,
+        Command::Repair(opts) => repair::execute(&dbe, opts, config_file, &config)?,
         Command::Repoinfo(opts) => repoinfo::execute(&dbe, &be_hot, opts)?,
         Command::Tag(opts) => tag::execute(&dbe, opts, config_file)?,
     };

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -181,7 +181,7 @@ enum Command {
     Tag(tag::Opts),
 }
 
-pub async fn execute() -> Result<()> {
+pub fn execute() -> Result<()> {
     let command: Vec<_> = std::env::args_os().into_iter().collect();
     let args = Opts::parse_from(&command);
 

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -263,29 +263,27 @@ pub async fn execute() -> Result<()> {
         (None, None, None) => None,
     };
 
-    let config_ids = be.list(FileType::Config).await?;
+    let config_ids = be.list(FileType::Config)?;
 
     let (cmd, key, dbe, cache, be, be_hot, config) = match (args.command, config_ids.len()) {
-        (Command::Init(opts), _) => {
-            return init::execute(&be, &be_hot, opts, password, config_ids).await
-        }
+        (Command::Init(opts), _) => return init::execute(&be, &be_hot, opts, password, config_ids),
         (cmd, 1) => {
             let be = HotColdBackend::new(be, be_hot.clone());
             if let Some(be_hot) = &be_hot {
-                let mut keys = be.list_with_size(FileType::Key).await?;
+                let mut keys = be.list_with_size(FileType::Key)?;
                 keys.sort_unstable_by_key(|key| key.0);
-                let mut hot_keys = be_hot.list_with_size(FileType::Key).await?;
+                let mut hot_keys = be_hot.list_with_size(FileType::Key)?;
                 hot_keys.sort_unstable_by_key(|key| key.0);
                 if keys != hot_keys {
                     bail!("keys from repo and repo-hot do not match. Aborting.");
                 }
             }
 
-            let key = get_key(&be, password).await?;
+            let key = get_key(&be, password)?;
             info!("password is correct.");
 
             let dbe = DecryptBackend::new(&be, key.clone());
-            let config: ConfigFile = dbe.get_file(&config_ids[0]).await?;
+            let config: ConfigFile = dbe.get_file(&config_ids[0])?;
             match (config.is_hot == Some(true), be_hot.is_some()) {
                 (true, false) => bail!("repository is a hot repository!\nPlease use as --repo-hot in combination with the normal repo. Aborting."),
                 (false, true) => bail!("repo-hot is not a hot repository! Aborting."),
@@ -308,14 +306,14 @@ pub async fn execute() -> Result<()> {
 
     match cmd {
         Command::Backup(opts) => backup::execute(&dbe, opts, config, config_file, command).await?,
-        Command::Config(opts) => config::execute(&dbe, &be_hot, opts, config).await?,
+        Command::Config(opts) => config::execute(&dbe, &be_hot, opts, config)?,
         Command::Cat(opts) => cat::execute(&dbe, opts).await?,
         Command::Check(opts) => check::execute(&dbe, &cache, &be_hot, &be, opts).await?,
         Command::Completions(_) => {} // already handled above
         Command::Diff(opts) => diff::execute(&dbe, opts).await?,
         Command::Forget(opts) => forget::execute(&dbe, cache, opts, config, config_file).await?,
         Command::Init(_) => {} // already handled above
-        Command::Key(opts) => key::execute(&dbe, key, opts).await?,
+        Command::Key(opts) => key::execute(&dbe, key, opts)?,
         Command::List(opts) => list::execute(&dbe, opts).await?,
         Command::Ls(opts) => ls::execute(&dbe, opts).await?,
         Command::SelfUpdate(_) => {} // already handled above

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -307,22 +307,22 @@ pub async fn execute() -> Result<()> {
     match cmd {
         Command::Backup(opts) => backup::execute(&dbe, opts, config, config_file, command).await?,
         Command::Config(opts) => config::execute(&dbe, &be_hot, opts, config)?,
-        Command::Cat(opts) => cat::execute(&dbe, opts).await?,
+        Command::Cat(opts) => cat::execute(&dbe, opts)?,
         Command::Check(opts) => check::execute(&dbe, &cache, &be_hot, &be, opts).await?,
         Command::Completions(_) => {} // already handled above
         Command::Diff(opts) => diff::execute(&dbe, opts).await?,
         Command::Forget(opts) => forget::execute(&dbe, cache, opts, config, config_file).await?,
         Command::Init(_) => {} // already handled above
         Command::Key(opts) => key::execute(&dbe, key, opts)?,
-        Command::List(opts) => list::execute(&dbe, opts).await?,
+        Command::List(opts) => list::execute(&dbe, opts)?,
         Command::Ls(opts) => ls::execute(&dbe, opts).await?,
         Command::SelfUpdate(_) => {} // already handled above
-        Command::Snapshots(opts) => snapshots::execute(&dbe, opts, config_file).await?,
+        Command::Snapshots(opts) => snapshots::execute(&dbe, opts, config_file)?,
         Command::Prune(opts) => prune::execute(&dbe, cache, opts, config, vec![]).await?,
         Command::Restore(opts) => restore::execute(&dbe, opts).await?,
         Command::Repair(opts) => repair::execute(&dbe, opts, config_file, &config).await?,
-        Command::Repoinfo(opts) => repoinfo::execute(&dbe, &be_hot, opts).await?,
-        Command::Tag(opts) => tag::execute(&dbe, opts, config_file).await?,
+        Command::Repoinfo(opts) => repoinfo::execute(&dbe, &be_hot, opts)?,
+        Command::Tag(opts) => tag::execute(&dbe, opts, config_file)?,
     };
 
     Ok(())

--- a/src/commands/prune.rs
+++ b/src/commands/prune.rs
@@ -113,9 +113,7 @@ pub(super) async fn execute(
 
     if let Some(cache) = &cache {
         let p = progress_spinner("cleaning up packs from cache...");
-        cache
-            .remove_not_in_list(FileType::Pack, index_collector.tree_packs())
-            .await?;
+        cache.remove_not_in_list(FileType::Pack, index_collector.tree_packs())?;
         p.finish();
     }
     match (cache.is_some(), opts.cache_only) {
@@ -137,11 +135,7 @@ pub(super) async fn execute(
 
     // list existing pack files
     let p = progress_spinner("geting packs from repository...");
-    let existing_packs: HashMap<_, _> = be
-        .list_with_size(FileType::Pack)
-        .await?
-        .into_iter()
-        .collect();
+    let existing_packs: HashMap<_, _> = be.list_with_size(FileType::Pack)?.into_iter().collect();
     p.finish();
 
     let mut pruner = Pruner::new(used_ids, existing_packs, index_files);
@@ -896,7 +890,7 @@ impl Pruner {
                         time: Some(Local::now()),
                         blobs: Vec::new(),
                     };
-                    indexer.write().await.add_remove(pack).await?;
+                    indexer.write().await.add_remove(pack)?;
                 }
             }
         }
@@ -933,7 +927,7 @@ impl Pruner {
                     PackToDo::Keep => {
                         // keep pack: add to new index
                         let pack = pack.into_index_pack();
-                        indexer.write().await.add(pack).await?;
+                        indexer.write().await.add(pack)?;
                     }
                     PackToDo::Repack => {
                         // TODO: repack in parallel
@@ -959,7 +953,7 @@ impl Pruner {
                         } else {
                             // mark pack for removal
                             let pack = pack.into_index_pack_with_time(self.time);
-                            indexer.write().await.add_remove(pack).await?;
+                            indexer.write().await.add_remove(pack)?;
                         }
                     }
                     PackToDo::MarkDelete => {
@@ -968,7 +962,7 @@ impl Pruner {
                         } else {
                             // mark pack for removal
                             let pack = pack.into_index_pack_with_time(self.time);
-                            indexer.write().await.add_remove(pack).await?;
+                            indexer.write().await.add_remove(pack)?;
                         }
                     }
                     PackToDo::KeepMarked => {
@@ -977,13 +971,13 @@ impl Pruner {
                         } else {
                             // keep pack: add to new index
                             let pack = pack.into_index_pack();
-                            indexer.write().await.add_remove(pack).await?;
+                            indexer.write().await.add_remove(pack)?;
                         }
                     }
                     PackToDo::Recover => {
                         // recover pack: add to new index in section packs
                         let pack = pack.into_index_pack_with_time(self.time);
-                        indexer.write().await.add(pack).await?;
+                        indexer.write().await.add(pack)?;
                     }
                     PackToDo::Delete => delete_pack(pack),
                 }
@@ -992,7 +986,7 @@ impl Pruner {
         }
         tree_repacker.finalize().await?;
         data_repacker.finalize().await?;
-        indexer.write().await.finalize().await?;
+        indexer.write().await.finalize()?;
         p.finish();
 
         if !data_packs_remove.is_empty() {

--- a/src/commands/prune.rs
+++ b/src/commands/prune.rs
@@ -83,7 +83,7 @@ pub(super) struct Opts {
     warm_up_wait: Option<humantime::Duration>,
 }
 
-pub(super) async fn execute(
+pub(super) fn execute(
     be: &(impl DecryptFullBackend + Unpin),
     cache: Option<Cache>,
     opts: Opts,
@@ -162,14 +162,14 @@ pub(super) async fn execute(
     pruner.print_stats();
 
     if opts.warm_up {
-        warm_up(be, pruner.repack_packs().into_iter()).await?;
+        warm_up(be, pruner.repack_packs().into_iter())?;
     } else if opts.warm_up_command.is_some() {
         warm_up_command(
             pruner.repack_packs().into_iter(),
             opts.warm_up_command.as_ref().unwrap(),
         )?;
     }
-    wait(opts.warm_up_wait).await;
+    wait(opts.warm_up_wait);
 
     if !opts.dry_run {
         pruner.do_prune(be, opts, config)?;

--- a/src/commands/repair.rs
+++ b/src/commands/repair.rs
@@ -80,19 +80,19 @@ struct SnapOpts {
     ids: Vec<String>,
 }
 
-pub(super) async fn execute(
+pub(super) fn execute(
     be: &impl DecryptFullBackend,
     opts: Opts,
     config_file: RusticConfig,
     config: &ConfigFile,
 ) -> Result<()> {
     match opts.command {
-        Command::Index(opt) => repair_index(be, opt).await,
+        Command::Index(opt) => repair_index(be, opt),
         Command::Snapshots(opt) => repair_snaps(be, opt, config_file, config),
     }
 }
 
-async fn repair_index(be: &impl DecryptFullBackend, opts: IndexOpts) -> Result<()> {
+fn repair_index(be: &impl DecryptFullBackend, opts: IndexOpts) -> Result<()> {
     let p = progress_spinner("listing packs...");
     let mut packs: HashMap<_, _> = be.list_with_size(FileType::Pack)?.into_iter().collect();
     p.finish();
@@ -166,7 +166,7 @@ async fn repair_index(be: &impl DecryptFullBackend, opts: IndexOpts) -> Result<(
     pack_read_header.extend(packs.into_iter().map(|(id, size)| (id, false, None, size)));
 
     if opts.warm_up {
-        warm_up(be, pack_read_header.iter().map(|(id, _, _, _)| *id)).await?;
+        warm_up(be, pack_read_header.iter().map(|(id, _, _, _)| *id))?;
         if opts.dry_run {
             return Ok(());
         }
@@ -179,7 +179,7 @@ async fn repair_index(be: &impl DecryptFullBackend, opts: IndexOpts) -> Result<(
             return Ok(());
         }
     }
-    wait(opts.warm_up_wait).await;
+    wait(opts.warm_up_wait);
 
     let indexer = Indexer::new(be.clone()).into_shared();
     let p = progress_counter("reading pack headers");

--- a/src/commands/repoinfo.rs
+++ b/src/commands/repoinfo.rs
@@ -1,7 +1,6 @@
 use anyhow::Result;
 use clap::Parser;
 use derive_more::Add;
-use futures::TryStreamExt;
 use log::*;
 use prettytable::{format, row, Table};
 
@@ -14,18 +13,15 @@ use crate::repo::{IndexFile, IndexPack};
 #[derive(Parser)]
 pub(super) struct Opts;
 
-pub(super) async fn execute(
+pub(super) fn execute(
     be: &impl DecryptReadBackend,
     hot_be: &Option<impl ReadBackend>,
     _opts: Opts,
 ) -> Result<()> {
-    fileinfo("repository files", be).await?;
+    fileinfo("repository files", be)?;
     if let Some(hot_be) = hot_be {
-        fileinfo("hot repository files", hot_be).await?;
+        fileinfo("hot repository files", hot_be)?;
     }
-
-    let p = progress_counter("scanning index...");
-    let mut stream = be.stream_all::<IndexFile>(p.clone()).await?;
 
     #[derive(Default, Clone, Copy, Add)]
     struct Info {
@@ -59,7 +55,8 @@ pub(super) async fn execute(
     info[BlobType::Data].min_pack_size = u64::MAX;
     let mut info_delete = BlobTypeMap::<Info>::default();
 
-    while let Some((_, index)) = stream.try_next().await? {
+    let p = progress_counter("scanning index...");
+    for (_, index) in be.stream_all::<IndexFile>(p.clone())? {
         for pack in &index.packs {
             info[pack.blob_type()].add_pack(pack);
 
@@ -109,7 +106,7 @@ pub(super) async fn execute(
     Ok(())
 }
 
-async fn fileinfo(text: &str, be: &impl ReadBackend) -> Result<()> {
+fn fileinfo(text: &str, be: &impl ReadBackend) -> Result<()> {
     info!("scanning files...");
 
     let mut table = Table::new();

--- a/src/commands/repoinfo.rs
+++ b/src/commands/repoinfo.rs
@@ -116,7 +116,7 @@ async fn fileinfo(text: &str, be: &impl ReadBackend) -> Result<()> {
     let mut total_count = 0;
     let mut total_size = 0;
     for tpe in ALL_FILE_TYPES {
-        let list = be.list_with_size(tpe).await?;
+        let list = be.list_with_size(tpe)?;
         let count = list.len();
         let size = list.iter().map(|f| f.1 as u64).sum();
         table.add_row(row![format!("{:?}", tpe), r->count, r->bytes(size)]);

--- a/src/commands/restore.rs
+++ b/src/commands/restore.rs
@@ -57,7 +57,7 @@ pub(super) struct Opts {
     dest: String,
 }
 
-pub(super) async fn execute(be: &(impl DecryptReadBackend + Unpin), opts: Opts) -> Result<()> {
+pub(super) fn execute(be: &(impl DecryptReadBackend + Unpin), opts: Opts) -> Result<()> {
     if let Some(command) = &opts.warm_up_command {
         if !command.contains("%id") {
             bail!("warm-up command must contain %id!")
@@ -88,14 +88,14 @@ pub(super) async fn execute(be: &(impl DecryptReadBackend + Unpin), opts: Opts) 
         info!("all file contents are fine.");
     } else {
         if opts.warm_up {
-            warm_up(be, file_infos.to_packs().into_iter()).await?;
+            warm_up(be, file_infos.to_packs().into_iter())?;
         } else if opts.warm_up_command.is_some() {
             warm_up_command(
                 file_infos.to_packs().into_iter(),
                 opts.warm_up_command.as_ref().unwrap(),
             )?;
         }
-        wait(opts.warm_up_wait).await;
+        wait(opts.warm_up_wait);
         if !opts.dry_run {
             restore_contents(be, &dest, file_infos)?;
         }

--- a/src/commands/restore.rs
+++ b/src/commands/restore.rs
@@ -67,9 +67,9 @@ pub(super) async fn execute(be: &(impl DecryptReadBackend + Unpin), opts: Opts) 
     }
 
     let (id, path) = opts.snap.split_once(':').unwrap_or((&opts.snap, ""));
-    let snap = SnapshotFile::from_str(be, id, |_| true, progress_counter("")).await?;
+    let snap = SnapshotFile::from_str(be, id, |_| true, progress_counter(""))?;
 
-    let index = IndexBackend::new(be, progress_counter("")).await?;
+    let index = IndexBackend::new(be, progress_counter(""))?;
     let tree = Tree::subtree_id(&index, snap.tree, Path::new(path))?;
 
     let dest = LocalBackend::new(&opts.dest);

--- a/src/commands/restore.rs
+++ b/src/commands/restore.rs
@@ -70,7 +70,7 @@ pub(super) async fn execute(be: &(impl DecryptReadBackend + Unpin), opts: Opts) 
     let snap = SnapshotFile::from_str(be, id, |_| true, progress_counter("")).await?;
 
     let index = IndexBackend::new(be, progress_counter("")).await?;
-    let tree = Tree::subtree_id(&index, snap.tree, Path::new(path)).await?;
+    let tree = Tree::subtree_id(&index, snap.tree, Path::new(path))?;
 
     let dest = LocalBackend::new(&opts.dest);
 
@@ -222,7 +222,7 @@ async fn allocate_and_collect(
         .filter_map(Result::ok); // TODO: print out the ignored error
     let mut next_dst = dst_iter.next();
 
-    let mut node_streamer = NodeStreamer::new(index.clone(), tree).await?;
+    let mut node_streamer = NodeStreamer::new(index.clone(), tree)?;
     let mut next_node = node_streamer.try_next().await?;
 
     loop {
@@ -323,7 +323,6 @@ async fn restore_contents(
                                 bl.length,
                                 bl.uncompressed_length,
                             )
-                            .await
                             .unwrap()
                         }
                     };
@@ -351,7 +350,7 @@ async fn restore_metadata(
     opts: &Opts,
 ) -> Result<()> {
     // walk over tree in repository and compare with tree in dest
-    let mut node_streamer = NodeStreamer::new(index, tree).await?;
+    let mut node_streamer = NodeStreamer::new(index, tree)?;
     let mut dir_stack = Vec::new();
     while let Some((path, node)) = node_streamer.try_next().await? {
         match node.node_type() {

--- a/src/commands/restore.rs
+++ b/src/commands/restore.rs
@@ -223,7 +223,7 @@ async fn allocate_and_collect(
     let mut next_dst = dst_iter.next();
 
     let mut node_streamer = NodeStreamer::new(index.clone(), tree)?;
-    let mut next_node = node_streamer.try_next().await?;
+    let mut next_node = node_streamer.next().transpose()?;
 
     loop {
         match (&next_dst, &next_node) {
@@ -244,16 +244,16 @@ async fn allocate_and_collect(
                     // does not match the type of the node in the snapshot!
                     process_node(path, node, true)?;
                     next_dst = dst_iter.next();
-                    next_node = node_streamer.try_next().await?;
+                    next_node = node_streamer.next().transpose()?;
                 }
                 Ordering::Greater => {
                     process_node(path, node, false)?;
-                    next_node = node_streamer.try_next().await?;
+                    next_node = node_streamer.next().transpose()?;
                 }
             },
             (None, Some((path, node))) => {
                 process_node(path, node, false)?;
-                next_node = node_streamer.try_next().await?;
+                next_node = node_streamer.next().transpose()?;
             }
         }
     }
@@ -352,7 +352,7 @@ async fn restore_metadata(
     // walk over tree in repository and compare with tree in dest
     let mut node_streamer = NodeStreamer::new(index, tree)?;
     let mut dir_stack = Vec::new();
-    while let Some((path, node)) = node_streamer.try_next().await? {
+    while let Some((path, node)) = node_streamer.next().transpose()? {
         match node.node_type() {
             NodeType::Dir => {
                 // set metadata for all non-parent paths in stack

--- a/src/commands/self_update.rs
+++ b/src/commands/self_update.rs
@@ -9,7 +9,7 @@ pub(super) struct Opts {
     force: bool,
 }
 
-pub(super) async fn execute(opts: Opts) -> Result<()> {
+pub(super) fn execute(opts: Opts) -> Result<()> {
     let status = self_update::backends::github::Update::configure()
         .repo_owner("rustic-rs")
         .repo_name("rustic")

--- a/src/commands/snapshots.rs
+++ b/src/commands/snapshots.rs
@@ -43,7 +43,7 @@ pub(super) struct Opts {
     ids: Vec<String>,
 }
 
-pub(super) async fn execute(
+pub(super) fn execute(
     be: &impl DecryptReadBackend,
     mut opts: Opts,
     config_file: RusticConfig,
@@ -51,10 +51,9 @@ pub(super) async fn execute(
     config_file.merge_into("snapshot-filter", &mut opts.filter)?;
 
     let groups = match &opts.ids[..] {
-        [] => SnapshotFile::group_from_backend(be, &opts.filter, &opts.group_by).await?,
+        [] => SnapshotFile::group_from_backend(be, &opts.filter, &opts.group_by)?,
         [id] if id == "latest" => {
-            SnapshotFile::group_from_backend(be, &opts.filter, &opts.group_by)
-                .await?
+            SnapshotFile::group_from_backend(be, &opts.filter, &opts.group_by)?
                 .into_iter()
                 .map(|(group, mut snaps)| {
                     snaps.sort_unstable();
@@ -67,7 +66,7 @@ pub(super) async fn execute(
         }
         _ => vec![(
             SnapshotGroup::default(),
-            SnapshotFile::from_ids(be, &opts.ids).await?,
+            SnapshotFile::from_ids(be, &opts.ids)?,
         )],
     };
 

--- a/src/commands/tag.rs
+++ b/src/commands/tag.rs
@@ -68,7 +68,7 @@ pub(super) struct Opts {
     ids: Vec<String>,
 }
 
-pub(super) async fn execute(
+pub(super) fn execute(
     be: &impl DecryptFullBackend,
     mut opts: Opts,
     config_file: RusticConfig,
@@ -76,8 +76,8 @@ pub(super) async fn execute(
     config_file.merge_into("snapshot-filter", &mut opts.filter)?;
 
     let snapshots = match opts.ids.is_empty() {
-        true => SnapshotFile::all_from_backend(be, &opts.filter).await?,
-        false => SnapshotFile::from_ids(be, &opts.ids).await?,
+        true => SnapshotFile::all_from_backend(be, &opts.filter)?,
+        false => SnapshotFile::from_ids(be, &opts.ids)?,
     };
 
     let delete = match (
@@ -109,11 +109,10 @@ pub(super) async fn execute(
         ),
         (false, false) => {
             let p = progress_counter("saving new snapshots...");
-            be.save_list(snapshots, p).await?;
+            be.save_list(snapshots, p)?;
 
             let p = progress_counter("deleting old snapshots...");
-            be.delete_list(FileType::Snapshot, true, old_snap_ids, p)
-                .await?;
+            be.delete_list(FileType::Snapshot, true, old_snap_ids, p)?;
         }
     }
     Ok(())

--- a/src/index/indexer.rs
+++ b/src/index/indexer.rs
@@ -53,26 +53,26 @@ impl<BE: DecryptWriteBackend> Indexer<BE> {
         Arc::new(RwLock::new(self))
     }
 
-    pub async fn finalize(&self) -> Result<()> {
-        self.save().await
+    pub fn finalize(&self) -> Result<()> {
+        self.save()
     }
 
-    pub async fn save(&self) -> Result<()> {
+    pub fn save(&self) -> Result<()> {
         if (self.file.packs.len() + self.file.packs_to_delete.len()) > 0 {
-            self.be.save_file(&self.file).await?;
+            self.be.save_file(&self.file)?;
         }
         Ok(())
     }
 
-    pub async fn add(&mut self, pack: IndexPack) -> Result<()> {
-        self.add_with(pack, false).await
+    pub fn add(&mut self, pack: IndexPack) -> Result<()> {
+        self.add_with(pack, false)
     }
 
-    pub async fn add_remove(&mut self, pack: IndexPack) -> Result<()> {
-        self.add_with(pack, true).await
+    pub fn add_remove(&mut self, pack: IndexPack) -> Result<()> {
+        self.add_with(pack, true)
     }
 
-    pub async fn add_with(&mut self, pack: IndexPack, delete: bool) -> Result<()> {
+    pub fn add_with(&mut self, pack: IndexPack, delete: bool) -> Result<()> {
         self.count += pack.blobs.len();
 
         if let Some(indexed) = &mut self.indexed {
@@ -85,7 +85,7 @@ impl<BE: DecryptWriteBackend> Indexer<BE> {
 
         // check if IndexFile needs to be saved
         if self.count >= MAX_COUNT || self.created.elapsed()? >= MAX_AGE {
-            self.save().await?;
+            self.save()?;
             self.reset();
         }
         Ok(())

--- a/src/index/indexer.rs
+++ b/src/index/indexer.rs
@@ -1,9 +1,9 @@
 use std::collections::HashSet;
 use std::sync::Arc;
+use std::sync::RwLock;
 use std::time::{Duration, SystemTime};
 
 use anyhow::Result;
-use tokio::sync::RwLock;
 
 use crate::backend::DecryptWriteBackend;
 use crate::id::Id;

--- a/src/index/mod.rs
+++ b/src/index/mod.rs
@@ -41,17 +41,15 @@ impl IndexEntry {
     }
 
     /// Get a blob described by IndexEntry from the backend
-    pub async fn read_data<B: DecryptReadBackend>(&self, be: &B) -> Result<Bytes> {
-        let data = be
-            .read_encrypted_partial(
-                FileType::Pack,
-                &self.pack,
-                self.blob_type.is_cacheable(),
-                self.offset,
-                self.length,
-                self.uncompressed_length,
-            )
-            .await?;
+    pub fn read_data<B: DecryptReadBackend>(&self, be: &B) -> Result<Bytes> {
+        let data = be.read_encrypted_partial(
+            FileType::Pack,
+            &self.pack,
+            self.blob_type.is_cacheable(),
+            self.offset,
+            self.length,
+            self.uncompressed_length,
+        )?;
         Ok(data)
     }
 
@@ -91,10 +89,10 @@ pub trait IndexedBackend: ReadIndex + Clone + Sync + Send + 'static {
 
     fn be(&self) -> &Self::Backend;
 
-    async fn blob_from_backend(&self, tpe: &BlobType, id: &Id) -> Result<Bytes> {
+    fn blob_from_backend(&self, tpe: &BlobType, id: &Id) -> Result<Bytes> {
         match self.get_id(tpe, id) {
             None => Err(anyhow!("blob not found in index")),
-            Some(ie) => ie.read_data(self.be()).await,
+            Some(ie) => ie.read_data(self.be()),
         }
     }
 }

--- a/src/index/mod.rs
+++ b/src/index/mod.rs
@@ -2,11 +2,9 @@ use std::num::NonZeroU32;
 use std::sync::Arc;
 
 use anyhow::{anyhow, Result};
-use async_trait::async_trait;
 use bytes::Bytes;
 use derive_getters::Getters;
 use derive_more::Constructor;
-use futures::StreamExt;
 use indicatif::ProgressBar;
 
 use crate::backend::{DecryptReadBackend, FileType};
@@ -83,7 +81,6 @@ pub trait ReadIndex {
     }
 }
 
-#[async_trait]
 pub trait IndexedBackend: ReadIndex + Clone + Sync + Send + 'static {
     type Backend: DecryptReadBackend;
 
@@ -124,31 +121,23 @@ impl<BE: DecryptReadBackend> IndexBackend<BE> {
         }
     }
 
-    async fn new_from_collector(
-        be: &BE,
-        p: ProgressBar,
-        mut collector: IndexCollector,
-    ) -> Result<Self> {
+    fn new_from_collector(be: &BE, p: ProgressBar, mut collector: IndexCollector) -> Result<Self> {
         p.set_prefix("reading index...");
-        let mut stream = be
-            .stream_all::<IndexFile>(p.clone())
-            .await?
-            .map(|i| i.unwrap().1);
-
-        while let Some(index) = stream.next().await {
-            collector.extend(index.packs);
+        for (_, i) in be.stream_all::<IndexFile>(p.clone())? {
+            collector.extend(i.packs);
         }
+
         p.finish();
 
         Ok(Self::new_from_index(be, collector.into_index()))
     }
 
-    pub async fn new(be: &BE, p: ProgressBar) -> Result<Self> {
-        Self::new_from_collector(be, p, IndexCollector::new(IndexType::Full)).await
+    pub fn new(be: &BE, p: ProgressBar) -> Result<Self> {
+        Self::new_from_collector(be, p, IndexCollector::new(IndexType::Full))
     }
 
-    pub async fn only_full_trees(be: &BE, p: ProgressBar) -> Result<Self> {
-        Self::new_from_collector(be, p, IndexCollector::new(IndexType::FullTrees)).await
+    pub fn only_full_trees(be: &BE, p: ProgressBar) -> Result<Self> {
+        Self::new_from_collector(be, p, IndexCollector::new(IndexType::FullTrees))
     }
 
     pub fn into_index(self) -> Index {

--- a/src/main.rs
+++ b/src/main.rs
@@ -40,7 +40,6 @@ mod id;
 mod index;
 mod repo;
 
-#[tokio::main]
-async fn main() -> Result<()> {
-    commands::execute().await
+fn main() -> Result<()> {
+    commands::execute()
 }

--- a/src/repo/packfile.rs
+++ b/src/repo/packfile.rs
@@ -156,7 +156,7 @@ impl PackHeader {
     }
 
     /// Read the pack header directly from a packfile using the backend
-    pub async fn from_file(
+    pub fn from_file(
         be: &impl DecryptReadBackend,
         id: Id,
         size_hint: Option<u32>,
@@ -170,9 +170,7 @@ impl PackHeader {
         // read (guessed) header + length field
         let read_size = size_guess + LENGTH_LEN;
         let offset = pack_size - read_size;
-        let mut data = be
-            .read_partial(FileType::Pack, &id, false, offset, read_size)
-            .await?;
+        let mut data = be.read_partial(FileType::Pack, &id, false, offset, read_size)?;
 
         // get header length from the file
         let size_real =
@@ -185,8 +183,7 @@ impl PackHeader {
         } else {
             // size_guess was too small; we have to read again
             let offset = pack_size - size_real - LENGTH_LEN;
-            be.read_partial(FileType::Pack, &id, false, offset, size_real)
-                .await?
+            be.read_partial(FileType::Pack, &id, false, offset, size_real)?
         };
 
         Self::from_binary(&be.decrypt(&data)?)

--- a/src/repo/snapshotfile.rs
+++ b/src/repo/snapshotfile.rs
@@ -108,8 +108,8 @@ impl SnapshotFile {
     }
 
     /// Get a SnapshotFile from the backend
-    pub async fn from_backend<B: DecryptReadBackend>(be: &B, id: &Id) -> Result<Self> {
-        Ok(Self::set_id((*id, be.get_file(id).await?)))
+    pub fn from_backend<B: DecryptReadBackend>(be: &B, id: &Id) -> Result<Self> {
+        Ok(Self::set_id((*id, be.get_file(id)?)))
     }
 
     pub async fn from_str<B: DecryptReadBackend>(
@@ -120,7 +120,7 @@ impl SnapshotFile {
     ) -> Result<Self> {
         match string {
             "latest" => Self::latest(be, predicate, p).await,
-            _ => Self::from_id(be, string).await,
+            _ => Self::from_id(be, string),
         }
     }
 
@@ -152,15 +152,15 @@ impl SnapshotFile {
     }
 
     /// Get a SnapshotFile from the backend by (part of the) id
-    pub async fn from_id<B: DecryptReadBackend>(be: &B, id: &str) -> Result<Self> {
+    pub fn from_id<B: DecryptReadBackend>(be: &B, id: &str) -> Result<Self> {
         info!("getting snapshot...");
-        let id = be.find_id(FileType::Snapshot, id).await?;
-        SnapshotFile::from_backend(be, &id).await
+        let id = be.find_id(FileType::Snapshot, id)?;
+        SnapshotFile::from_backend(be, &id)
     }
 
     /// Get a Vector of SnapshotFile from the backend by list of (parts of the) ids
     pub async fn from_ids<B: DecryptReadBackend>(be: &B, ids: &[String]) -> Result<Vec<Self>> {
-        let ids = be.find_ids(FileType::Snapshot, ids).await?;
+        let ids = be.find_ids(FileType::Snapshot, ids)?;
         Ok(be
             .stream_list::<Self>(ids, ProgressBar::hidden())
             .await?

--- a/src/repo/snapshotfile.rs
+++ b/src/repo/snapshotfile.rs
@@ -6,7 +6,6 @@ use anyhow::{anyhow, bail, Result};
 use chrono::{DateTime, Local};
 use clap::Parser;
 use derivative::Derivative;
-use futures::{future, TryStreamExt};
 use indicatif::ProgressBar;
 use log::*;
 use merge::Merge;
@@ -112,33 +111,33 @@ impl SnapshotFile {
         Ok(Self::set_id((*id, be.get_file(id)?)))
     }
 
-    pub async fn from_str<B: DecryptReadBackend>(
+    pub fn from_str<B: DecryptReadBackend>(
         be: &B,
         string: &str,
-        predicate: impl FnMut(&Self) -> bool,
+        predicate: impl FnMut(&Self) -> bool + Send + Sync,
         p: ProgressBar,
     ) -> Result<Self> {
         match string {
-            "latest" => Self::latest(be, predicate, p).await,
+            "latest" => Self::latest(be, predicate, p),
             _ => Self::from_id(be, string),
         }
     }
 
     /// Get the latest SnapshotFile from the backend
-    pub async fn latest<B: DecryptReadBackend>(
+    pub fn latest<B: DecryptReadBackend>(
         be: &B,
-        predicate: impl FnMut(&Self) -> bool,
+        predicate: impl FnMut(&Self) -> bool + Send + Sync,
         p: ProgressBar,
     ) -> Result<Self> {
         p.set_prefix("getting latest snapshot...");
         let mut latest: Option<Self> = None;
         let mut pred = predicate;
-        let mut snaps = be.stream_all::<SnapshotFile>(p.clone()).await?;
 
-        while let Some((id, mut snap)) = snaps.try_next().await? {
+        for (id, mut snap) in be.stream_all::<SnapshotFile>(p.clone())? {
             if !pred(&snap) {
                 continue;
             }
+
             snap.id = id;
             match &latest {
                 Some(l) if l.time > snap.time => {}
@@ -159,14 +158,13 @@ impl SnapshotFile {
     }
 
     /// Get a Vector of SnapshotFile from the backend by list of (parts of the) ids
-    pub async fn from_ids<B: DecryptReadBackend>(be: &B, ids: &[String]) -> Result<Vec<Self>> {
+    pub fn from_ids<B: DecryptReadBackend>(be: &B, ids: &[String]) -> Result<Vec<Self>> {
         let ids = be.find_ids(FileType::Snapshot, ids)?;
         Ok(be
-            .stream_list::<Self>(ids, ProgressBar::hidden())
-            .await?
-            .map_ok(Self::set_id)
-            .try_collect()
-            .await?)
+            .stream_list::<Self>(ids, ProgressBar::hidden())?
+            .into_iter()
+            .map(Self::set_id)
+            .collect())
     }
 
     fn cmp_group(&self, crit: &SnapshotGroupCriterion, other: &Self) -> Ordering {
@@ -199,12 +197,12 @@ impl SnapshotFile {
 
     /// Get SnapshotFiles which match the filter grouped by the group criterion
     /// from the backend
-    pub async fn group_from_backend<B: DecryptReadBackend>(
+    pub fn group_from_backend<B: DecryptReadBackend>(
         be: &B,
         filter: &SnapshotFilter,
         crit: &SnapshotGroupCriterion,
     ) -> Result<Vec<(SnapshotGroup, Vec<Self>)>> {
-        let mut snaps = Self::all_from_backend(be, filter).await?;
+        let mut snaps = Self::all_from_backend(be, filter)?;
         snaps.sort_unstable_by(|sn1, sn2| sn1.cmp_group(crit, sn2));
 
         let mut result = Vec::new();
@@ -233,17 +231,16 @@ impl SnapshotFile {
         Ok(result)
     }
 
-    pub async fn all_from_backend<B: DecryptReadBackend>(
+    pub fn all_from_backend<B: DecryptReadBackend>(
         be: &B,
         filter: &SnapshotFilter,
     ) -> Result<Vec<Self>> {
         Ok(be
-            .stream_all::<SnapshotFile>(ProgressBar::hidden())
-            .await?
-            .map_ok(Self::set_id)
-            .try_filter(|sn| future::ready(sn.matches(filter)))
-            .try_collect()
-            .await?)
+            .stream_all::<SnapshotFile>(ProgressBar::hidden())?
+            .into_iter()
+            .map(Self::set_id)
+            .filter(|sn| sn.matches(filter))
+            .collect())
     }
 
     pub fn matches(&self, filter: &SnapshotFilter) -> bool {


### PR DESCRIPTION
I've been racking my brain for the last couple of weeks how to parallelize and tweak performance of rustic. I tried quite some optimizations just to find out they didn't work at all or traded a slightly improved parallelization for a huge increase in memory requirement - or made rustic even slower..

Recapturing, I think one of the point is that within rustic, we want to have a lot of heavy cpu work parallelized which is not the typical setting async code is for.

So I decided to give it a try and convert rustic back to sync code in order to use "traditional" parallelization methods...

This is WIP, but IMO it looks already pretty good and most commands are much better parallelized than before... Feedback at any time heavily appreciated!

Open points:
- [x] fully remove the async code
- [ ] identify all places where to parallelize and do so
- [ ] identify code simplifications due to the removal of async code