### PR TITLE
refactor backup command

### DIFF
--- a/crates/rustic_core/examples/backup.rs
+++ b/crates/rustic_core/examples/backup.rs
@@ -1,0 +1,32 @@
+//! `backup` example
+use rustic_core::{BackupOpts, PathList, Repository, RepositoryOptions, SnapshotFile};
+use simplelog::{Config, LevelFilter, SimpleLogger};
+
+fn main() {
+    // Display info logs
+    let _ = SimpleLogger::init(LevelFilter::Info, Config::default());
+
+    // Open repository
+    let repo_opts = RepositoryOptions {
+        repository: Some("/tmp/repo".to_string()),
+        password: Some("test".to_string()),
+        ..Default::default()
+    };
+
+    let repo = Repository::new(&repo_opts)
+        .unwrap()
+        .open()
+        .unwrap()
+        .to_indexed_ids()
+        .unwrap();
+
+    let backup_opts = BackupOpts::default();
+    let source = PathList::from_string(".", true).unwrap(); // true: sanitize the given string
+    let dry_run = false;
+
+    let snap = repo
+        .backup(&backup_opts, source, SnapshotFile::default(), dry_run)
+        .unwrap();
+
+    println!("successfully created snapshot:\n{snap:#?}")
+}

--- a/crates/rustic_core/src/commands.rs
+++ b/crates/rustic_core/src/commands.rs
@@ -1,3 +1,4 @@
+pub mod backup;
 pub mod cat;
 pub mod check;
 pub mod config;

