### PR TITLE
Use global config files when user-specific file doesn't exist

### DIFF
--- a/changelog/new.txt
+++ b/changelog/new.txt
@@ -5,3 +5,4 @@ Breaking changes:
 Bugs fixed:
 
 New features:
+- new global configuration paths are available, located at /etc/rustic/*.toml or %PROGRAMDATA%/rustic/config/*.toml, depending on your platform


### PR DESCRIPTION
Fixes #652 

For all profile names, it will look for configuration files in the following paths and in the following order:

- User-specific config path (same as it always was), e.g. `~/.config/rustic/{profile_name}.toml` on linux
- Global config path: `/etc/rustic/{profile_name}.toml` on Linux and MacOS, `%PROGRAMDATA%\config\rustic\{profile_name}.toml` on Windows
- Current directory: `./{profile_name}.toml`

It will just use the first found file, meaning that if you have a config in the user-specific config path, it will override the config with the same name in the global config path, ignoring everything on it. 

`use-profile` works normally, meaning you can have a user-specific config "inheriting" from the global config.

On smaller behavior changes, I removed the check if the directory exists, it will just check if the file exists directly, and I've fixed  `./{profile-name}.toml` (it was giving an error as it wasn't a canonical path, just had to change `AbsPathBuf::new` to `AbsPathBuf::canonicalize`). 

I haven't been able to test this on MacOS yet.

Is this how you think it should work?

# Example outputs

## Config files

`/etc/rustic/apple.toml`
```toml
[global]
```

`~/.config/rustic/banana.toml`
```toml
[global]
use-profile = ["apple"]
```

`./cocoa.toml`
```toml
[global]
use-profile = ["banana"]
```

## Outputs

```console
$ cargo run --quiet -- -P cocoa ls a
using config ./cocoa.toml
using config /home/bilko/.config/rustic/banana.toml
using config /home/bilko/.config/rustic/apple.toml
error: No repository given. Please use the --repository option.
```

```console
$ cargo run --quiet -- -P dragon-fruit ls a
using no config file, none of these exist: /home/bilko/.config/rustic/dragon-fruit.toml, /etc/rustic/dragon-fruit.toml, ./dragon-fruit.toml
error: No repository given. Please use the --repository option.
```

Let's change `banana.toml` to point to `apricot` instead:

```console
$ cargo run --quiet -- -P cocoa ls a
using config ./cocoa.toml
using config /home/bilko/.config/rustic/banana.toml
using no config file, none of these exist: /home/bilko/.config/rustic/apricot.toml, /etc/rustic/apricot.toml, ./apricot.toml
error: No repository given. Please use the --repository option.
```