### PR TITLE
Refactor repoinfo

### DIFF
--- a/changelog/new.txt
+++ b/changelog/new.txt
@@ -11,3 +11,4 @@ New features:
 - restore: Files are now allocated just before being first processed. This allows easier resumed restores.
 - New option: `no-require-git` for backup - if enabled, a git repository is not required to apply `git-ignore` rule.
 - fix: wait for password-command to successfully exit, allowing to input something into the command, and read password from stdout.
+- repoinfo: Added new options --json, --only-files, --only-index

--- a/crates/rustic_core/src/backend.rs
+++ b/crates/rustic_core/src/backend.rs
@@ -15,6 +15,7 @@ use std::{io::Read, path::PathBuf};
 use bytes::Bytes;
 use displaydoc::Display;
 use log::trace;
+use serde::{Deserialize, Serialize};
 
 use crate::{backend::node::Node, error::BackendErrorKind, id::Id, RusticResult};
 
@@ -27,17 +28,22 @@ pub const ALL_FILE_TYPES: [FileType; 4] = [
 ];
 
 /// Type for describing the kind of a file that can occur.
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Display)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Display, Serialize, Deserialize)]
 pub enum FileType {
     /// config
+    #[serde(rename = "config")]
     Config,
     /// index
+    #[serde(rename = "index")]
     Index,
     /// keys
+    #[serde(rename = "key")]
     Key,
     /// snapshots
+    #[serde(rename = "snapshot")]
     Snapshot,
     /// data
+    #[serde(rename = "pack")]
     Pack,
 }
 

--- a/crates/rustic_core/src/commands.rs
+++ b/crates/rustic_core/src/commands.rs
@@ -1,2 +1,3 @@
 pub mod cat;
 pub mod check;
+pub mod repoinfo;

