### PR TITLE
backup: fix dir stats

### DIFF
--- a/changelog/new.txt
+++ b/changelog/new.txt
@@ -4,6 +4,7 @@ Breaking changes:
 
 Bugs fixed:
 - restore: Warm-up options given by the command line didn't work. This has been fixed.
+- backup showed 1 dir as changed when backing up without parent. This has been fixed.
 
 New features:
 - prune: Added option --repack-all

--- a/src/archiver/tree_archiver.rs
+++ b/src/archiver/tree_archiver.rs
@@ -129,7 +129,7 @@ impl<BE: DecryptWriteBackend, I: IndexedBackend> TreeArchiver<BE, I> {
 
     pub fn finalize(mut self, parent_tree: Option<Id>) -> Result<(Id, SnapshotSummary)> {
         let parent = match parent_tree {
-            None => ParentResult::NotMatched,
+            None => ParentResult::NotFound,
             Some(id) => ParentResult::Matched(id),
         };
         let id = self.backup_tree(&PathBuf::new(), parent)?;


### PR DESCRIPTION
related to #541 - the case having no parent wasn't implemented properly.