### PR TITLE
Allow treating stdin as a tar archive

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,12 @@
 version = 3
 
 [[package]]
+name = "Inflector"
+version = "0.11.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe438c63458706e03479442743baae6c88256498e6431708f6dfc520a26515d3"
+
+[[package]]
 name = "adler"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -52,6 +58,12 @@ checksum = "cc936419f96fa211c1b9166887b38e5e40b19958e5b895be7c1f93adec7071ac"
 dependencies = [
  "memchr",
 ]
+
+[[package]]
+name = "aliasable"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "250f629c0161ad8107cf89319e990051fae62832fd343083bea452d93e2205fd"
 
 [[package]]
 name = "android_system_properties"
@@ -1261,9 +1273,9 @@ dependencies = [
 
 [[package]]
 name = "nom"
-version = "7.1.2"
+version = "7.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5507769c4919c998e69e49c839d9dc6e693ede4cc4290d6ad8b41d4f09c548c"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
 dependencies = [
  "memchr",
  "minimal-lexical",
@@ -1330,6 +1342,29 @@ name = "os_str_bytes"
 version = "6.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b7820b9daea5457c9f21c69448905d723fbd21136ccf521748f23fd49e723ee"
+
+[[package]]
+name = "ouroboros"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dfbb50b356159620db6ac971c6d5c9ab788c9cc38a6f49619fca2a27acb062ca"
+dependencies = [
+ "aliasable",
+ "ouroboros_macro",
+]
+
+[[package]]
+name = "ouroboros_macro"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a0d9d1a6191c4f391f87219d1ea42b23f09ee84d64763cd05ee6ea88d9f384d"
+dependencies = [
+ "Inflector",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "owo-colors"
@@ -1746,6 +1781,7 @@ dependencies = [
  "merge",
  "nix",
  "nom",
+ "ouroboros",
  "path-dedot",
  "quickcheck",
  "quickcheck_macros",
@@ -1763,6 +1799,7 @@ dependencies = [
  "serde_with",
  "sha2",
  "simplelog",
+ "tar",
  "thiserror",
  "toml",
  "users",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -87,6 +87,8 @@ itertools = "0.10"
 simplelog = "0.12"
 comfy-table = "6.1.4"
 libc="0.2"
+tar = "0.4"
+ouroboros = "0.15"
 
 [dev-dependencies]
 rstest = "0.16"

--- a/src/archiver/archiver_impl.rs
+++ b/src/archiver/archiver_impl.rs
@@ -8,7 +8,7 @@ use indicatif::ProgressBar;
 use log::*;
 use rayon::prelude::*;
 
-use crate::backend::DecryptWriteBackend;
+use crate::backend::{DecryptWriteBackend, ReadSourceOpen};
 use crate::blob::{BlobType, Metadata, Node, NodeType, Packer, Tree};
 use crate::chunker::ChunkIter;
 use crate::crypto::hash;
@@ -102,12 +102,12 @@ impl<BE: DecryptWriteBackend, I: IndexedBackend> Archiver<BE, I> {
         self.summary.total_dirsize_processed += size;
     }
 
-    pub fn add_entry<R: Read + Send + 'static>(
+    pub fn add_entry(
         &mut self,
         path: &Path,
         real_path: &Path,
         node: Node,
-        open_fn: Option<impl FnOnce(&Path) -> Result<R>>,
+        open: Option<impl ReadSourceOpen>,
         p: ProgressBar,
     ) -> Result<()> {
         let basepath = if node.is_dir() {
@@ -147,9 +147,9 @@ impl<BE: DecryptWriteBackend, I: IndexedBackend> Archiver<BE, I> {
 
         match node.node_type() {
             NodeType::File => {
-                let open_fn =
-                    open_fn.expect("ReadSourceEntry should always provide a reader for file types");
-                self.backup_file(real_path, node, open_fn, p)?;
+                let open =
+                    open.expect("ReadSourceEntry should always provide a reader for file types");
+                self.backup_file(real_path, node, open, p)?;
             }
             NodeType::Dir => {}          // is already handled, see above
             _ => self.add_file(node, 0), // all other cases: just save the given node
@@ -207,11 +207,11 @@ impl<BE: DecryptWriteBackend, I: IndexedBackend> Archiver<BE, I> {
         Ok(())
     }
 
-    pub fn backup_file<R: Read + Send + 'static>(
+    pub fn backup_file(
         &mut self,
         path: &Path,
         node: Node,
-        open_fn: impl FnOnce(&Path) -> Result<R>,
+        opener: impl ReadSourceOpen,
         p: ProgressBar,
     ) -> Result<()> {
         if let ParentResult::Matched(p_node) = self.parent.is_parent(&node) {
@@ -229,7 +229,7 @@ impl<BE: DecryptWriteBackend, I: IndexedBackend> Archiver<BE, I> {
                 );
             }
         }
-        let f = open_fn(path)?;
+        let f = opener.open(path)?;
         self.backup_reader(f, node, p)
     }
 

--- a/src/backend/ignore.rs
+++ b/src/backend/ignore.rs
@@ -310,7 +310,7 @@ const S_ISVTX: u32 = 0o1000; // sticky bit (see below)
 /// map `st_mode` from POSIX (`inode(7)`) to golang's definition (<https://pkg.go.dev/io/fs#ModeType>)
 /// Note, that it only sets the bits `os.ModePerm | os.ModeType | os.ModeSetuid | os.ModeSetgid | os.ModeSticky`
 /// to stay compatible with the restic implementation
-fn map_mode_to_go(mode: u32) -> u32 {
+pub(crate) fn map_mode_to_go(mode: u32) -> u32 {
     let mut go_mode = mode & MODE_PERM;
 
     match mode & S_IFFORMAT {

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -144,10 +144,20 @@ pub trait WriteBackend: ReadBackend {
     fn remove(&self, tpe: FileType, id: &Id, cacheable: bool) -> Result<()>;
 }
 
-pub trait ReadSource: Iterator<Item = Result<(PathBuf, Node)>> {
+pub struct ReadSourceEntry<F> {
+    pub path: PathBuf,
+    pub node: Node,
+    pub open: Option<F>,
+}
+
+pub trait ReadSource {
     type Reader: Read;
-    fn read(path: &Path) -> Result<Self::Reader>;
-    fn size(&self) -> Result<u64>;
+    type Open: FnOnce(&Path) -> Result<Self::Reader>;
+    type Iter: Iterator<Item = Result<ReadSourceEntry<Self::Open>>>;
+
+    fn size(&self) -> Result<Option<u64>>;
+
+    fn entries(self) -> Self::Iter;
 }
 
 pub trait WriteSource: Clone {

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -144,15 +144,20 @@ pub trait WriteBackend: ReadBackend {
     fn remove(&self, tpe: FileType, id: &Id, cacheable: bool) -> Result<()>;
 }
 
-pub struct ReadSourceEntry<F> {
+pub struct ReadSourceEntry<O> {
     pub path: PathBuf,
     pub node: Node,
-    pub open: Option<F>,
+    pub open: Option<O>,
+}
+
+pub trait ReadSourceOpen {
+    type Reader: Read + Send + 'static;
+
+    fn open(self, path: &Path) -> Result<Self::Reader>;
 }
 
 pub trait ReadSource {
-    type Reader: Read;
-    type Open: FnOnce(&Path) -> Result<Self::Reader>;
+    type Open: ReadSourceOpen;
     type Iter: Iterator<Item = Result<ReadSourceEntry<Self::Open>>>;
 
     fn size(&self) -> Result<Option<u64>>;

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -17,6 +17,7 @@ pub mod local;
 pub mod node;
 pub mod rclone;
 pub mod rest;
+pub mod tar;
 
 pub use self::ignore::*;
 pub use cache::*;

--- a/src/backend/tar.rs
+++ b/src/backend/tar.rs
@@ -1,0 +1,276 @@
+use crate::backend::{map_mode_to_go, ReadSource, ReadSourceEntry, ReadSourceOpen};
+use crate::blob::{Metadata, Node, NodeType};
+use anyhow::{bail, Context, Result};
+use chrono::{DateTime, Local, TimeZone, Utc};
+use ouroboros::self_referencing;
+use std::io::Read;
+use std::path::{Path, PathBuf};
+use std::sync::{Arc, Condvar, Mutex};
+use std::{io, mem};
+use tar::EntryType;
+
+pub struct TarSource<R: Read + 'static>(Arc<Data<R>>);
+
+pub struct TarFile<R: Read + 'static>(Arc<Data<R>>);
+
+pub struct TarOpen<R: Read + 'static>(TarFile<R>);
+
+pub struct TarEntries<R: Read + 'static>(Arc<Data<R>>);
+
+impl<R: Read + 'static> TarSource<R> {
+    pub fn new(archive: tar::Archive<R>) -> io::Result<Self> {
+        let result = ReaderTryBuilder {
+            archive,
+            entries_builder: |archive| {
+                archive
+                    .entries()
+                    .map(|entries| Entries::NoCurrentFile { entries })
+            },
+        }
+        .try_build()?;
+        Ok(Self(Arc::new(Data::new(result))))
+    }
+}
+
+impl<R: Read + Send + 'static> ReadSource for TarSource<R> {
+    type Open = TarOpen<R>;
+    type Iter = TarEntries<R>;
+
+    fn size(&self) -> Result<Option<u64>> {
+        Ok(None)
+    }
+
+    fn entries(self) -> Self::Iter {
+        TarEntries(self.0)
+    }
+}
+
+impl<R: Read + 'static> Iterator for TarEntries<R> {
+    type Item = Result<ReadSourceEntry<TarOpen<R>>>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let mut reader = self.0.data.lock().unwrap();
+        loop {
+            let res = match reader.with_entries_mut(|entries| entries.read_entry()) {
+                EntryReadResult::NoMoreEntries => None,
+                EntryReadResult::Error(e) => Some(Err(e)),
+                EntryReadResult::StartedReader(mut entry) => {
+                    entry.open = Some(TarOpen(TarFile(Arc::clone(&self.0))));
+                    Some(Ok(*entry))
+                }
+                EntryReadResult::WaitForReaderDone => {
+                    reader = self.0.entry_read.wait(reader).unwrap();
+                    continue;
+                }
+            };
+            return res;
+        }
+    }
+}
+
+fn timestamp_from_maybe_secs<E: std::error::Error + Sync + Send + 'static>(
+    s: Result<u64, E>,
+) -> Result<DateTime<Local>> {
+    let n = s?;
+    let n = i64::try_from(n).context("Tar timestamp out of range for i64")?;
+    let dt = Utc
+        .timestamp_opt(n, 0)
+        .single()
+        .with_context(|| format!("Cannot create timestamp from tar timestamp: {n}"))?;
+    Ok(dt.with_timezone(&Local))
+}
+
+fn make_dev(header: &tar::Header) -> Result<u64> {
+    let major = header.device_major()?.context("no major device")?;
+    let minor = header.device_minor()?.context("no minor device")?;
+
+    Ok(u64::from(major << 24 | minor))
+}
+
+fn path_node_from_entry<R: Read>(entry: &tar::Entry<R>) -> Result<(PathBuf, Node)> {
+    let path = entry.path()?;
+    let name = path.file_name().context("expected a file name")?;
+    let header = entry.header();
+    let size = entry.size();
+    let mtime = timestamp_from_maybe_secs(header.mtime())?;
+
+    let uid = header.uid()?.try_into().context("uid too large")?;
+    let gid = header.gid()?.try_into().context("gid too large")?;
+    let user = header.username()?.map(String::from);
+    let group = header.groupname()?.map(String::from);
+    let mode = map_mode_to_go(header.mode()?);
+
+    let meta = Metadata {
+        size,
+        mtime: Some(mtime),
+        atime: None,
+        ctime: Some(mtime),
+        mode: Some(mode),
+        uid: Some(uid),
+        gid: Some(gid),
+        user,
+        group,
+        inode: 0,
+        device_id: 0,
+        links: 0,
+    };
+    let node_type = match header.entry_type() {
+        EntryType::Regular | EntryType::GNUSparse | EntryType::Continuous => NodeType::File,
+        EntryType::Symlink => {
+            let name_bytes = header
+                .link_name_bytes()
+                .context("Expected symlink entry to contain link name")?;
+            let link_name = String::from_utf8(name_bytes.into_owned())
+                .context("symlink name must be unicode")?;
+            NodeType::Symlink {
+                linktarget: link_name,
+            }
+        }
+        EntryType::Char => NodeType::Chardev {
+            device: make_dev(header)?,
+        },
+        EntryType::Block => NodeType::Dev {
+            device: make_dev(header)?,
+        },
+        EntryType::Directory => NodeType::Dir,
+        EntryType::Fifo => NodeType::Fifo,
+
+        EntryType::Link | EntryType::GNULongLink => bail!("hard links not implemented"),
+        other => bail!("unimplemented entry type: {other:?}"),
+    };
+    let node = Node::new_node(name, node_type, meta);
+    Ok((path.into_owned(), node))
+}
+
+#[derive(Default)]
+enum Entries<'a, R: Read> {
+    NoCurrentFile {
+        entries: tar::Entries<'a, R>,
+    },
+    Reading {
+        entries: tar::Entries<'a, R>,
+        entry: Box<tar::Entry<'a, R>>,
+    },
+    // Used as an in-between state, to allow stealing the
+    #[default]
+    Empty,
+}
+
+enum EntryReadResult<R: Read + 'static> {
+    StartedReader(Box<ReadSourceEntry<TarOpen<R>>>),
+    WaitForReaderDone,
+    NoMoreEntries,
+    Error(anyhow::Error),
+}
+
+impl<'a, R: Read> Entries<'a, R> {
+    fn done_with_entry(&mut self) {
+        match mem::take(self) {
+            Entries::Reading { entries, .. } => *self = Self::NoCurrentFile { entries },
+            _ => panic!("expected to be reading a tar entry"),
+        }
+    }
+
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        match self {
+            Entries::Reading { entry, .. } => entry.read(buf),
+            _ => panic!("expected to be reading a tar entry"),
+        }
+    }
+
+    fn read_entry(&mut self) -> EntryReadResult<R> {
+        let (new_self, result) = match mem::take(self) {
+            new_self @ Entries::Reading { .. } => (new_self, EntryReadResult::WaitForReaderDone),
+            Entries::NoCurrentFile { mut entries } => match entries.next() {
+                Some(Ok(entry)) => {
+                    match path_node_from_entry(&entry) {
+                        Ok((path, node)) => {
+                            let new_self = Entries::Reading {
+                                entries,
+                                entry: Box::new(entry),
+                            };
+                            (
+                                new_self,
+                                EntryReadResult::StartedReader(Box::new(ReadSourceEntry {
+                                    path,
+                                    node,
+                                    open: None,
+                                })),
+                            )
+                        }
+                        Err(e) => {
+                            (Entries::NoCurrentFile { entries }, EntryReadResult::Error(e))
+                        }
+                    }
+                }
+                Some(Err(e)) => (
+                    Entries::NoCurrentFile { entries },
+                    EntryReadResult::Error(e.into()),
+                ),
+                None => (
+                    Entries::NoCurrentFile { entries },
+                    EntryReadResult::NoMoreEntries,
+                ),
+            },
+            Entries::Empty => panic!("Never expect to see empty result"),
+        };
+        *self = new_self;
+        result
+    }
+}
+
+#[self_referencing]
+struct Reader<R: Read + 'static> {
+    archive: tar::Archive<R>,
+    #[borrows(mut archive)]
+    #[not_covariant]
+    entries: Entries<'this, R>,
+}
+
+// SAFETY:
+// Reader does not implement Send automatically because it contains (through `entries`) a reference
+// to a cell (also indirectly). &Cell is not Send because Cell is not Sync.
+// However: The entry's reference points into `archive` (and is not otherwise shared), and we will never separate them,
+// all accesses will go through `Reader`, and Reader will only be accessed through a mutex: all writes through the cell
+// will be synchronized via the mutex, and cannot be observed without the mutex.
+#[allow(unsafe_code)]
+unsafe impl<R: Read + 'static> Send for Reader<R> {}
+
+struct Data<R: Read + 'static> {
+    data: Mutex<Reader<R>>,
+    entry_read: Condvar,
+}
+
+impl<R: Read + 'static> Data<R> {
+    fn new(reader: Reader<R>) -> Self {
+        Data {
+            data: Mutex::new(reader),
+            entry_read: Condvar::new(),
+        }
+    }
+}
+
+impl<R: Read + 'static> Read for TarFile<R> {
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        let mut data = self.0.data.lock().unwrap();
+        data.with_entries_mut(|entries| entries.read(buf))
+    }
+}
+
+impl<R: Read + 'static> Drop for TarFile<R> {
+    fn drop(&mut self) {
+        let Ok(mut reader) = self.0.data.lock() else { return };
+        reader.with_entries_mut(|entries| {
+            entries.done_with_entry();
+        });
+        self.0.entry_read.notify_all();
+    }
+}
+
+impl<R: Read + Send + 'static> ReadSourceOpen for TarOpen<R> {
+    type Reader = TarFile<R>;
+
+    fn open(self, _path: &Path) -> Result<Self::Reader> {
+        Ok(self.0)
+    }
+}

