### PR TITLE
backup: Add --as-path option

### DIFF
--- a/src/archiver/archiver_impl.rs
+++ b/src/archiver/archiver_impl.rs
@@ -104,7 +104,13 @@ impl<BE: DecryptWriteBackend, I: IndexedBackend> Archiver<BE, I> {
         self.summary.total_dirsize_processed += size;
     }
 
-    pub fn add_entry(&mut self, path: &Path, node: Node, p: ProgressBar) -> Result<()> {
+    pub fn add_entry(
+        &mut self,
+        path: &Path,
+        real_path: &Path,
+        node: Node,
+        p: ProgressBar,
+    ) -> Result<()> {
         let basepath = if node.is_dir() {
             path
         } else {
@@ -135,7 +141,7 @@ impl<BE: DecryptWriteBackend, I: IndexedBackend> Archiver<BE, I> {
 
         match node.node_type() {
             NodeType::File => {
-                self.backup_file(path, node, p)?;
+                self.backup_file(real_path, node, p)?;
             }
             NodeType::Dir => {}          // is already handled, see above
             _ => self.add_file(node, 0), // all other cases: just save the given node

--- a/src/backend/ignore.rs
+++ b/src/backend/ignore.rs
@@ -165,9 +165,14 @@ impl Iterator for LocalSource {
     type Item = Result<(PathBuf, Node)>;
 
     fn next(&mut self) -> Option<Self::Item> {
-        self.walker
-            .next()
-            .map(|e| map_entry(e?, self.with_atime, &self.cache))
+        match self.walker.next() {
+            // ignore root dir, i.e. an entry with depth 0 of type dir
+            Some(Ok(entry)) if entry.depth() == 0 && entry.file_type().unwrap().is_dir() => {
+                self.walker.next()
+            }
+            item => item,
+        }
+        .map(|e| map_entry(e?, self.with_atime, &self.cache))
     }
 }
 


### PR DESCRIPTION
The option `--as-path` lets rustic set an other path instead of the path specified by SOURCE. It also generates the tree structure according to this given path.

Example:
If you have the files `/dir/a` and `/dir/subdir/b` and call `rustic backup /dir`, the snapshot will contain
```
/dir
/dir/a
/dir/subdir
/dir/subdir/b
```
If you call `rustic backup /dir --as-path /my/directory`, it will generate
```
/my
/my/directory
/my/directory/a
/my/directory/subdir
/my/directory/subdir/b
```