### PR TITLE
repository: integrate warm-up options

### DIFF
--- a/examples/ovh-hot-cold.toml
+++ b/examples/ovh-hot-cold.toml
@@ -1,4 +1,5 @@
 # rustic config file to backup /home, /etc and /root to a hot/cold repository hosted by OVH
+# using OVH cloud archive and OVH object storage
 #
 # backup usage: "rustic -P ovh-hot-cold backup
 # cleanup:      "rustic -P ovh-hot-cold forget --prune
@@ -8,6 +9,8 @@ repository = "rclone:ovh:backup-home"
 repo-hot = "rclone:ovh:backup-home-hot"
 password-file =  "/root/key-rustic-ovh"
 cache-dir = "/var/lib/cache/rustic" # explicitely specify cache dir for remote repository 
+warm-up = true # cold storage needs warm-up, just trying to access a file is sufficient to start the warm-up
+warm-up-wait = "10m" # in my examples, 10 minutes wait-time was sufficient, according to docu it can be up to 12h
 
 [forget]
 keep-daily = 8

--- a/src/commands/restore.rs
+++ b/src/commands/restore.rs
@@ -14,7 +14,7 @@ use log::*;
 use rayon::ThreadPoolBuilder;
 
 use super::rustic_config::RusticConfig;
-use super::{bytes, progress_bytes, progress_counter, wait, warm_up, warm_up_command};
+use super::{bytes, progress_bytes, progress_counter, warm_up_wait};
 use crate::backend::{DecryptReadBackend, FileType, LocalBackend};
 use crate::blob::{Node, NodeStreamer, NodeType, Tree};
 use crate::commands::helpers::progress_spinner;
@@ -117,15 +117,7 @@ pub(super) fn execute(
     if file_infos.restore_size == 0 {
         info!("all file contents are fine.");
     } else {
-        if opts.warm_up {
-            warm_up(be, file_infos.to_packs().into_iter())?;
-        } else if opts.warm_up_command.is_some() {
-            warm_up_command(
-                file_infos.to_packs().into_iter(),
-                opts.warm_up_command.as_ref().unwrap(),
-            )?;
-        }
-        wait(opts.warm_up_wait);
+        warm_up_wait(&repo, file_infos.to_packs().into_iter(), !opts.dry_run)?;
         if !opts.dry_run {
             restore_contents(be, &dest, file_infos)?;
         }


### PR DESCRIPTION
This PR moves the warm-up options from the commands `restore`, `repair`, `prune` (these are the three commands where it is currently used) to to repository options. This consolidates some code.

Another benefit is that this makes it possible to define warm-up in the config file.