### PR TITLE
xattrs: Allow null value in JSON

### DIFF
--- a/changelog/new.txt
+++ b/changelog/new.txt
@@ -4,6 +4,7 @@ Breaking changes:
 
 Bugs fixed:
 - backup crashed when there was a non-unicode link target. The crash has been fixed. However, non-unicode link targets are still unsupported.
+- Extended attributes which were saved with value null couldn't be handled. This has been fixed.
 
 New features:
 - copy: Added --init option to initialize uninitialized target repos


### PR DESCRIPTION
With this PR rustic doesn't fail when xattrs have a JSON `null` value.

Maybe closes #638 