### PR TITLE
feat: wait for password-command to exit

### DIFF
--- a/changelog/new.txt
+++ b/changelog/new.txt
@@ -10,3 +10,4 @@ New features:
 - restore: The restore algorithm has been improved and should now be faster for remote repositories.
 - restore: Files are now allocated just before being first processed. This allows easier resumed restores.
 - New option: `no-require-git` for backup - if enabled, a git repository is not required to apply `git-ignore` rule.
+- fix: wait for password-command to successfully exit, allowing to input something into the command, and read password from stdout.


### PR DESCRIPTION
Useful for commands that requires interactive input

tested on Linux