--- a/crates/rustic_core/src/commands/backup.rs
+++ b/crates/rustic_core/src/commands/backup.rs
@@ -1,0 +1,182 @@
+//! `backup` subcommand
+
+/// App-local prelude includes `app_reader()`/`app_writer()`/`app_config()`
+/// accessors along with logging macros. Customize as you see fit.
+use log::info;
+
+use std::path::PathBuf;
+
+use path_dedot::ParseDot;
+use serde::Deserialize;
+
+use crate::{
+    archiver::{parent::Parent, Archiver},
+    repository::{IndexedIds, IndexedTree},
+    DryRunBackend, Id, LocalSource, LocalSourceFilterOptions, LocalSourceSaveOptions, Open,
+    PathList, ProgressBars, Repository, RusticResult, SnapshotFile, SnapshotGroup,
+    SnapshotGroupCriterion, StdinSource,
+};
+
+/// `backup` subcommand
+#[cfg_attr(feature = "clap", derive(clap::Parser))]
+#[cfg_attr(feature = "merge", derive(merge::Merge))]
+#[derive(Clone, Default, Debug, Deserialize)]
+#[serde(default, rename_all = "kebab-case", deny_unknown_fields)]
+// Note: using sources and source within this struct is a hack to support serde(deny_unknown_fields)
+// for deserializing the backup options from TOML
+// Unfortunately we cannot work with nested flattened structures, see
+// https://github.com/serde-rs/serde/issues/1547
+// A drawback is that a wrongly set "source(s) = ..." won't get correct error handling and need to be manually checked, see below.
+#[allow(clippy::struct_excessive_bools)]
+pub struct ParentOpts {
+    /// Group snapshots by any combination of host,label,paths,tags to find a suitable parent (default: host,label,paths)
+    #[cfg_attr(feature = "clap", clap(long, short = 'g', value_name = "CRITERION",))]
+    pub group_by: Option<SnapshotGroupCriterion>,
+
+    /// Snapshot to use as parent
+    #[cfg_attr(
+        feature = "clap",
+        clap(long, value_name = "SNAPSHOT", conflicts_with = "force",)
+    )]
+    pub parent: Option<String>,
+
+    /// Use no parent, read all files
+    #[cfg_attr(feature = "clap", clap(long, short, conflicts_with = "parent",))]
+    #[cfg_attr(feature = "merge", merge(strategy = merge::bool::overwrite_false))]
+    pub force: bool,
+
+    /// Ignore ctime changes when checking for modified files
+    #[cfg_attr(feature = "clap", clap(long, conflicts_with = "force",))]
+    #[cfg_attr(feature = "merge", merge(strategy = merge::bool::overwrite_false))]
+    pub ignore_ctime: bool,
+
+    /// Ignore inode number changes when checking for modified files
+    #[cfg_attr(feature = "clap", clap(long, conflicts_with = "force",))]
+    #[cfg_attr(feature = "merge", merge(strategy = merge::bool::overwrite_false))]
+    pub ignore_inode: bool,
+}
+
+impl ParentOpts {
+    pub fn get_parent<P: ProgressBars, S: IndexedTree>(
+        &self,
+        repo: &Repository<P, S>,
+        snap: &SnapshotFile,
+        backup_stdin: bool,
+    ) -> (Option<Id>, Parent) {
+        let parent = match (backup_stdin, self.force, &self.parent) {
+            (true, _, _) | (false, true, _) => None,
+            (false, false, None) => {
+                // get suitable snapshot group from snapshot and opts.group_by. This is used to filter snapshots for the parent detection
+                let group = SnapshotGroup::from_sn(snap, self.group_by.unwrap_or_default());
+                SnapshotFile::latest(
+                    repo.dbe(),
+                    |snap| snap.has_group(&group),
+                    &repo.pb.progress_counter(""),
+                )
+                .ok()
+            }
+            (false, false, Some(parent)) => SnapshotFile::from_id(repo.dbe(), parent).ok(),
+        };
+
+        let (parent_tree, parent_id) = parent.map(|parent| (parent.tree, parent.id)).unzip();
+
+        (
+            parent_id,
+            Parent::new(
+                repo.index(),
+                parent_tree,
+                self.ignore_ctime,
+                self.ignore_inode,
+            ),
+        )
+    }
+}
+
+#[cfg_attr(feature = "clap", derive(clap::Parser))]
+#[cfg_attr(feature = "merge", derive(merge::Merge))]
+#[derive(Clone, Default, Debug, Deserialize)]
+#[serde(default, rename_all = "kebab-case", deny_unknown_fields)]
+pub struct BackupOpts {
+    /// Set filename to be used when backing up from stdin
+    #[cfg_attr(
+        feature = "clap",
+        clap(long, value_name = "FILENAME", default_value = "stdin")
+    )]
+    #[cfg_attr(feature = "merge", merge(skip))]
+    pub stdin_filename: String,
+
+    /// Manually set backup path in snapshot
+    #[cfg_attr(feature = "clap", clap(long, value_name = "PATH"))]
+    pub as_path: Option<PathBuf>,
+
+    #[cfg_attr(feature = "clap", clap(flatten))]
+    #[serde(flatten)]
+    pub parent_opts: ParentOpts,
+
+    #[cfg_attr(feature = "clap", clap(flatten))]
+    #[serde(flatten)]
+    pub ignore_save_opts: LocalSourceSaveOptions,
+
+    #[cfg_attr(feature = "clap", clap(flatten))]
+    #[serde(flatten)]
+    pub ignore_filter_opts: LocalSourceFilterOptions,
+}
+
+pub(crate) fn backup<P: ProgressBars, S: IndexedIds>(
+    repo: &Repository<P, S>,
+    opts: &BackupOpts,
+    source: PathList,
+    mut snap: SnapshotFile,
+    dry_run: bool,
+) -> RusticResult<SnapshotFile> {
+    let index = repo.index();
+
+    let backup_stdin = source == PathList::from_string("-", false)?;
+    let backup_path = if backup_stdin {
+        vec![PathBuf::from(&opts.stdin_filename)]
+    } else {
+        source.paths()
+    };
+
+    let as_path = opts
+        .as_path
+        .as_ref()
+        .map(|p| -> RusticResult<_> { Ok(p.parse_dot()?.to_path_buf()) })
+        .transpose()?;
+
+    match &as_path {
+        Some(p) => snap.paths.set_paths(&[p.clone()])?,
+        None => snap.paths.set_paths(&backup_path)?,
+    };
+
+    let (parent_id, parent) = opts.parent_opts.get_parent(repo, &snap, backup_stdin);
+    match parent_id {
+        Some(id) => {
+            info!("using parent {}", id);
+            snap.parent = Some(id);
+        }
+        None => {
+            info!("using no parent");
+        }
+    };
+
+    let be = DryRunBackend::new(repo.dbe().clone(), dry_run);
+    info!("starting to backup {source}...");
+    let archiver = Archiver::new(be, index.clone(), repo.config(), parent, snap)?;
+    let p = repo.pb.progress_bytes("determining size...");
+
+    let snap = if backup_stdin {
+        let path = &backup_path[0];
+        let src = StdinSource::new(path.clone())?;
+        archiver.archive(repo.index(), src, path, as_path.as_ref(), &p)?
+    } else {
+        let src = LocalSource::new(
+            opts.ignore_save_opts,
+            &opts.ignore_filter_opts,
+            &backup_path,
+        )?;
+        archiver.archive(repo.index(), src, &backup_path[0], as_path.as_ref(), &p)?
+    };
+
+    Ok(snap)
+}

--- a/crates/rustic_core/src/commands/cat.rs
+++ b/crates/rustic_core/src/commands/cat.rs
@@ -4,7 +4,7 @@ use bytes::Bytes;
 
 use crate::{
     error::CommandErrorKind,
-    repository::{Indexed, Open, Repository},
+    repository::{IndexedFull, IndexedTree, Open, Repository},
     BlobType, DecryptReadBackend, FileType, Id, IndexedBackend, ProgressBars, ReadBackend,
     RusticResult, SnapshotFile, Tree,
 };
@@ -19,7 +19,7 @@ pub(crate) fn cat_file<P, S: Open>(
     Ok(data)
 }
 
