### PR TITLE
ci: Fail fast if something is not working out in build matrix

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -19,6 +19,7 @@ jobs:
     name: Publishing ${{ matrix.job.target }}
     runs-on: ${{ matrix.job.os }}
     strategy:
+      fail-fast: true # stop the build as soon as one job fails
       matrix:
         rust: [stable]
         job:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -18,6 +18,7 @@ jobs:
     name: Test
     runs-on: ${{ matrix.job.os }}
     strategy:
+      fail-fast: true # stop the build as soon as one job fails
       matrix:
         rust: [stable]
         job:

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 mutants.out
 cargo-test*
 coverage/*lcov
+coverage/lcov.info


### PR DESCRIPTION
I think that this would be better for the contingent of the CI hours (I think it's 2000 hours per month). If something doesn't work for one platform, we rather fix it anyway and don't release binaries for other platforms, as we can't be sure, that they won't have unintended side effects either?