### PR TITLE
handle non-unicode link-targets

### DIFF
--- a/changelog/new.txt
+++ b/changelog/new.txt
@@ -6,6 +6,7 @@ Bugs fixed:
 - prune did abort when no time was set for a pack-do-delete. This case is now handled correctly.
 - retrying backend access didn't work for long operations. This has been fixed (and retries are now customizable)
 - The zstd compression library led to data corruption in very unlikely cases. This has been fixed by a dependency update.
+- Non-unicode link targets are now correctly handled on Unix (after this has been added to the restic repo format).
 
 New features:
 - New global configuration paths are available, located at /etc/rustic/*.toml or %PROGRAMDATA%/rustic/config/*.toml, depending on your platform.

--- a/crates/rustic_core/src/backend/ignore.rs
+++ b/crates/rustic_core/src/backend/ignore.rs
@@ -313,15 +313,7 @@ fn map_entry(
         Node::new_node(name, NodeType::Dir, meta)
     } else if m.is_symlink() {
         let target = read_link(entry.path()).map_err(IgnoreErrorKind::FromIoError)?;
-        let node_type = NodeType::Symlink {
-            linktarget: target
-                .to_str()
-                .ok_or(IgnoreErrorKind::TargetIsNotValidUnicode {
-                    file: entry.path().to_path_buf(),
-                    target: target.clone(),
-                })?
-                .to_string(),
-        };
+        let node_type = NodeType::from_link(&target);
         Node::new_node(name, node_type, meta)
     } else {
         Node::new_node(name, NodeType::File, meta)
@@ -441,15 +433,7 @@ fn map_entry(
         Node::new_node(name, NodeType::Dir, meta)
     } else if m.is_symlink() {
         let target = read_link(entry.path()).map_err(IgnoreErrorKind::FromIoError)?;
-        let node_type = NodeType::Symlink {
-            linktarget: target
-                .to_str()
-                .ok_or_else(|| IgnoreErrorKind::TargetIsNotValidUnicode {
-                    file: entry.path().to_path_buf(),
-                    target: target.clone(),
-                })?
-                .to_string(),
-        };
+        let node_type = NodeType::from_link(&target);
         Node::new_node(name, node_type, meta)
     } else if filetype.is_block_device() {
         let node_type = NodeType::Dev { device: m.rdev() };

--- a/crates/rustic_core/src/backend/local.rs
+++ b/crates/rustic_core/src/backend/local.rs
@@ -488,12 +488,14 @@ impl LocalDestination {
         let filename = self.path(item);
 
         match &node.node_type {
-            NodeType::Symlink { linktarget } => symlink(linktarget.clone(), filename.clone())
-                .map_err(|err| LocalErrorKind::SymlinkingFailed {
-                    linktarget: linktarget.to_string(),
+            NodeType::Symlink { .. } => {
+                let linktarget = node.node_type.to_link();
+                symlink(linktarget, &filename).map_err(|err| LocalErrorKind::SymlinkingFailed {
+                    linktarget: linktarget.to_path_buf(),
                     filename,
                     source: err,
-                })?,
+                })?;
+            }
             NodeType::Dev { device } => {
                 #[cfg(not(any(
                     target_os = "macos",

--- a/crates/rustic_core/src/commands/restore.rs
+++ b/crates/rustic_core/src/commands/restore.rs
@@ -225,17 +225,7 @@ impl RestoreOpts {
                         // process existing node
                         if (node.is_dir() && !dst.file_type().unwrap().is_dir())
                             || (node.is_file() && !dst.metadata().unwrap().is_file())
-                            || {
-                                let this = &node;
-                                matches!(
-                                    this.node_type,
-                                    NodeType::Symlink { linktarget: _ }
-                                        | NodeType::Dev { device: _ }
-                                        | NodeType::Chardev { device: _ }
-                                        | NodeType::Fifo
-                                        | NodeType::Socket
-                                )
-                            }
+                            || node.is_special()
                         {
                             // if types do not match, first remove the existing file
                             process_existing(dst)?;

--- a/crates/rustic_core/src/error.rs
+++ b/crates/rustic_core/src/error.rs
@@ -669,7 +669,7 @@ pub enum LocalErrorKind {
     /// failed to symlink target {linktarget:?} from {filename:?} with {source:?}
     #[cfg(not(any(windows, target_os = "openbsd")))]
     SymlinkingFailed {
-        linktarget: String,
+        linktarget: PathBuf,
         filename: PathBuf,
         #[source]
         source: std::io::Error,

--- a/src/commands/diff.rs
+++ b/src/commands/diff.rs
@@ -194,14 +194,9 @@ fn diff(
                     NodeType::File if metadata && node1.meta != node2.meta => {
                         println!("U    {path:?}");
                     }
-                    NodeType::Symlink { linktarget } => {
-                        if let NodeType::Symlink {
-                            linktarget: linktarget2,
-                        } = &node2.node_type
-                        {
-                            if *linktarget != *linktarget2 {
-                                println!("U    {path:?}");
-                            }
+                    NodeType::Symlink { .. } => {
+                        if node1.node_type.to_link() != node1.node_type.to_link() {
+                            println!("U    {path:?}");
                         }
                     }
                     _ => {} // no difference to show

--- a/src/commands/ls.rs
+++ b/src/commands/ls.rs
@@ -137,8 +137,8 @@ fn print_node(node: &Node, path: &Path) {
             .mtime
             .map(|t| t.format("%_d %b %H:%M").to_string())
             .unwrap_or_else(|| "?".to_string()),
-        if let NodeType::Symlink { linktarget } = &node.node_type {
-            ["->", linktarget].join(" ")
+        if let NodeType::Symlink { .. } = &node.node_type {
+            ["->", &node.node_type.to_link().to_string_lossy()].join(" ")
         } else {
             String::new()
         }


### PR DESCRIPTION
After this has been added to the restic repository format (https://github.com/restic/restic/pull/3802), this can be also handled within rustic.

Note that for windows, this PR assumes that there are no non-unicode link-targets.

closes #117 