--- a/crates/rustic_core/src/commands/repoinfo.rs
+++ b/crates/rustic_core/src/commands/repoinfo.rs
@@ -1,0 +1,136 @@
+use crate::{
+    index::IndexEntry,
+    repofile::indexfile::{IndexFile, IndexPack},
+    BlobType, BlobTypeMap, DecryptReadBackend, FileType, OpenRepository, Progress, ProgressBars,
+    ReadBackend, Repository, RusticResult, ALL_FILE_TYPES,
+};
+
+#[derive(Default, Clone, Debug)]
+pub struct IndexInfos {
+    pub blobs: Vec<BlobInfo>,
+    pub blobs_delete: Vec<BlobInfo>,
+    pub packs: Vec<PackInfo>,
+    pub packs_delete: Vec<PackInfo>,
+}
+
+#[derive(Clone, Copy, Debug)]
+pub struct BlobInfo {
+    pub blob_type: BlobType,
+    pub count: u64,
+    pub size: u64,
+    pub data_size: u64,
+}
+
+impl BlobInfo {
+    pub fn add(&mut self, ie: IndexEntry) {
+        self.count += 1;
+        self.size += u64::from(ie.length);
+        self.data_size += u64::from(ie.data_length());
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+pub struct PackInfo {
+    pub blob_type: BlobType,
+    pub count: u64,
+    pub min_size: Option<u64>,
+    pub max_size: Option<u64>,
+}
+
+impl PackInfo {
+    pub fn add(&mut self, ip: &IndexPack) {
+        self.count += 1;
+        let size = u64::from(ip.pack_size());
+        self.min_size = self
+            .min_size
+            .map_or(Some(size), |min_size| Some(min_size.min(size)));
+        self.max_size = self
+            .max_size
+            .map_or(Some(size), |max_size| Some(max_size.max(size)));
+    }
+}
+
+pub(crate) fn collect_index_infos<P: ProgressBars>(
+    repo: &OpenRepository<P>,
+) -> RusticResult<IndexInfos> {
+    let mut blob_info = BlobTypeMap::<()>::default().map(|blob_type, _| BlobInfo {
+        blob_type,
+        count: 0,
+        size: 0,
+        data_size: 0,
+    });
+    let mut blob_info_delete = blob_info;
+    let mut pack_info = BlobTypeMap::<()>::default().map(|blob_type, _| PackInfo {
+        blob_type,
+        count: 0,
+        min_size: None,
+        max_size: None,
+    });
+    let mut pack_info_delete = pack_info;
+
+    let p = repo.pb.progress_counter("scanning index...");
+    for index in repo.dbe.stream_all::<IndexFile>(&p)? {
+        let index = index?.1;
+        for pack in &index.packs {
+            let tpe = pack.blob_type();
+            pack_info[tpe].add(pack);
+
+            for blob in &pack.blobs {
+                let ie = IndexEntry::from_index_blob(blob, pack.id);
+                blob_info[tpe].add(ie);
+            }
+        }
+
+        for pack in &index.packs_to_delete {
+            let tpe = pack.blob_type();
+            pack_info_delete[tpe].add(pack);
+            for blob in &pack.blobs {
+                let ie = IndexEntry::from_index_blob(blob, pack.id);
+                blob_info_delete[tpe].add(ie);
+            }
+        }
+    }
+    p.finish();
+
+    let info = IndexInfos {
+        blobs: blob_info.into_values().collect(),
+        blobs_delete: blob_info_delete.into_values().collect(),
+        packs: pack_info.into_values().collect(),
+        packs_delete: pack_info_delete.into_values().collect(),
+    };
+
+    Ok(info)
+}
+
+#[derive(Default, Clone, Debug)]
+pub struct RepoFileInfos {
+    pub files: Vec<RepoFileInfo>,
+    pub files_hot: Option<Vec<RepoFileInfo>>,
+}
+
+#[derive(Clone, Copy, Debug)]
+pub struct RepoFileInfo {
+    pub tpe: FileType,
+    pub count: u64,
+    pub size: u64,
+}
+
+pub(crate) fn collect_file_info(be: &impl ReadBackend) -> RusticResult<Vec<RepoFileInfo>> {
+    let mut files = Vec::with_capacity(ALL_FILE_TYPES.len());
+    for tpe in ALL_FILE_TYPES {
+        let list = be.list_with_size(tpe)?;
+        let count = list.len() as u64;
+        let size = list.iter().map(|f| u64::from(f.1)).sum();
+        files.push(RepoFileInfo { tpe, count, size });
+    }
+    Ok(files)
+}
+
+pub fn collect_file_infos<P: ProgressBars>(repo: &Repository<P>) -> RusticResult<RepoFileInfos> {
+    let p = repo.pb.progress_spinner("scanning files...");
+    let files = collect_file_info(&repo.be)?;
+    let files_hot = repo.be_hot.as_ref().map(collect_file_info).transpose()?;
+    p.finish();
+
+    Ok(RepoFileInfos { files, files_hot })
+}

--- a/crates/rustic_core/src/lib.rs
+++ b/crates/rustic_core/src/lib.rs
@@ -120,7 +120,10 @@ pub use crate::{
         BlobLocation, BlobType, BlobTypeMap, Initialize, Sum,
     },
     chunker::random_poly,
-    commands::check::CheckOpts,
+    commands::{
+        check::CheckOpts,
+        repoinfo::{BlobInfo, IndexInfos, PackInfo, RepoFileInfo, RepoFileInfos},
+    },
     crypto::{aespoly1305::Key, hasher::hash},
     error::{RusticError, RusticResult},
     file::{AddFileResult, FileInfos, RestoreStats},
@@ -142,5 +145,5 @@ pub use crate::{
         },
         RepoFile,
     },
-    repository::{parse_command, OpenRepository, RepoInfo, Repository, RepositoryOptions},
+    repository::{parse_command, OpenRepository, Repository, RepositoryOptions},
 };

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -16,7 +16,7 @@ use rayon::{
 use rustic_core::{
     parse_command, BlobType, DecryptWriteBackend, FileType, Id, IndexBackend, IndexedBackend,
     Indexer, NodeType, OpenRepository, Packer, Progress, ProgressBars, ReadBackend, ReadIndex,
-    RusticResult, SnapshotFile, TreeStreamerOnce, ALL_FILE_TYPES,
+    SnapshotFile, TreeStreamerOnce,
 };
 
 use crate::{application::RUSTIC_APP, config::progress_options::ProgressOptions};
@@ -272,37 +272,6 @@ pub fn table_right_from<I: IntoIterator<Item = T>, T: ToString>(start: usize, ti
         .for_each(|c| c.set_cell_alignment(CellAlignment::Right));
 
     table
-}
-
-pub fn print_file_info(text: &str, be: &impl ReadBackend) -> RusticResult<()> {
-    info!("scanning files...");
-
-    let mut table = table_right_from(1, ["File type", "Count", "Total Size"]);
-    let mut total_count = 0;
-    let mut total_size = 0;
-    for tpe in ALL_FILE_TYPES {
-        let list = be.list_with_size(tpe)?;
-        let count = list.len();
-        let size = list.iter().map(|f| u64::from(f.1)).sum();
-        _ = table.add_row([
-            format!("{tpe:?}"),
-            count.to_string(),
-            bytes_size_to_string(size),
-        ]);
-        total_count += count;
-        total_size += size;
-    }
-    println!("{text}");
-    _ = table.add_row([
-        "Total".to_string(),
-        total_count.to_string(),
-        bytes_size_to_string(total_size),
-    ]);
-
-    println!();
-    println!("{table}");
-    println!();
-    Ok(())
 }
 
 #[must_use]


### PR DESCRIPTION
Also adds new options `--json`, `--only-files`, `--only-index` to the `repoinfo` command.
Closes #627 