### PR TITLE
Silence build warning on OpenBSD

### DIFF
--- a/src/backend/local.rs
+++ b/src/backend/local.rs
@@ -6,7 +6,7 @@ use std::path::{Path, PathBuf};
 use std::process::Command;
 
 use aho_corasick::AhoCorasick;
-#[cfg(not(windows))]
+#[cfg(not(any(windows, target_os = "openbsd")))]
 use anyhow::Context;
 use anyhow::{anyhow, bail, Result};
 use bytes::Bytes;


### PR DESCRIPTION
While building rustic-0.5.2 on OpenBSD current:

```
warning: unused import: `anyhow::Context`
  --> src/backend/local.rs:10:5
   |
10 | use anyhow::Context;
   |     ^^^^^^^^^^^^^^^
   |
note: the lint level is defined here
  --> src/main.rs:23:5
   |
23 |     unused,
   |     ^^^^^^
   = note: `#[warn(unused_imports)]` implied by `#[warn(unused)]`
```

Proposed diff should actually be part of 3d72aee.