### PR TITLE
Enable building on OpenBSD

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -47,6 +47,12 @@ jobs:
             architecture: i686
             binary-postfix: ""
             use-cross: true
+          - os: openbsd-latest
+            os-name: openbsd
+            target: x86_64-unknown-openbsd
+            architecture: x86_64
+            binary-postfix: ""
+            use-cross: true
 
     steps:
       - name: Checkout repository

--- a/src/backend/local.rs
+++ b/src/backend/local.rs
@@ -231,16 +231,16 @@ impl LocalBackend {
                 symlink(linktarget, filename)?;
             }
             NodeType::Dev { device } => {
-                #[cfg(not(target_os = "macos"))]
+                #[cfg(not(any(target_os = "macos", target_os = "openbsd")))]
                 let device = *device;
-                #[cfg(target_os = "macos")]
+                #[cfg(any(target_os = "macos", target_os = "openbsd"))]
                 let device = *device as i32;
                 mknod(&filename, SFlag::S_IFBLK, Mode::empty(), device)?;
             }
             NodeType::Chardev { device } => {
-                #[cfg(not(target_os = "macos"))]
+                #[cfg(not(any(target_os = "macos", target_os = "openbsd")))]
                 let device = *device;
-                #[cfg(target_os = "macos")]
+                #[cfg(any(target_os = "macos", target_os = "openbsd"))]
                 let device = *device as i32;
                 mknod(&filename, SFlag::S_IFCHR, Mode::empty(), device)?;
             }


### PR DESCRIPTION
This is needed to get rustic to build on OpenBSD. Lightly run tested the build against a local restic repo.