### PR TITLE
TOML config: Abort with error on unknown fields

### DIFF
--- a/changelog/new.txt
+++ b/changelog/new.txt
@@ -1,5 +1,9 @@
 Changes in version x.x.x:
 
+Breaking changes:
+- Repository options in the config file must now be given under the `[repository]` section.
+
 Bugs fixed:
 
 New features:
+- Extra or wrong fields in the config file now lead to rustic complaining and aborting.

--- a/src/backend/ignore.rs
+++ b/src/backend/ignore.rs
@@ -25,7 +25,7 @@ pub struct LocalSource {
 
 #[serde_as]
 #[derive(Default, Clone, Parser, Deserialize, Merge)]
-#[serde(default, rename_all = "kebab-case")]
+#[serde(default, rename_all = "kebab-case", deny_unknown_fields)]
 pub struct LocalSourceOptions {
     /// Save access time for files and directories
     #[clap(long)]

--- a/src/commands/backup.rs
+++ b/src/commands/backup.rs
@@ -24,7 +24,7 @@ use crate::repository::OpenRepository;
 #[serde_as]
 #[derive(Clone, Default, Parser, Deserialize, Merge)]
 #[clap(global_setting(AppSettings::DeriveDisplayOrder))]
-#[serde(default, rename_all = "kebab-case")]
+#[serde(default, rename_all = "kebab-case", deny_unknown_fields)]
 pub(super) struct Opts {
     /// Output generated snapshot in json format
     #[clap(long)]

--- a/src/commands/forget.rs
+++ b/src/commands/forget.rs
@@ -39,7 +39,7 @@ pub(super) struct Opts {
 #[serde_as]
 #[derive(Default, Parser, Deserialize, Merge)]
 #[clap(global_setting(AppSettings::DeriveDisplayOrder))]
-#[serde(default, rename_all = "kebab-case")]
+#[serde(default, rename_all = "kebab-case", deny_unknown_fields)]
 struct ConfigOpts {
     /// Group snapshots by any combination of host,label,paths,tags (default: "host,label,paths")
     #[clap(long, short = 'g', value_name = "CRITERION")]
@@ -163,7 +163,7 @@ pub(super) fn execute(
 #[serde_as]
 #[derive(Clone, PartialEq, Derivative, Parser, Deserialize, Merge)]
 #[derivative(Default)]
-#[serde(default, rename_all = "kebab-case")]
+#[serde(default, rename_all = "kebab-case", deny_unknown_fields)]
 pub(super) struct KeepOptions {
     /// Keep snapshots with this taglist (can be specified multiple times)
     #[clap(long, value_name = "TAG[,TAG,..]")]

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -62,7 +62,7 @@ struct Opts {
 
 #[serde_as]
 #[derive(Default, Parser, Deserialize, Merge)]
-#[serde(default, rename_all = "kebab-case")]
+#[serde(default, rename_all = "kebab-case", deny_unknown_fields)]
 struct GlobalOpts {
     /// Use this log level [default: info]
     #[clap(long, global = true, env = "RUSTIC_LOG_LEVEL")]
@@ -193,7 +193,6 @@ pub fn execute() -> Result<()> {
 
     let mut repo_opts = args.repository;
     config_file.merge_into("repository", &mut repo_opts)?;
-    config_file.merge_into("global", &mut repo_opts)?; // deprecated, but repo-options were originally under [global]
     let repo = Repository::new(repo_opts)?;
 
     if let Command::Init(opts) = args.command {

--- a/src/commands/rustic_config.rs
+++ b/src/commands/rustic_config.rs
@@ -30,7 +30,9 @@ impl RusticConfig {
             Value::Array(Vec::new())
         };
 
-        Ok(RusticConfig(config))
+        Ok(RusticConfig(
+            config.try_into().context("reading config file")?,
+        ))
     }
 
     fn get_value(&self, section: &str) -> Option<&Value> {
@@ -45,7 +47,10 @@ impl RusticConfig {
         Opts: Merge + Deserialize<'de>,
     {
         if let Some(value) = self.get_value(section) {
-            let config: Opts = value.clone().try_into()?;
+            let config: Opts = value
+                .clone()
+                .try_into()
+                .with_context(|| format!("reading section [{section}] in config file"))?;
             opts.merge(config);
         }
         Ok(())

--- a/src/repofile/snapshotfile.rs
+++ b/src/repofile/snapshotfile.rs
@@ -309,7 +309,7 @@ impl Ord for SnapshotFile {
 
 #[serde_as]
 #[derive(Default, Parser, Deserialize, Merge)]
-#[serde(default, rename_all = "kebab-case")]
+#[serde(default, rename_all = "kebab-case", deny_unknown_fields)]
 pub struct SnapshotFilter {
     /// Hostname to filter (can be specified multiple times)
     #[clap(long, value_name = "HOSTNAME")]

--- a/src/repository/mod.rs
+++ b/src/repository/mod.rs
@@ -30,7 +30,7 @@ use crate::repofile::{find_key_in_backend, ConfigFile};
 
 #[serde_as]
 #[derive(Default, Parser, Deserialize, Merge)]
-#[serde(default, rename_all = "kebab-case")]
+#[serde(default, rename_all = "kebab-case", deny_unknown_fields)]
 pub struct RepositoryOptions {
     /// Repository to use
     #[clap(short, long, global = true, env = "RUSTIC_REPOSITORY")]


### PR DESCRIPTION
closes #459 

This PR also removes the possibility to specify repository options under the `[global]` section. If you encounter errors, please move these options under `[repository]`.