### PR TITLE
Local backend hooks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1716,6 +1716,7 @@ name = "rustic-rs"
 version = "0.4.3-dev"
 dependencies = [
  "aes256ctr_poly1305aes",
+ "aho-corasick",
  "anyhow",
  "backoff",
  "base64 0.20.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,6 +60,7 @@ walkdir = "2"
 ignore = "0.4"
 nix = "0.26"
 filetime = "0.2"
+aho-corasick = "0.7"
 # rest backend
 reqwest = {version = "0.11", default-features = false, features = ["json", "rustls-tls", "stream", "blocking"] }
 backoff = "0.4"

--- a/examples/par2.toml
+++ b/examples/par2.toml
@@ -1,0 +1,18 @@
+# This is an example how to use the post-create-command and post-delete-command hooks to add
+# error correction files using par2create to a local repository.
+# The commands can use the variable %file, %type and %id which are replaced by the filename, the 
+# file type and the file id before calling the command.
+[repository]
+repository = "/tmp/repo"
+password = "test"
+
+[repository.options]
+# after saving a file in the repo, this command is called
+post-create-command = "par2create -qq -n1 -r5 %file"
+
+# after removing a file from the repo, this command is called.
+# Note that we want to use a "*" in the rm command, hence we have to call sh to resolve the wildcard!
+post-delete-command = "sh -c \"rm -f %file*.par2\""
+
+
+

--- a/src/commands/helpers.rs
+++ b/src/commands/helpers.rs
@@ -101,10 +101,8 @@ pub fn warm_up_command(packs: impl ExactSizeIterator<Item = Id>, command: &str) 
     for pack in packs {
         let actual_command = command.replace("%id", &pack.to_hex());
         debug!("calling {actual_command}...");
-        let mut commands = parse_command::<()>(&actual_command)?.1;
-        let status = Command::new(commands[0])
-            .args(&mut commands[1..])
-            .status()?;
+        let commands = parse_command::<()>(&actual_command)?.1;
+        let status = Command::new(commands[0]).args(&commands[1..]).status()?;
         if !status.success() {
             warn!("warm-up command was not successful for pack {pack:?}. {status}");
         }

--- a/src/id.rs
+++ b/src/id.rs
@@ -80,7 +80,7 @@ pub struct HexId([u8; HEX_LEN]);
 impl HexId {
     const EMPTY: Self = Self([b'0'; HEX_LEN]);
 
-    fn as_str(&self) -> &str {
+    pub fn as_str(&self) -> &str {
         // This is only ever filled with hex chars, which are ascii
         std::str::from_utf8(&self.0).unwrap()
     }


### PR DESCRIPTION
This PR adds the possibility to configure hooks (after creating files and after removing files) for the local backend.
This is currently only possible in the config file.
An example config to use the hook to create par2 error correction information is also added.

closes #445 