### PR TITLE
Fix "forget" command not removing provided IDs' snapshots

### DIFF
--- a/src/commands/forget.rs
+++ b/src/commands/forget.rs
@@ -104,7 +104,7 @@ impl ForgetCmd {
                     .into_iter()
                     .map(|sn| ForgetSnapshot {
                         snapshot: sn,
-                        keep: true,
+                        keep: false,
                         reasons: vec!["id argument".to_string()],
                     })
                     .collect(),


### PR DESCRIPTION
Fix "forget" command not removing provided IDs' snapshots. Its says nothing to remove when there are snapshots matching  the id