### PR TITLE
fix CI for *bsd

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -47,9 +47,9 @@ jobs:
             architecture: i686
             binary-postfix: ""
             use-cross: true
-          - os: openbsd-latest
-            os-name: openbsd
-            target: x86_64-unknown-openbsd
+          - os: ubuntu-latest
+            os-name: netbsd
+            target: x86_64-unknown-netbsd
             architecture: x86_64
             binary-postfix: ""
             use-cross: true

--- a/src/backend/local.rs
+++ b/src/backend/local.rs
@@ -231,17 +231,29 @@ impl LocalBackend {
                 symlink(linktarget, filename)?;
             }
             NodeType::Dev { device } => {
-                #[cfg(not(any(target_os = "macos", target_os = "openbsd")))]
+                #[cfg(not(any(
+                    target_os = "macos",
+                    target_os = "openbsd",
+                    target_os = "freebsd"
+                )))]
                 let device = *device;
                 #[cfg(any(target_os = "macos", target_os = "openbsd"))]
-                let device = *device as i32;
+                let device = i32::try_from(*device)?;
+                #[cfg(target_os = "freebsd")]
+                let device = u32::try_from(*device)?;
                 mknod(&filename, SFlag::S_IFBLK, Mode::empty(), device)?;
             }
             NodeType::Chardev { device } => {
-                #[cfg(not(any(target_os = "macos", target_os = "openbsd")))]
+                #[cfg(not(any(
+                    target_os = "macos",
+                    target_os = "openbsd",
+                    target_os = "freebsd"
+                )))]
                 let device = *device;
                 #[cfg(any(target_os = "macos", target_os = "openbsd"))]
-                let device = *device as i32;
+                let device = i32::try_from(*device)?;
+                #[cfg(target_os = "freebsd")]
+                let device = u32::try_from(*device)?;
                 mknod(&filename, SFlag::S_IFCHR, Mode::empty(), device)?;
             }
             NodeType::Fifo => {


### PR DESCRIPTION
openbsd seems to lack toolchain support, see e.g. https://github.com/rust-lang/rustup/issues/2168
freebsd got an linking error
So, only netbsd is added to the CI here...