### PR TITLE
Allow multiple sources within one snapshot

### DIFF
--- a/changelog/new.txt
+++ b/changelog/new.txt
@@ -2,8 +2,10 @@ Changes in version x.x.x:
 
 Breaking changes:
 - Repository options in the config file must now be given under the `[repository]` section.
+- Backing up multiple sources on the command line now results in one instead of several snapshots.
 
 Bugs fixed:
 
 New features:
 - Extra or wrong fields in the config file now lead to rustic complaining and aborting.
+- backup: Paths are now sanitized from command arguments and config file before matching and applying the configuration.

--- a/src/backend/ignore.rs
+++ b/src/backend/ignore.rs
@@ -79,13 +79,12 @@ pub struct LocalSourceOptions {
 }
 
 impl LocalSource {
-    pub fn new(opts: LocalSourceOptions, backup_path: PathBuf) -> Result<Self> {
-        let mut walk_builder = WalkBuilder::new(backup_path);
-        /*
-         for path in &paths[1..] {
-            wb.add(path);
+    pub fn new(opts: LocalSourceOptions, backup_paths: &[impl AsRef<Path>]) -> Result<Self> {
+        let mut walk_builder = WalkBuilder::new(&backup_paths[0]);
+
+        for path in &backup_paths[1..] {
+            walk_builder.add(path);
         }
-        */
 
         let mut override_builder = OverrideBuilder::new("/");
 

--- a/src/commands/diff.rs
+++ b/src/commands/diff.rs
@@ -85,7 +85,7 @@ pub(super) fn execute(
                 .metadata()
                 .with_context(|| format!("Error accessing {path2:?}"))?
                 .is_dir();
-            let src = LocalSource::new(opts.ignore_opts, path2.clone())?.map(|item| {
+            let src = LocalSource::new(opts.ignore_opts, &[&path2])?.map(|item| {
                 let (path, node) = item?;
                 let path = if is_dir {
                     // remove given path prefix for dirs as local path


### PR DESCRIPTION
Note: This PR breaks the default behavior when multiple sources are given in the command line.
The old behavior was to generate one snapshot per source, now one snapshot is generated which contains all sources.

The behavior when no source is given is unchanged, i.e. here still all sources are read from the config file.
However, the config file now also accepts multiple path within one source, i.e. `source = "path1 path2"` is possible.

Moreover, with this PR paths given by command line or config file are always first sanitized before being used.
This is necessary to avoid confusion when users use paths in different order or overlapping paths in one place.
As side effect is that paths that cannot be sanitized (e.g. absolute paths not present in the system) will give an error.
Errors in the config file are ignored but a warning is logged.

TODO:
- [x] sanitize paths in args and in all `[sources]` and then compare
- [x] check `--set-path` behavior
- [x] output format of snapshots in logs

closes #457 