### PR TITLE
Optimize chunker

### DIFF
--- a/src/cdc/rolling_hash.rs
+++ b/src/cdc/rolling_hash.rs
@@ -12,6 +12,7 @@ pub trait RollingHash64 {
     fn get_hash(&self) -> &Polynom64;
 }
 
+#[derive(Clone)]
 pub struct Rabin64 {
     // Configuration
     window_size: usize, // The size of the data window used in the hash calculation.


### PR DESCRIPTION
This initializes the chunker once instead of once-per-file and therefore speeds up the backup of many files a lot.