### PR TITLE
OpenBSD does not support extended file attributes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -91,6 +91,8 @@ rhai = {version = "1.13", features = ["sync", "serde", "no_optimize", "no_module
 
 [target.'cfg(not(windows))'.dependencies]
 users = "0.11"
+
+[target.'cfg(not(any(windows, target_os="openbsd")))'.dependencies]
 xattr = "1"
 
 [dev-dependencies]

--- a/changelog/new.txt
+++ b/changelog/new.txt
@@ -3,5 +3,6 @@ Changes in version x.x.x:
 Breaking changes:
 
 Bugs fixed:
+- Fixed compiliation on OpenBSD.
 
 New features:

--- a/src/backend/local.rs
+++ b/src/backend/local.rs
@@ -324,7 +324,7 @@ impl LocalDestination {
         Ok(())
     }
 
-    #[cfg(windows)]
+    #[cfg(any(windows, target_os = "openbsd"))]
     pub fn set_extended_attributes(
         &self,
         _item: impl AsRef<Path>,
@@ -333,7 +333,7 @@ impl LocalDestination {
         Ok(())
     }
 
-    #[cfg(not(windows))]
+    #[cfg(not(any(windows, target_os = "openbsd")))]
     pub fn set_extended_attributes(
         &self,
         item: impl AsRef<Path>,


### PR DESCRIPTION
#522 breaks building on OpenBSD because there is no xattr support.