### PR TITLE
prune: Add option --repack-all

### DIFF
--- a/changelog/new.txt
+++ b/changelog/new.txt
@@ -6,5 +6,6 @@ Bugs fixed:
 - restore: Warm-up options given by the command line didn't work. This has been fixed.
 
 New features:
+- prune: Added option --repack-all
 - Option --dry-run is now a global option and can also be defined in the config file or via env variable 
 - Updated to clap v4


### PR DESCRIPTION
This PR adds the `--repack-all` option to `prune` which simply repacks all packs.
This is handy if you want to change the compression (level) and ensure that each blob is re-compressed again.
Also nice to test repacking without the need to create repack reasons.