### PR TITLE
rest/rclone: make # of retries cusomizable and use sensible default

### DIFF
--- a/changelog/new.txt
+++ b/changelog/new.txt
@@ -4,6 +4,7 @@ Breaking changes:
 
 Bugs fixed:
 - prune did abort when no time was set for a pack-do-delete. This case is now handled correctly.
+- retrying backend access didn't work for long operations. This has been fixed (and retries are now customizable)
 
 New features:
 - New global configuration paths are available, located at /etc/rustic/*.toml or %PROGRAMDATA%/rustic/config/*.toml, depending on your platform.

--- a/config/full.toml
+++ b/config/full.toml
@@ -33,7 +33,7 @@ warm-up-wait = "10min" # Default: not set
 [repository.options]
 post-create-command = "par2create -qq -n1 -r5 %file" # Only local backend; Default: not set
 post-delete-command = "sh -c \"rm -f %file*.par2\"" # Only local backend; Default: not set 
-retry = "true" # Only rest/rclone backend
+retry = "default" # Only rest/rclone backend; Allowed values: "false"/"off", "default" or number of retries
 timeout = "10min" # Only rest/rclone backend
 
 # Snapshot-filter options: These options apply to all commands that use snapshot filters


### PR DESCRIPTION
Default number of retries is set to 5.