### PR TITLE
forget: Interpret '--keep-X -1' as 'keep all X'

### DIFF
--- a/changelog/new.txt
+++ b/changelog/new.txt
@@ -9,6 +9,7 @@ Bugs fixed:
 
 New features:
 - backup: Backing up (small) files is now much more parallelized.
+- forget: Using "-1" as value for --keep-* options will keep all snapshots of that interval
 - prune: Added option --repack-all
 - Option --dry-run is now a global option and can also be defined in the config file or via env variable 
 - Updated to clap v4

--- a/src/commands/forget.rs
+++ b/src/commands/forget.rs
@@ -175,45 +175,45 @@ pub(super) struct KeepOptions {
     #[merge(strategy=merge::vec::overwrite_empty)]
     keep_ids: Vec<String>,
 
-    /// Keep the last N snapshots
-    #[clap(long, short = 'l', value_name = "N", default_value = "0")]
+    /// Keep the last N snapshots (N == -1: keep all snapshots)
+    #[clap(long, short = 'l', value_name = "N", default_value = "0", allow_hyphen_values = true, value_parser = clap::value_parser!(i32).range(-1..))]
     #[merge(strategy=merge::num::overwrite_zero)]
-    keep_last: u32,
+    keep_last: i32,
 
-    /// Keep the last N hourly snapshots
-    #[clap(long, short = 'H', value_name = "N", default_value = "0")]
+    /// Keep the last N hourly snapshots (N == -1: keep all hourly snapshots)
+    #[clap(long, short = 'H', value_name = "N", default_value = "0", allow_hyphen_values = true, value_parser = clap::value_parser!(i32).range(-1..))]
     #[merge(strategy=merge::num::overwrite_zero)]
-    keep_hourly: u32,
+    keep_hourly: i32,
 
-    /// Keep the last N daily snapshots
-    #[clap(long, short = 'd', value_name = "N", default_value = "0")]
+    /// Keep the last N daily snapshots (N == -1: keep all daily snapshots)
+    #[clap(long, short = 'd', value_name = "N", default_value = "0", allow_hyphen_values = true, value_parser = clap::value_parser!(i32).range(-1..))]
     #[merge(strategy=merge::num::overwrite_zero)]
-    keep_daily: u32,
+    keep_daily: i32,
 
-    /// Keep the last N weekly snapshots
-    #[clap(long, short = 'w', value_name = "N", default_value = "0")]
+    /// Keep the last N weekly snapshots (N == -1: keep all weekly snapshots)
+    #[clap(long, short = 'w', value_name = "N", default_value = "0", allow_hyphen_values = true, value_parser = clap::value_parser!(i32).range(-1..))]
     #[merge(strategy=merge::num::overwrite_zero)]
-    keep_weekly: u32,
+    keep_weekly: i32,
 
-    /// Keep the last N monthly snapshots
-    #[clap(long, short = 'm', value_name = "N", default_value = "0")]
+    /// Keep the last N monthly snapshots (N == -1: keep all monthly snapshots)
+    #[clap(long, short = 'm', value_name = "N", default_value = "0", allow_hyphen_values = true, value_parser = clap::value_parser!(i32).range(-1..))]
     #[merge(strategy=merge::num::overwrite_zero)]
-    keep_monthly: u32,
+    keep_monthly: i32,
 
-    /// Keep the last N quarter-yearly snapshots
-    #[clap(long, value_name = "N", default_value = "0")]
+    /// Keep the last N quarter-yearly snapshots (N == -1: keep all quarter-yearly snapshots)
+    #[clap(long, value_name = "N", default_value = "0", allow_hyphen_values = true, value_parser = clap::value_parser!(i32).range(-1..))]
     #[merge(strategy=merge::num::overwrite_zero)]
-    keep_quarter_yearly: u32,
+    keep_quarter_yearly: i32,
 
-    /// Keep the last N half-yearly snapshots
-    #[clap(long, value_name = "N", default_value = "0")]
+    /// Keep the last N half-yearly snapshots (N == -1: keep all half-yearly snapshots)
+    #[clap(long, value_name = "N", default_value = "0", allow_hyphen_values = true, value_parser = clap::value_parser!(i32).range(-1..))]
     #[merge(strategy=merge::num::overwrite_zero)]
-    keep_half_yearly: u32,
+    keep_half_yearly: i32,
 
-    /// Keep the last N yearly snapshots
-    #[clap(long, short = 'y', value_name = "N", default_value = "0")]
+    /// Keep the last N yearly snapshots (N == -1: keep all yearly snapshots)
+    #[clap(long, short = 'y', value_name = "N", default_value = "0", allow_hyphen_values = true, value_parser = clap::value_parser!(i32).range(-1..))]
     #[merge(strategy=merge::num::overwrite_zero)]
-    keep_yearly: u32,
+    keep_yearly: i32,
 
     /// Keep snapshots newer than DURATION relative to latest snapshot
     #[clap(long, value_name = "DURATION", default_value = "0h")]
@@ -404,10 +404,12 @@ impl KeepOptions {
 
         for (check_fun, counter, reason1, within, reason2) in keep_checks {
             if !has_next || last.is_none() || !check_fun(sn, last.unwrap()) {
-                if *counter > 0 {
-                    *counter -= 1;
+                if *counter != 0 {
                     keep = true;
                     reason.push(reason1);
+                    if *counter > 0 {
+                        *counter -= 1;
+                    }
                 }
                 if sn.time + Duration::from_std(*within).unwrap() > latest_time {
                     keep = true;


### PR DESCRIPTION
This PR interprets the use of value `-1` (negative 1) for `--keep-*` options to mean "keep all".

So `--keep-hourly -1` would mean "keep all hourly snapshots" etc:

```shell
$ ./target/release/rustic -r ~/rstc1/ forget --prune -n --keep-hourly -1
using no config file (./rustic.toml doesn't exist)
enter repository password: 
[INFO] repository local:/Users/thndrbrrr/rstc1/: password is correct.
[INFO] using cache at /Users/thndrbrrr/Library/Caches/rustic/a35ef0a3a66303a26a652040f5eb53d471fac3cf33779126b960c33184b59621
snapshots for (host [EP-ML-10471], label [], paths [/Users/thndrbrrr/devel/misc/thndrbrrr/rustic/test-bats])

| ID       | Time                | Host        | Label | Tags | Paths                                                              | Action | Reason |
|----------|---------------------|-------------|-------|------|--------------------------------------------------------------------|--------|--------|
| 564a8fc1 | 2023-04-18 15:11:01 | EP-ML-10471 |       |      | /Users/thndrbrrr/devel/misc/thndrbrrr/rustic/test-bats | keep   | hourly |
| cb51365f | 2023-04-18 14:55:39 | EP-ML-10471 |       |      | /Users/thndrbrrr/devel/misc/thndrbrrr/rustic/test-bats | keep   | hourly |
| 6556f929 | 2023-04-18 14:40:39 | EP-ML-10471 |       |      | /Users/thndrbrrr/devel/misc/thndrbrrr/rustic/test-bats | remove |        |
| b295de85 | 2023-04-18 14:25:38 | EP-ML-10471 |       |      | /Users/thndrbrrr/devel/misc/thndrbrrr/rustic/test-bats | remove |        |
| 71757a83 | 2023-04-18 14:10:37 | EP-ML-10471 |       |      | /Users/thndrbrrr/devel/misc/thndrbrrr/rustic/test-bats | remove |        |
| 4a0f8eda | 2023-04-18 13:55:37 | EP-ML-10471 |       |      | /Users/thndrbrrr/devel/misc/thndrbrrr/rustic/test-bats | keep   | hourly |
| 682089ba | 2023-04-18 13:40:36 | EP-ML-10471 |       |      | /Users/thndrbrrr/devel/misc/thndrbrrr/rustic/test-bats | remove |        |
| 2aba13bd | 2023-04-18 13:25:36 | EP-ML-10471 |       |      | /Users/thndrbrrr/devel/misc/thndrbrrr/rustic/test-bats | remove |        |
| 395d7796 | 2023-04-18 13:10:35 | EP-ML-10471 |       |      | /Users/thndrbrrr/devel/misc/thndrbrrr/rustic/test-bats | remove |        |
| 391f52e2 | 2023-04-18 13:09:23 | EP-ML-10471 |       |      | /Users/thndrbrrr/devel/misc/thndrbrrr/rustic/test-bats | remove |        |
| 511e4a5e | 2023-04-17 15:03:00 | EP-ML-10471 |       |      | /Users/thndrbrrr/devel/misc/thndrbrrr/rustic/test-bats | keep   | hourly |

would have removed the following snapshots:
 [6556f929ecd9ee122c60dd3eb3d4e972ed9481ffca2ef25607789d8859e6f4b9, b295de85959ef6778a988b0156f9dd5611faa3e05f2350a27f507d126dbede01, 71757a83f6a3fcdc52614b39440dbbf021149eb88a4bedb776dab19efa7810b1, 682089baca3cff22fdc2ee3f37041fa227e793b08b1e0e095d252d349479f8f9, 2aba13bd1116106e64b57bb95f2a5cbb9e43c52548cb6f82aba4bffafe7a6204, 395d779637861794ff6e2facaa863913ece2ce5827a4d5820b67c2830232913e, 391f52e29469a8d2724417619c910b2ec8223ea92cd57212d21690347b717513]
[00:00:00] reading index...               ████████████████████████████████████████          1/1                                                                                                  
[00:00:00] reading snapshots...           ████████████████████████████████████████          5/5                                                                                                  
[00:00:00] finding used blobs...          ████████████████████████████████████████          5/5                                                                                                  
[00:00:00] getting packs from repository...                                                                                                                                                      to repack:          0 packs,          0 blobs,        0 B
this removes:                         0 blobs,        0 B
to delete:          0 packs,          0 blobs,        0 B
total prune:                          0 blobs,        0 B
remaining:                          486 blobs,   14.5 MiB
unused size after prune:        0 B (0.00% of remaining size)

packs marked for deletion:          0,        0 B
 - complete deletion:               0,        0 B
 - keep marked:                     0,        0 B
 - recover:                         0,        0 B
```

The usage instructions have been updated accordingly:

```shell
$ ./target/release/rustic forget --help
rustic-forget 
Remove snapshots from the repository

USAGE:
    rustic forget [OPTIONS] [IDS]...

[---8<---snip---8<---]

RETENTION OPTIONS:
        --keep-tags <TAG[,TAG,..]>
            Keep snapshots with this taglist (can be specified multiple times)

        --keep-id <ID>
            Keep snapshots ids that start with ID (can be specified multiple times)

    -l, --keep-last <N>
            Keep the last N snapshots (N == -1: keep all snapshots) [default: 0]

    -H, --keep-hourly <N>
            Keep the last N hourly snapshots (N == -1: keep all hourly snapshots) [default: 0]

    -d, --keep-daily <N>
            Keep the last N daily snapshots (N == -1: keep all daily snapshots) [default: 0]

[---8<---snip---8<---]
```