### PR TITLE
Systemd timers for backup and forget

### DIFF
--- a/util/systemd/rustic-backup@.service
+++ b/util/systemd/rustic-backup@.service
@@ -1,0 +1,8 @@
+[Unit]
+Description=rustic --use-profile %I backup
+
+[Service]
+Nice=19
+IOSchedulingClass=idle
+KillSignal=SIGINT
+ExecStart=/usr/bin/rustic --use-profile %I backup

--- a/util/systemd/rustic-backup@.timer
+++ b/util/systemd/rustic-backup@.timer
@@ -1,0 +1,12 @@
+[Unit]
+Description=Daily rustic --use-profile %I backup
+Wants=rustic-forget@%i.timer
+
+[Timer]
+OnCalendar=daily
+AccuracySec=1m
+RandomizedDelaySec=1h
+Persistent=true
+
+[Install]
+WantedBy=timers.target

--- a/util/systemd/rustic-forget@.service
+++ b/util/systemd/rustic-forget@.service
@@ -1,0 +1,6 @@
+[Unit]
+Description=rustic --use-profile %I forget
+
+[Service]
+KillSignal=SIGINT
+ExecStart=/usr/bin/rustic --use-profile %I forget

--- a/util/systemd/rustic-forget@.timer
+++ b/util/systemd/rustic-forget@.timer
@@ -1,0 +1,12 @@
+[Unit]
+Description=Monthly rustic --use-profile %I forget
+PartOf=rustic-backup@%i.timer
+
+[Timer]
+OnCalendar=monthly
+AccuracySec=1m
+RandomizedDelaySec=1h
+Persistent=true
+
+[Install]
+WantedBy=timers.target


### PR DESCRIPTION
(Related to [this discussion](https://github.com/rustic-rs/rustic/discussions/609#discussioncomment-6262498))

One thing that I think is particularly handy with crestic and config profiles is the possibility of creating systemd timers that periodically run backups and forgets. In the case of the config files of this PR, backup would run daily, forget would run monthly.

Right now the files in the PR are not really installed anywhere because `cargo build` doesn't support creating datafiles or creating Linux packages, so I guess it'd be the task of the downstream packagers to put these files in the packages. There are two locations where these files could go:

 - `/usr/lib/systemd/system/` for system units (i.e. run by `root` and config files in `/etc/`)
 - `/usr/lib/systemd/user` for user units (i.e. run by each user and config files in `~/.config/`)

However since rustic currenly seems to only read config files from `~/.config/rustic` and not from `/etc/rustic`, only user units make sense. Each individual user can then activate one ore more timers using

```
systemctl --user activate --now rustic-backup@PROFILENAME.timer
```

to have the system periodically run

```
rustic --user-profile PROFILENAME backup
```