### PR TITLE
Config updates

### DIFF
--- a/changelog/new.txt
+++ b/changelog/new.txt
@@ -1,6 +1,7 @@
 Changes in version x.x.x:
 
 Breaking changes:
+- config file: use-config now expects an array of config profiles to read.
 
 Bugs fixed:
 - The [[backup.sources]] section in the config file was ignored 0.5.2. This has been fixed.

--- a/changelog/new.txt
+++ b/changelog/new.txt
@@ -7,3 +7,4 @@ Bugs fixed:
 - The [[backup.sources]] section in the config file was ignored 0.5.2. This has been fixed.
 
 New features:
+- The show-config command has been added.

--- a/examples/full.toml
+++ b/examples/full.toml
@@ -7,7 +7,7 @@
 
 # Global options: These options are used for all commands. 
 [global]
-use-profile = "" 
+use-profile = [] 
 log-level = "info" # any of "off", "error", "warn", "info", "debug", "trace"; default: "info"
 log-file = "/path/to/rustic.log" # Default: not set
 no-progress = false

--- a/src/backend/ignore.rs
+++ b/src/backend/ignore.rs
@@ -31,7 +31,7 @@ pub struct LocalSource {
 }
 
 #[serde_as]
-#[derive(Default, Clone, Parser, Deserialize, Merge)]
+#[derive(Default, Clone, Debug, Parser, Deserialize, Merge)]
 #[serde(default, rename_all = "kebab-case", deny_unknown_fields)]
 pub struct LocalSourceSaveOptions {
     /// Save access time for files and directories
@@ -46,7 +46,7 @@ pub struct LocalSourceSaveOptions {
 }
 
 #[serde_as]
-#[derive(Default, Clone, Parser, Deserialize, Merge)]
+#[derive(Default, Clone, Debug, Parser, Deserialize, Merge)]
 #[serde(default, rename_all = "kebab-case", deny_unknown_fields)]
 pub struct LocalSourceFilterOptions {
     /// Glob pattern to exclude/include (can be specified multiple times)

--- a/src/commands/backup.rs
+++ b/src/commands/backup.rs
@@ -20,7 +20,7 @@ use crate::repofile::{
 };
 use crate::repository::OpenRepository;
 
-#[derive(Clone, Default, Parser, Deserialize, Merge)]
+#[derive(Clone, Default, Debug, Parser, Deserialize, Merge)]
 #[serde(default, rename_all = "kebab-case", deny_unknown_fields)]
 // Note: using cli_sources, sources and source within this strict is a hack to support serde(deny_unknown_fields)
 // for deserializing the backup options from TOML

--- a/src/commands/configfile.rs
+++ b/src/commands/configfile.rs
@@ -51,9 +51,8 @@ impl Config {
             let mut config: Self =
                 toml::from_str(&data).context("error reading TOML from config file")?;
             // if "use_profile" is defined in config file, merge this referenced profile first
-            if !config.global.use_profile.is_empty() {
-                let profile = config.global.use_profile.clone();
-                config.merge_profile(&profile)?;
+            for profile in &config.global.use_profile.clone() {
+                config.merge_profile(profile)?;
             }
             self.merge(config);
         } else {

--- a/src/commands/configfile.rs
+++ b/src/commands/configfile.rs
@@ -10,7 +10,7 @@ use crate::{repofile::SnapshotFilter, repository::RepositoryOptions};
 
 use super::{backup, copy, forget, GlobalOpts};
 
-#[derive(Default, Parser, Deserialize, Merge)]
+#[derive(Default, Debug, Parser, Deserialize, Merge)]
 #[serde(default, rename_all = "kebab-case", deny_unknown_fields)]
 pub struct Config {
     #[clap(flatten, next_help_heading = "Global options")]

--- a/src/commands/copy.rs
+++ b/src/commands/copy.rs
@@ -21,7 +21,7 @@ pub(super) struct Opts {
     ids: Vec<String>,
 }
 
-#[derive(Default, Deserialize, Merge)]
+#[derive(Default, Debug, Deserialize, Merge)]
 pub struct Targets {
     #[merge(strategy = merge::vec::overwrite_empty)]
     targets: Vec<RepositoryOptions>,

--- a/src/commands/forget.rs
+++ b/src/commands/forget.rs
@@ -32,7 +32,7 @@ pub(super) struct Opts {
 }
 
 #[serde_as]
-#[derive(Clone, Default, Parser, Deserialize, Merge)]
+#[derive(Clone, Default, Debug, Parser, Deserialize, Merge)]
 #[serde(default, rename_all = "kebab-case")]
 pub struct ConfigOpts {
     /// Group snapshots by any combination of host,label,paths,tags (default: "host,label,paths")
@@ -155,7 +155,7 @@ pub(super) fn execute(repo: OpenRepository, config: Config, mut opts: Opts) -> R
 }
 
 #[serde_as]
-#[derive(Clone, PartialEq, Derivative, Parser, Deserialize, Merge)]
+#[derive(Clone, Debug, PartialEq, Derivative, Parser, Deserialize, Merge)]
 #[derivative(Default)]
 #[serde(default, rename_all = "kebab-case", deny_unknown_fields)]
 pub(super) struct KeepOptions {

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -50,7 +50,7 @@ struct Args {
 }
 
 #[serde_as]
-#[derive(Default, Parser, Deserialize, Merge)]
+#[derive(Default, Debug, Parser, Deserialize, Merge)]
 #[serde(default, rename_all = "kebab-case", deny_unknown_fields)]
 pub struct GlobalOpts {
     /// Config profile to use. This parses the file `<PROFILE>.toml` in the config directory.
@@ -145,6 +145,9 @@ enum Command {
     /// Show a detailed overview of the snapshots within the repository
     Snapshots(snapshots::Opts),
 
+    /// Show the configuration which has been read from the config file(s)
+    ShowConfig,
+
     /// Update to the latest rustic release
     SelfUpdate(self_update::Opts),
 
@@ -177,6 +180,10 @@ pub fn execute() -> Result<()> {
         config.merge_profile(profile)?;
     }
 
+    if let Command::ShowConfig = args.command {
+        println!("{config:#?}");
+        return Ok(());
+    }
 
     // start logger
     let level_filter = config.global.log_level.unwrap_or(LevelFilter::Info);
@@ -260,6 +267,7 @@ pub fn execute() -> Result<()> {
         Command::Merge(opts) => merge_cmd::execute(repo, config, opts, command)?,
         Command::SelfUpdate(_) => {} // already handled above
         Command::Snapshots(opts) => snapshots::execute(repo, config, opts)?,
+        Command::ShowConfig => {} // already handled above
         Command::Prune(opts) => prune::execute(repo, config, opts, vec![])?,
         Command::Restore(opts) => restore::execute(repo, config, opts)?,
         Command::Repair(opts) => repair::execute(repo, config, opts)?,

--- a/src/repofile/snapshotfile.rs
+++ b/src/repofile/snapshotfile.rs
@@ -24,7 +24,7 @@ use crate::backend::{DecryptReadBackend, FileType, RepoFile};
 use crate::repository::parse_command;
 
 #[serde_as]
-#[derive(Clone, Default, Parser, Deserialize, Merge)]
+#[derive(Clone, Default, Debug, Parser, Deserialize, Merge)]
 #[serde(default, rename_all = "kebab-case", deny_unknown_fields)]
 pub struct SnapshotOptions {
     /// Label snapshot with given label
@@ -419,7 +419,7 @@ impl Ord for SnapshotFile {
     }
 }
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 struct SnapshotFn(FnPtr, AST);
 impl FromStr for SnapshotFn {
     type Err = anyhow::Error;
@@ -440,7 +440,7 @@ impl SnapshotFn {
 }
 
 #[serde_as]
-#[derive(Clone, Default, Parser, Deserialize, Merge)]
+#[derive(Clone, Default, Debug, Parser, Deserialize, Merge)]
 #[serde(default, rename_all = "kebab-case", deny_unknown_fields)]
 pub struct SnapshotFilter {
     /// Hostname to filter (can be specified multiple times)
@@ -471,7 +471,7 @@ pub struct SnapshotFilter {
     filter_fn: Option<SnapshotFn>,
 }
 
-#[derive(Clone, Default, DeserializeFromStr)]
+#[derive(Clone, Default, Debug, DeserializeFromStr)]
 pub struct SnapshotGroupCriterion {
     hostname: bool,
     label: bool,

--- a/src/repofile/snapshotfile.rs
+++ b/src/repofile/snapshotfile.rs
@@ -444,29 +444,29 @@ impl SnapshotFn {
 #[serde(default, rename_all = "kebab-case", deny_unknown_fields)]
 pub struct SnapshotFilter {
     /// Hostname to filter (can be specified multiple times)
-    #[clap(long, value_name = "HOSTNAME")]
+    #[clap(long, global = true, value_name = "HOSTNAME")]
     #[merge(strategy=merge::vec::overwrite_empty)]
     filter_host: Vec<String>,
 
     /// Label to filter (can be specified multiple times)
-    #[clap(long, value_name = "LABEL")]
+    #[clap(long, global = true, value_name = "LABEL")]
     #[merge(strategy=merge::vec::overwrite_empty)]
     filter_label: Vec<String>,
 
     /// Path list to filter (can be specified multiple times)
-    #[clap(long, value_name = "PATH[,PATH,..]")]
+    #[clap(long, global = true, value_name = "PATH[,PATH,..]")]
     #[serde_as(as = "Vec<DisplayFromStr>")]
     #[merge(strategy=merge::vec::overwrite_empty)]
     filter_paths: Vec<StringList>,
 
     /// Tag list to filter (can be specified multiple times)
-    #[clap(long, value_name = "TAG[,TAG,..]")]
+    #[clap(long, global = true, value_name = "TAG[,TAG,..]")]
     #[serde_as(as = "Vec<DisplayFromStr>")]
     #[merge(strategy=merge::vec::overwrite_empty)]
     filter_tags: Vec<StringList>,
 
     /// Function to filter snapshots
-    #[clap(long, value_name = "FUNC")]
+    #[clap(long, global = true, value_name = "FUNC")]
     #[serde_as(as = "Option<DisplayFromStr>")]
     filter_fn: Option<SnapshotFn>,
 }

--- a/src/repository/mod.rs
+++ b/src/repository/mod.rs
@@ -29,7 +29,7 @@ use crate::crypto::Key;
 use crate::repofile::{find_key_in_backend, ConfigFile};
 
 #[serde_as]
-#[derive(Clone, Default, Parser, Deserialize, Merge)]
+#[derive(Clone, Default, Debug, Parser, Deserialize, Merge)]
 #[serde(default, rename_all = "kebab-case", deny_unknown_fields)]
 pub struct RepositoryOptions {
     /// Repository to use


### PR DESCRIPTION
This PR optimizes the configuration of rustic:
- filter options can now be given at any place in the CLI
- rustic now allows multiple config files
- the command `show-config` has been added to display the configuration from config files