### PR TITLE
backup: Don't crash on non-unicode link targets

### DIFF
--- a/changelog/new.txt
+++ b/changelog/new.txt
@@ -3,5 +3,6 @@ Changes in version x.x.x:
 Breaking changes:
 
 Bugs fixed:
+- backup crashed when there was a non-unicode link target. The crash has been fixed. However, non-unicode link targets are still unsupported.
 
 New features:


### PR DESCRIPTION
closes #650 
Note: This doesn't close #117, it only makes rustic not crash and ignore these links in the backup.