### PR TITLE
Add scriptable snapshot filter option

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -45,6 +45,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "ahash"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c99f64d1e06488f620f932677e24bc6e2897582980441ae90a671415bd7ec2f"
+dependencies = [
+ "cfg-if",
+ "const-random",
+ "getrandom",
+ "once_cell",
+ "version_check",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "0.7.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -327,6 +340,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "const-random"
+version = "0.1.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "368a7a772ead6ce7e1de82bfb04c485f3db8ec744f72925af5735e29a22cc18e"
+dependencies = [
+ "const-random-macro",
+ "proc-macro-hack",
+]
+
+[[package]]
+name = "const-random-macro"
+version = "0.1.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d7d6ab3c3a2282db210df5f02c4dab6e0a7057af0fb7ebd4070f30fe05c0ddb"
+dependencies = [
+ "getrandom",
+ "once_cell",
+ "proc-macro-hack",
+ "tiny-keccak",
+]
+
+[[package]]
 name = "convert_case"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -423,6 +458,12 @@ checksum = "2ae1b35a484aa10e07fe0638d02301c5ad24de82d310ccbd2f3693da5f09bf1c"
 dependencies = [
  "winapi",
 ]
+
+[[package]]
+name = "crunchy"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
 
 [[package]]
 name = "crypto-common"
@@ -1498,6 +1539,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "proc-macro-hack"
+version = "0.5.20+deprecated"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc375e1527247fe1a97d8b7156678dfe7c1af2fc075c9a4db3690ecd2a148068"
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1677,6 +1724,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "rhai"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd29fa1f740be6dc91982013957e08c3c4232d7efcfe19e12da87d50bad47758"
+dependencies = [
+ "ahash",
+ "bitflags",
+ "instant",
+ "num-traits",
+ "rhai_codegen",
+ "serde",
+ "smallvec",
+ "smartstring",
+]
+
+[[package]]
+name = "rhai_codegen"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db74e3fdd29d969a0ec1f8e79171a6f0f71d0429293656901db382d248c4c021"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "ring"
 version = "0.16.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1793,6 +1867,7 @@ dependencies = [
  "rand",
  "rayon",
  "reqwest",
+ "rhai",
  "rpassword",
  "rstest",
  "scrypt",
@@ -2093,6 +2168,21 @@ name = "smallvec"
 version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "smartstring"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fb72c633efbaa2dd666986505016c32c3044395ceaf881518399d2f4127ee29"
+dependencies = [
+ "autocfg",
+ "serde",
+ "static_assertions",
+ "version_check",
+]
 
 [[package]]
 name = "socket2"
@@ -2265,6 +2355,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fd80a657e71da814b8e5d60d3374fc6d35045062245d80224748ae522dd76f36"
 dependencies = [
  "time-core",
+]
+
+[[package]]
+name = "tiny-keccak"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237"
+dependencies = [
+ "crunchy",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -87,7 +87,8 @@ humantime = "2"
 itertools = "0.10"
 simplelog = "0.12"
 comfy-table = "6.1.4"
-libc="0.2"
+libc = "0.2"
+rhai = {version = "1.13", features = ["sync", "serde", "no_optimize", "no_module", "no_custom_syntax", "only_i64"]}
 
 [target.'cfg(not(windows))'.dependencies]
 users = "0.11"

--- a/changelog/new.txt
+++ b/changelog/new.txt
@@ -9,6 +9,7 @@ Bugs fixed:
 
 New features:
 - Experimental windows support has been added.
+- New option --filter-fn allows to implement your own snapshot filter using the Rhai language.
 - New command dump has been added.
 - New command merge has been added.
 - Extra or wrong fields in the config file now lead to rustic complaining and aborting.

--- a/src/backend/rclone.rs
+++ b/src/backend/rclone.rs
@@ -114,7 +114,7 @@ impl RcloneBackend {
             bail!("url must start with http://! url: {url}");
         }
 
-        let url = "http://".to_string() + &user + ":" + &password + "@" + &url[7..];
+        let url = "http://".to_string() + user.as_str() + ":" + password.as_str() + "@" + &url[7..];
 
         debug!("using REST backend with url {url}.");
         let rest = RestBackend::new(&url)?;


### PR DESCRIPTION
This PR adds the option to filter snapshots by a given script in the [rhai](https://rhai.rs/book/index.html) scripting language.

You can use something like
```
rustic snapshots --filter '|sn| sn.time < "2023-03-08" && ("my_tag" in sn.tags ||  sn.host != "xx_host")'
```

Note that the filter options are available in many commend, e.g. `tag`, `forget`, `copy`, `merge` and all commands which allow to use `latest` as snapshot

All fields are available and are represented in Rhai as Object Map (i.e. like JSON).
Note that when comparing times, this is actually a string-compare!

TODO:
- [x] think about name: Maybe `--filter-by` or `--filter-func` is better? => `filter-fn` was chosen.
- [x] reuse initialization of rhai engine and function parsing
- [x] Error handling