### PR TITLE
backup: Allow relative paths

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1317,15 +1317,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "path-absolutize"
-version = "3.0.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f1d4993b16f7325d90c18c3c6a3327db7808752db8d208cea0acee0abd52c52"
-dependencies = [
- "path-dedot",
-]
-
-[[package]]
 name = "path-dedot"
 version = "3.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1706,7 +1697,7 @@ dependencies = [
  "merge",
  "nix",
  "pariter",
- "path-absolutize",
+ "path-dedot",
  "prettytable-rs",
  "quickcheck",
  "quickcheck_macros",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -81,7 +81,7 @@ rpassword = "7"
 prettytable-rs = {version = "0.9", default-features = false }
 bytesize = "1"
 indicatif = "0.17"
-path-absolutize = "3"
+path-dedot = "3"
 gethostname = "0.4"
 humantime = "2"
 users = "0.11"


### PR DESCRIPTION
closes #294 

This doesn't change anything in the `restore` command, but the restore command already only works with the trees within the snapshot. So absolute/relative paths work there. The only left-open point is to maybe use the absolute path as restore target if no target is given. 