### PR TITLE
backup: Use rayon to parallelize hashing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -363,20 +363,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "crossbeam"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2801af0d36612ae591caa9568261fddce32ce6e08a7275ea334a06a4ad021a2c"
-dependencies = [
- "cfg-if",
- "crossbeam-channel",
- "crossbeam-deque",
- "crossbeam-epoch",
- "crossbeam-queue",
- "crossbeam-utils",
-]
-
-[[package]]
 name = "crossbeam-channel"
 version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -408,16 +394,6 @@ dependencies = [
  "crossbeam-utils",
  "memoffset",
  "scopeguard",
-]
-
-[[package]]
-name = "crossbeam-queue"
-version = "0.3.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1cfb3ea8a53f37c40dea2c7bedcbd88bdfae54f5e2175d6ecaff1c988353add"
-dependencies = [
- "cfg-if",
- "crossbeam-utils",
 ]
 
 [[package]]
@@ -1331,17 +1307,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1b04fb49957986fdce4d6ee7a65027d55d4b6d2265e5848bbb507b58ccfdb6f"
 
 [[package]]
-name = "pariter"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "324a62b9e7b5f270c0acc92a2040f8028bb643f959f9c068f11a7864f327e3d9"
-dependencies = [
- "crossbeam",
- "crossbeam-channel",
- "num_cpus",
-]
-
-[[package]]
 name = "parking_lot"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1737,7 +1702,6 @@ dependencies = [
  "log",
  "merge",
  "nix",
- "pariter",
  "path-dedot",
  "quickcheck",
  "quickcheck_macros",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,6 @@ log = "0.4"
 # parallelize
 crossbeam-channel = "0.5"
 rayon = "1"
-pariter = "0.5"
 #crypto
 aes256ctr_poly1305aes = "0.1"
 sha2 = "0.10"

--- a/src/chunker.rs
+++ b/src/chunker.rs
@@ -16,7 +16,7 @@ fn default_predicate(x: u64) -> bool {
     (x & SPLITMASK) == 0
 }
 
-pub struct ChunkIter<R: Read> {
+pub struct ChunkIter<R: Read + Send> {
     buf: Vec<u8>,
     pos: usize,
     reader: R,
@@ -28,7 +28,7 @@ pub struct ChunkIter<R: Read> {
     finished: bool,
 }
 
-impl<R: Read> ChunkIter<R> {
+impl<R: Read + Send> ChunkIter<R> {
     pub fn new(reader: R, size_hint: usize, poly: &Polynom64) -> Self {
         Self {
             buf: Vec::with_capacity(4 * KB),
@@ -44,7 +44,7 @@ impl<R: Read> ChunkIter<R> {
     }
 }
 
-impl<R: Read> Iterator for ChunkIter<R> {
+impl<R: Read + Send> Iterator for ChunkIter<R> {
     type Item = io::Result<Vec<u8>>;
 
     fn next(&mut self) -> Option<io::Result<Vec<u8>>> {


### PR DESCRIPTION
This makes use of rayon's threadpool and therefore improves performance especially for lots of files.
Tests show also a better parallelization for a single large file.

Also simplifies dependencies.