### PR TITLE
chore: add support for `cargo-binstall`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -190,7 +190,9 @@ serde-aux = "4"
 # local backend
 walkdir = "2"
 ignore = "0.4"
-cached = {version = "0.44", default-features = false, features = ["proc_macro"]} 
+cached = { version = "0.44", default-features = false, features = [
+    "proc_macro",
+] }
 nix = "0.26"
 filetime = "0.2"
 aho-corasick = "1"
@@ -261,8 +263,14 @@ pretty_assertions = "1.4"
 toml = "0.7"
 dircmp = "0.2"
 
-# see: https://nnethercote.github.io/perf-book/build-configuration.html
+# cargo-binstall support
+# https://github.com/cargo-bins/cargo-binstall/blob/HEAD/SUPPORT.md
+[package.metadata.binstall]
+pkg-url = "{ repo }/releases/download/v{ version }/{ repo }-v{ version }-{ target }{ archive-suffix }"
+bin-dir = "{ bin }{ binary-ext }"
+pkg-fmt = "tar.gz"
 
+# see: https://nnethercote.github.io/perf-book/build-configuration.html
 [profile.dev]
 opt-level = 0
 debug = true


### PR DESCRIPTION
After merge, we can add that to the installation section's `From binaries` in #820
