### PR TITLE
restore: Download multiple contiguous blobs in one request

### DIFF
--- a/changelog/new.txt
+++ b/changelog/new.txt
@@ -7,3 +7,4 @@ Bugs fixed:
 New features:
 - New global configuration paths are available, located at /etc/rustic/*.toml or %PROGRAMDATA%/rustic/config/*.toml, depending on your platform.
 - REST backend: Now allows to use custom TLS root certificates.
+- restore: The restore algorithm has been improved and should now be faster for remote repositories.


### PR DESCRIPTION
The restore command used to download each needed blob by its own.
This PR checks if there are many needed blobs which form a contiguous piece of data within a pack file and downloads them together.
This should reduce repository operations and speed-up the restore especially for remote/high latency backends.
Also the restore path is no longer saved once per blob in the file, but only once per file. So this PR should reduce memory for large files-to-restore.