-pub(crate) fn cat_blob<P, S: Indexed>(
+pub(crate) fn cat_blob<P, S: IndexedFull>(
     repo: &Repository<P, S>,
     tpe: BlobType,
     id: &str,
@@ -30,7 +30,7 @@ pub(crate) fn cat_blob<P, S: Indexed>(
     Ok(data)
 }
 
-pub(crate) fn cat_tree<P: ProgressBars, S: Indexed>(
+pub(crate) fn cat_tree<P: ProgressBars, S: IndexedTree>(
     repo: &Repository<P, S>,
     snap: &str,
     sn_filter: impl FnMut(&SnapshotFile) -> bool + Send + Sync,

--- a/crates/rustic_core/src/commands/dump.rs
+++ b/crates/rustic_core/src/commands/dump.rs
@@ -2,11 +2,11 @@ use std::io::Write;
 
 use crate::{
     error::CommandErrorKind,
-    repository::{Indexed, Repository},
+    repository::{IndexedFull, IndexedTree, Repository},
     BlobType, IndexedBackend, Node, NodeType, RusticResult,
 };
 
-pub(crate) fn dump<P, S: Indexed>(
+pub(crate) fn dump<P, S: IndexedFull>(
     repo: &Repository<P, S>,
     node: &Node,
     w: &mut impl Write,

--- a/crates/rustic_core/src/commands/restore.rs
+++ b/crates/rustic_core/src/commands/restore.rs
@@ -17,9 +17,11 @@ use itertools::Itertools;
 use rayon::ThreadPoolBuilder;
 
 use crate::{
-    error::CommandErrorKind, hash, repository::Indexed, DecryptReadBackend, FileType, Id,
-    IndexedBackend, LocalDestination, Node, NodeType, Open, Progress, ProgressBars, ReadBackend,
-    Repository, RusticResult,
+    error::CommandErrorKind,
+    hash,
+    repository::{IndexedFull, IndexedTree},
+    DecryptReadBackend, FileType, Id, IndexedBackend, LocalDestination, Node, NodeType, Open,
+    Progress, ProgressBars, ReadBackend, Repository, RusticResult,
 };
 
 pub(crate) mod constants {
@@ -65,7 +67,7 @@ pub struct RestoreStats {
 }
 
 impl RestoreOpts {
-    pub(crate) fn restore<P: ProgressBars, S: Indexed>(
+    pub(crate) fn restore<P: ProgressBars, S: IndexedTree>(
         self,
         file_infos: RestoreInfos,
         repo: &Repository<P, S>,
@@ -83,7 +85,7 @@ impl RestoreOpts {
     }
 
     /// collect restore information, scan existing files, create needed dirs and remove superfluous files
-    pub(crate) fn collect_and_prepare<P: ProgressBars, S: Indexed>(
+    pub(crate) fn collect_and_prepare<P: ProgressBars, S: IndexedFull>(
         self,
         repo: &Repository<P, S>,
         mut node_streamer: impl Iterator<Item = RusticResult<(PathBuf, Node)>>,

--- a/crates/rustic_core/src/lib.rs
+++ b/crates/rustic_core/src/lib.rs
@@ -101,7 +101,6 @@ pub(crate) mod repository;
 
 // rustic_core Public API
 pub use crate::{
-    archiver::Archiver,
     backend::{
         cache::Cache,
         decrypt::{DecryptBackend, DecryptFullBackend, DecryptReadBackend, DecryptWriteBackend},
@@ -120,6 +119,7 @@ pub use crate::{
     },
     chunker::random_poly,
     commands::{
+        backup::{BackupOpts, ParentOpts},
         check::CheckOpts,
         config::ConfigOpts,
         forget::{ForgetGroup, ForgetGroups, ForgetSnapshot, KeepOptions},

--- a/crates/rustic_core/src/repofile/snapshotfile.rs
+++ b/crates/rustic_core/src/repofile/snapshotfile.rs
@@ -471,10 +471,10 @@ impl Ord for SnapshotFile {
 #[allow(clippy::struct_excessive_bools)]
 #[derive(DeserializeFromStr, Clone, Debug, Copy)]
 pub struct SnapshotGroupCriterion {
-    hostname: bool,
-    label: bool,
-    paths: bool,
-    tags: bool,
+    pub hostname: bool,
+    pub label: bool,
+    pub paths: bool,
+    pub tags: bool,
 }
 
 impl Default for SnapshotGroupCriterion {

--- a/src/commands/diff.rs
+++ b/src/commands/diff.rs
@@ -100,7 +100,7 @@ impl DiffCmd {
                     .is_dir();
                 let src = LocalSource::new(
                     LocalSourceSaveOptions::default(),
-                    self.ignore_opts.clone(),
+                    &self.ignore_opts,
                     &[&path2],
                 )?
                 .map(|item| {


### PR DESCRIPTION
This PR not only refactors the backup command, but also introduces several new states for `Repository`:
- `IndexedTree`: index contains only tree information
- `IndexedIds`: index additionally contains information about data IDs (e.g. needed for backup)
- IndexedFull: index contains all information

By using the state type pattern and suitable traits, methods on the `Repository` are restricted to what kind of index information is needed to process them. So, to run `backup`, you need to have either `IndexedIds` or `IndexedFull`. To run `ls`, any of the `Indexed*` states is valid. To run `prepare_restore` or `dump`, you need to be in the `IndexedFull` state.