### PR TITLE
restore: Treat all existing contents correctly

### DIFF
--- a/src/backend/node.rs
+++ b/src/backend/node.rs
@@ -100,8 +100,19 @@ impl Node {
         self.node_type == NodeType::Dir
     }
 
-    pub fn is_symlink(&self) -> bool {
-        matches!(self.node_type, NodeType::Symlink { linktarget: _ })
+    pub fn is_file(&self) -> bool {
+        matches!(self.node_type, NodeType::File)
+    }
+
+    pub fn is_special(&self) -> bool {
+        matches!(
+            self.node_type,
+            NodeType::Symlink { linktarget: _ }
+                | NodeType::Dev { device: _ }
+                | NodeType::Chardev { device: _ }
+                | NodeType::Fifo
+                | NodeType::Socket
+        )
     }
 
     pub fn set_subtree(&mut self, id: Id) {

--- a/src/commands/restore.rs
+++ b/src/commands/restore.rs
@@ -302,8 +302,9 @@ fn allocate_and_collect(
                 }
                 Ordering::Equal => {
                     // process existing node
-                    if node.is_dir() != dst.file_type().unwrap().is_dir()
-                        || (node.is_symlink() != dst.file_type().unwrap().is_symlink())
+                    if (node.is_dir() && !dst.file_type().unwrap().is_dir())
+                        || (node.is_file() && !dst.metadata().unwrap().is_file())
+                        || node.is_special()
                     {
                         // if types do not match, first remove the existing file
                         process_existing(dst)?;


### PR DESCRIPTION
closes #561 (when used with `--delete`) 

Note that rustic never deletes existing files unless the `--delete` option is given. On the other side, it can only treat some situations like existing symlinks correctly by deleting and re-creating them. This means, this PR corrects the behavior for existing content when using `--delete` but doesn't fully help without `--delete`.