### PR TITLE
New command merge

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ Improvements:
  * `restore` uses existing files; also option `--delete` available
  * Snapshots save much more information, available in `snapshots` command
  * Allows to save repository options in the repository config file via the command `config`
+ * New command `merge`
  * New command `repo-info`
  * `check` command checks and uses cache; option `--trust-cache` is available
  * Option `prune --fast-repack` for faster repacking

--- a/changelog/new.txt
+++ b/changelog/new.txt
@@ -8,6 +8,7 @@ Bugs fixed:
 
 New features:
 - New command dump has been added.
+- New command merge has been added.
 - Extra or wrong fields in the config file now lead to rustic complaining and aborting.
 - backup: Paths are now sanitized from command arguments and config file before matching and applying the configuration.
 - check --read-data: progress bar now also shows total bytes to check and ETA.

--- a/src/archiver/archiver_impl.rs
+++ b/src/archiver/archiver_impl.rs
@@ -284,12 +284,7 @@ impl<BE: DecryptWriteBackend, I: IndexedBackend> Archiver<BE, I> {
 
         self.indexer.write().unwrap().finalize()?;
 
-        let end_time = Local::now();
-        self.summary.backup_duration = (end_time - self.summary.backup_start)
-            .to_std()?
-            .as_secs_f64();
-        self.summary.total_duration = (end_time - self.snap.time).to_std()?.as_secs_f64();
-        self.summary.backup_end = end_time;
+        self.summary.finalize(self.snap.time)?;
         self.snap.summary = Some(self.summary);
         let id = self.be.save_file(&self.snap)?;
         self.snap.id = id;

--- a/src/archiver/archiver_impl.rs
+++ b/src/archiver/archiver_impl.rs
@@ -269,18 +269,10 @@ impl<BE: DecryptWriteBackend, I: IndexedBackend> Archiver<BE, I> {
         self.snap.tree = id;
 
         let stats = self.data_packer.finalize()?;
-        self.summary.data_blobs += stats.blobs;
-        self.summary.data_added += stats.data;
-        self.summary.data_added_packed += stats.data_packed;
-        self.summary.data_added_files += stats.data;
-        self.summary.data_added_files_packed += stats.data_packed;
+        stats.apply(&mut self.summary, BlobType::Data);
 
         let stats = self.tree_packer.finalize()?;
-        self.summary.tree_blobs += stats.blobs;
-        self.summary.data_added += stats.data;
-        self.summary.data_added_packed += stats.data_packed;
-        self.summary.data_added_trees += stats.data;
-        self.summary.data_added_trees_packed += stats.data_packed;
+        stats.apply(&mut self.summary, BlobType::Tree);
 
         self.indexer.write().unwrap().finalize()?;
 

--- a/src/commands/backup.rs
+++ b/src/commands/backup.rs
@@ -109,7 +109,7 @@ pub(super) fn execute(
 
     let config_sources: Vec<_> = config_opts
         .iter()
-        .filter_map(|opt| match PathList::from_string(&opt.source) {
+        .filter_map(|opt| match PathList::from_string(&opt.source, true) {
             Ok(paths) => Some(paths),
             Err(err) => {
                 warn!(
@@ -122,7 +122,7 @@ pub(super) fn execute(
         .collect();
 
     let sources = match (opts.cli_sources.is_empty(), config_opts.is_empty()) {
-        (false, _) => vec![PathList::from_strings(&opts.cli_sources)?],
+        (false, _) => vec![PathList::from_strings(&opts.cli_sources, true)?],
         (true, false) => {
             info!("using all backup sources from config file.");
             config_sources.clone()
@@ -138,7 +138,7 @@ pub(super) fn execute(
     for source in sources {
         let mut opts = opts.clone();
         let index = index.clone();
-        let backup_stdin = source == PathList::from_string("-")?;
+        let backup_stdin = source == PathList::from_string("-", false)?;
         let backup_path = if backup_stdin {
             vec![PathBuf::from(&opts.stdin_filename)]
         } else {

--- a/src/commands/merge_cmd.rs
+++ b/src/commands/merge_cmd.rs
@@ -1,0 +1,110 @@
+use anyhow::Result;
+use chrono::Local;
+use clap::{AppSettings, Parser};
+use log::*;
+
+use crate::backend::{DecryptWriteBackend, FileType};
+use crate::blob::{merge_trees, BlobType, Node, Packer, Tree};
+use crate::index::{IndexBackend, Indexer, ReadIndex};
+use crate::repofile::{PathList, SnapshotFile, SnapshotFilter, SnapshotOptions};
+use crate::repository::OpenRepository;
+
+use super::helpers::{progress_counter, progress_spinner};
+use super::rustic_config::RusticConfig;
+
+#[derive(Default, Parser)]
+#[clap(global_setting(AppSettings::DeriveDisplayOrder))]
+pub(super) struct Opts {
+    /// Output generated snapshot in json format
+    #[clap(long)]
+    json: bool,
+
+    /// Remove input snapshots after merging
+    #[clap(long)]
+    delete: bool,
+
+    #[clap(flatten)]
+    snap_opts: SnapshotOptions,
+
+    #[clap(flatten, help_heading = "SNAPSHOT FILTER OPTIONS")]
+    filter: SnapshotFilter,
+
+    /// Snapshots to merge. If none is given, use filter to filter from all snapshots.
+    #[clap(value_name = "ID")]
+    ids: Vec<String>,
+}
+
+pub(super) fn execute(
+    repo: OpenRepository,
+    mut opts: Opts,
+    config_file: RusticConfig,
+    command: String,
+) -> Result<()> {
+    let time = Local::now();
+
+    let be = &repo.dbe;
+    config_file.merge_into("snapshot-filter", &mut opts.filter)?;
+
+    let snapshots = match opts.ids.is_empty() {
+        true => SnapshotFile::all_from_backend(be, &opts.filter)?,
+        false => SnapshotFile::from_ids(be, &opts.ids)?,
+    };
+    let index = IndexBackend::only_full_trees(&be.clone(), progress_counter(""))?;
+
+    let indexer = Indexer::new(be.clone()).into_shared();
+    let packer = Packer::new(
+        be.clone(),
+        BlobType::Tree,
+        indexer.clone(),
+        &repo.config,
+        index.total_size(BlobType::Tree),
+    )?;
+
+    let mut snap = SnapshotFile::new_from_options(opts.snap_opts, time, command)?;
+    let paths = PathList::from_strings(snapshots.iter().flat_map(|snap| snap.paths.iter()), false)?;
+    snap.paths.set_paths(&paths.paths())?;
+
+    let mut summary = snap.summary.take().unwrap();
+    summary.backup_start = Local::now();
+
+    let p = progress_spinner("merging snapshots...");
+    let trees = snapshots.iter().map(|sn| sn.tree).collect();
+
+    let cmp = |n1: &Node, n2: &Node| n1.meta.mtime.cmp(&n2.meta.mtime);
+    let save = |tree: Tree| {
+        let (chunk, new_id) = tree.serialize()?;
+        let size = u64::try_from(chunk.len())?;
+        if !index.has_tree(&new_id) {
+            packer.add(&chunk, &new_id)?;
+        }
+        Ok((new_id, size))
+    };
+
+    let tree_merged = merge_trees(&index, trees, &cmp, &save, &mut summary)?;
+    snap.tree = tree_merged;
+
+    let stats = packer.finalize()?;
+    stats.apply(&mut summary, BlobType::Tree);
+    indexer.write().unwrap().finalize()?;
+    p.finish();
+
+    summary.finalize(time)?;
+    snap.summary = Some(summary);
+
+    let new_id = be.save_file(&snap)?;
+    snap.id = new_id;
+
+    if opts.json {
+        let mut stdout = std::io::stdout();
+        serde_json::to_writer_pretty(&mut stdout, &snap)?;
+    }
+    info!("saved new snapshot as {new_id}.");
+
+    if opts.delete {
+        let p = progress_counter("deleting old snapshots...");
+        let snap_ids = snapshots.iter().map(|sn| &sn.id);
+        be.delete_list(FileType::Snapshot, true, snap_ids, p)?;
+    }
+
+    Ok(())
+}

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -27,6 +27,7 @@ mod init;
 mod key;
 mod list;
 mod ls;
+mod merge_cmd;
 mod prune;
 mod repair;
 mod repoinfo;
@@ -118,6 +119,9 @@ enum Command {
 
     /// List file contents of a snapshot
     Ls(ls::Opts),
+
+    /// Merge snapshots
+    Merge(merge_cmd::Opts),
 
     /// Show a detailed overview of the snapshots within the repository
     Snapshots(snapshots::Opts),
@@ -221,6 +225,7 @@ pub fn execute() -> Result<()> {
         Command::Key(opts) => key::execute(repo, opts)?,
         Command::List(opts) => list::execute(repo, opts)?,
         Command::Ls(opts) => ls::execute(repo, opts, config_file)?,
+        Command::Merge(opts) => merge_cmd::execute(repo, opts, config_file, command)?,
         Command::SelfUpdate(_) => {} // already handled above
         Command::Snapshots(opts) => snapshots::execute(repo, opts, config_file)?,
         Command::Prune(opts) => prune::execute(repo, opts, vec![])?,

--- a/src/repofile/snapshotfile.rs
+++ b/src/repofile/snapshotfile.rs
@@ -28,7 +28,7 @@ pub struct SnapshotOptions {
     #[clap(long, value_name = "LABEL")]
     label: Option<String>,
 
-    /// Tags to add to backup (can be specified multiple times)
+    /// Tags to add to snapshot (can be specified multiple times)
     #[clap(long, value_name = "TAG[,TAG,..]")]
     #[serde_as(as = "Vec<DisplayFromStr>")]
     #[merge(strategy = merge::vec::overwrite_empty)]
@@ -573,6 +573,10 @@ impl StringList {
 
     pub fn formatln(&self) -> String {
         self.0.join("\n")
+    }
+
+    pub fn iter(&self) -> std::slice::Iter<String> {
+        self.0.iter()
     }
 }
 

--- a/src/repofile/snapshotfile.rs
+++ b/src/repofile/snapshotfile.rs
@@ -550,6 +550,18 @@ impl StringList {
         }
     }
 
+    pub fn set_paths(&mut self, paths: &[PathBuf]) -> Result<()> {
+        self.0 = paths
+            .iter()
+            .map(|p| {
+                Ok(p.to_str()
+                    .ok_or_else(|| anyhow!("non-unicode path {:?}", p))?
+                    .to_string())
+            })
+            .collect::<Result<Vec<_>>>()?;
+        Ok(())
+    }
+
     pub fn remove_all(&mut self, string_lists: Vec<StringList>) {
         self.0
             .retain(|s| !string_lists.iter().any(|sl| sl.contains(s)));


### PR DESCRIPTION
This PR adds the `merge` command which allows to merge multiple snapshots.
It also fixes a minor bug how multiple paths were saved using #458.

The merging strategy is as follows:
- If files only exist in one of the snapshots, add this file to the newly created one
- If files with identical names but different content exist, take the file with newest mtime.

closes #43 

TODO:

- [x] compute correct "paths" of merged snapshots
- [x] compute correct summary of merged snapshot, e.g. #files #dirs, total size, etc..
- [x] enable setting other snapshot info, like tags, label, ... (use default if all are identical?)
- [x] add `--json` flag
- [x] add `--delete` flag to remove original snapshots