--- a/src/commands/diff.rs
+++ b/src/commands/diff.rs
@@ -5,7 +5,7 @@ use anyhow::{anyhow, bail, Context, Result};
 use clap::Parser;
 
 use super::{progress_counter, RusticConfig};
-use crate::backend::{LocalBackend, LocalSource, LocalSourceOptions};
+use crate::backend::{LocalBackend, LocalSource, LocalSourceOptions, ReadSourceEntry};
 use crate::blob::{Node, NodeStreamer, NodeType, Tree};
 use crate::commands::helpers::progress_spinner;
 use crate::crypto::hash;
@@ -86,7 +86,7 @@ pub(super) fn execute(
                 .with_context(|| format!("Error accessing {path2:?}"))?
                 .is_dir();
             let src = LocalSource::new(opts.ignore_opts, path2.clone())?.map(|item| {
-                let (path, node) = item?;
+                let ReadSourceEntry { path, node, .. } = item?;
                 let path = if is_dir {
                     // remove given path prefix for dirs as local path
                     path.strip_prefix(&path2)?.to_path_buf()


### PR DESCRIPTION
This is a work in progress, but I'm planning to try to use this to stream a google takeout (which outputs multiple tar.gz archives, so I plan to concatenate them, un-gzip them, and pipe to rustic). This will allow me to backup my entire google takeout to backblaze without needing to store anything locally.

Similar to restic/restic#2226