### PR TITLE
ci: Lint markdown with dprint, run initial dprint fmt

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,6 +1,6 @@
-#[build]
-#rustflags = "-C target-cpu=native -D warnings"
-#incremental = true
+# [build]
+# rustflags = "-C target-cpu=native -D warnings"
+# incremental = true
 
 # TODO: Introduced for `cargo public-api` test,
 # remove when it is working on sparse registry

--- a/.github/workflows/lint-markdown-toml.yaml
+++ b/.github/workflows/lint-markdown-toml.yaml
@@ -1,4 +1,4 @@
-name: Lint Markdown
+name: Lint Markdown / Toml
 
 on:
   push:

--- a/.github/workflows/lint-markdown.yaml
+++ b/.github/workflows/lint-markdown.yaml
@@ -1,0 +1,14 @@
+name: Lint Markdown
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  style:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: dprint/check@v2.2

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,13 +20,19 @@ We appreciate your help in making this project better.
 
 ## Code of Conduct
 
-Please review and abide by the general Rust Community [Code of Conduct](https://www.rust-lang.org/policies/code-of-conduct) when contributing to this project. In the future, we might create our own Code of Conduct and supplement it at this location.
+Please review and abide by the general Rust Community
+[Code of Conduct](https://www.rust-lang.org/policies/code-of-conduct) when
+contributing to this project. In the future, we might create our own Code of
+Conduct and supplement it at this location.
 
 ## How to Contribute
 
 ### Reporting Bugs
 
-If you find a bug, please open an [issue on GitHub](https://github.com/rustic-rs/rustic/issues/new/choose) and provide as much detail as possible. Include steps to reproduce the bug and the expected behavior.
+If you find a bug, please open an
+[issue on GitHub](https://github.com/rustic-rs/rustic/issues/new/choose) and
+provide as much detail as possible. Include steps to reproduce the bug and the
+expected behavior.
 
 ### Issue and Pull Request labels
 
@@ -51,11 +57,15 @@ WG - Working group
 
 ### Suggesting Enhancements
 
-If you have an idea for an enhancement or a new feature, we'd love to hear it! Open an [issue on GitHub](https://github.com/rustic-rs/rustic/issues/new/choose) and describe your suggestion in detail.
+If you have an idea for an enhancement or a new feature, we'd love to hear it!
+Open an [issue on GitHub](https://github.com/rustic-rs/rustic/issues/new/choose)
+and describe your suggestion in detail.
 
 ### Code Style and Formatting
 
-We follow the Rust community's best practices for code style and formatting. Before submitting code changes, please ensure your code adheres to these guidelines:
+We follow the Rust community's best practices for code style and formatting.
+Before submitting code changes, please ensure your code adheres to these
+guidelines:
 
 - Use `rustfmt` to format your code. You can run it with the following command:
 
@@ -63,13 +73,16 @@ We follow the Rust community's best practices for code style and formatting. Bef
   cargo fmt --all
   ```
 
-- Write clear and concise code with meaningful, self-describing variable and function names. This tells the reader **what** the code does.
+- Write clear and concise code with meaningful, self-describing variable and
+  function names. This tells the reader **what** the code does.
 
-- Write clear and consise comments to tell the reader **why** you chose to implement it that way and **which** problem it solves.
+- Write clear and consise comments to tell the reader **why** you chose to
+  implement it that way and **which** problem it solves.
 
 ### Testing
 
-We value code quality and maintainability. If you are adding new features or making changes, please include relevant unit tests. Run the test suite with:
+We value code quality and maintainability. If you are adding new features or
+making changes, please include relevant unit tests. Run the test suite with:
 
 ```bash
 cargo test --workspace
@@ -101,32 +114,40 @@ To contribute code changes, follow these steps:
    git push origin feature/your-feature-name
    ```
 
-5. **Open** a Pull Request (PR) to our repository. Please include a detailed description of the changes and reference any related issues.
+5. **Open** a Pull Request (PR) to our repository. Please include a detailed
+   description of the changes and reference any related issues.
 
 #### `Release early and often!` also applies to pull requests
 
-Consider drafting a Pull request early in the development process, so we can follow your progress and can give early feedback.
+Consider drafting a Pull request early in the development process, so we can
+follow your progress and can give early feedback.
 
-Once your PR is submitted, it will be reviewed by the maintainers. We may suggest changes or ask for clarifications before merging.
+Once your PR is submitted, it will be reviewed by the maintainers. We may
+suggest changes or ask for clarifications before merging.
 
 #### IMPORTANT NOTE
 
-Please don't force push commits in your branch, in order to keep commit history and make it easier for us to see changes between reviews.
+Please don't force push commits in your branch, in order to keep commit history
+and make it easier for us to see changes between reviews.
 
-Make sure to Allow edits of maintainers (under the text box) in the PR so people can actually collaborate on things or fix smaller issues themselves.
+Make sure to Allow edits of maintainers (under the text box) in the PR so people
+can actually collaborate on things or fix smaller issues themselves.
 
 #### Rebasing and other workflows
 
-(taken from: [openage on rebasing](https://github.com/SFTtech/openage/blob/master/doc/contributing.md#rebasing))
+(taken from:
+[openage on rebasing](https://github.com/SFTtech/openage/blob/master/doc/contributing.md#rebasing))
 
 **Rebasing** is 'moving' your commits to a different parent commit.
 
-In other words: _Cut off_ your branch from its tree, and _attach it_ somewhere else.
+In other words: *Cut off* your branch from its tree, and *attach it* somewhere
+else.
 
 There's two main applications:
 
-- If you based your work on a older master (so old that stuff can't be automatically merged),
-  you can rebase to move your commits to the current [upstream](https://help.github.com/articles/fork-a-repo/) master:
+- If you based your work on a older master (so old that stuff can't be
+  automatically merged), you can rebase to move your commits to the current
+  [upstream](https://help.github.com/articles/fork-a-repo/) master:
 
 ```bash
 # update the upstream remote to receive new commits
@@ -142,8 +163,9 @@ git branch my-awesome-feature-backup
 git rebase -m upstream/master
 ```
 
-- If you want to fix an older commit of yours, or merge several commits into a single one (**squash** them), rebase interactively.
-  We _**don't**_ want to have a commit history like this:
+- If you want to fix an older commit of yours, or merge several commits into a
+  single one (**squash** them), rebase interactively. We ***don't*** want to
+  have a commit history like this:
 
   - `add stuff`
   - `fix typo in stuff`
@@ -153,17 +175,18 @@ git rebase -m upstream/master
 
 ##### `rebase` in practice
 
-`git log --graph --oneline` shows your commit history as graph.
-To make some changes in that graph, you do an **interactive rebase**:
+`git log --graph --oneline` shows your commit history as graph. To make some
+changes in that graph, you do an **interactive rebase**:
 
 ```sh
 git rebase -i -m upstream/master
 ```
 
-With this command, your new "base" is `upstream/master` and you can
-then change any of your branch's commits.
+With this command, your new "base" is `upstream/master` and you can then change
+any of your branch's commits.
 
-`-i` will open an interactive editor where you can choose actions for each individual commit:
+`-i` will open an interactive editor where you can choose actions for each
+individual commit:
 
 - re-order commits
 - drop commits by deleting their line
@@ -175,10 +198,13 @@ Just follow the messages on screen.
 
 ##### Changing commits with `amend` and `fixup`
 
-There's also `git commit --amend` which is a "mini-rebase" that modifies just the last commit with your current changes by `git add`.
-It just skips the creation of a new commit and instead melds the changes into the last one you made.
+There's also `git commit --amend` which is a "mini-rebase" that modifies just
+the last commit with your current changes by `git add`. It just skips the
+creation of a new commit and instead melds the changes into the last one you
+made.
 
-If you want to update a single commit in the range `[upstream/master, current HEAD]` which is not the last commit:
+If you want to update a single commit in the range
+`[upstream/master, current HEAD]` which is not the last commit:
 
 - `edit stuff you wanna change in some previous commit`
 - `git add changed_stuff`
@@ -187,15 +213,19 @@ If you want to update a single commit in the range `[upstream/master, current HE
 
 ##### Pushing changes
 
-After you have rebased stuff (["rewritten history"](https://www.youtube.com/watch?v=9lXuZHkOoH8)) that had already been pushed,
-git will not accept your pushes because they're not simple fast-forwards:
+After you have rebased stuff
+(["rewritten history"](https://www.youtube.com/watch?v=9lXuZHkOoH8)) that had
+already been pushed, git will not accept your pushes because they're not simple
+fast-forwards:
 
-- The commit contents and the parent commit have changed as you updated the commit, therefore the commit hash changed, too.
-  - If somebody used those commits, they will keep a copy
-    and have a hard time updating to your updated version (because they "use" the old hashes).
+- The commit contents and the parent commit have changed as you updated the
+  commit, therefore the commit hash changed, too.
+  - If somebody used those commits, they will keep a copy and have a hard time
+    updating to your updated version (because they "use" the old hashes).
   - Update your pull request branch with your re-written history!
 
-- **force push** is the standard way of overwriting your development work with the fixed and mergeable version of your contribution!
+- **force push** is the standard way of overwriting your development work with
+  the fixed and mergeable version of your contribution!
   - Why? You changed the commits, so you want the old ones to be deleted!
 
   You can use any of:
@@ -211,11 +241,14 @@ Some extra tutorials on `git rebase`:
 
 ## Development Setup
 
-If you want to set up a local development environment, follow the steps in the [development guide](/docs/dev/development_guide.md) file - which is currently being worked on.
+If you want to set up a local development environment, follow the steps in the
+[development guide](/docs/dev/development_guide.md) file - which is currently
+being worked on.
 
 ## License
 
-By contributing to `rustic` or any crates contained in this repository, you agree that your contributions will be licensed under:
+By contributing to `rustic` or any crates contained in this repository, you
+agree that your contributions will be licensed under:
 
 - [Apache License, Version 2.0](./LICENSE-APACHE)
 - [MIT license](./LICENSE-MIT).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -73,6 +73,14 @@ guidelines:
   cargo fmt --all
   ```
 
+- Use `dprint` to format text in markdown, toml, and json. You can install it
+  with `cargo install dprint` and run it with the following command in the
+  repository root:
+
+  ```bash
+  dprint fmt
+  ```
+
 - Write clear and concise code with meaningful, self-describing variable and
   function names. This tells the reader **what** the code does.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -121,7 +121,7 @@ Make sure to Allow edits of maintainers (under the text box) in the PR so people
 
 **Rebasing** is 'moving' your commits to a different parent commit.
 
-In other words: *Cut off* your branch from its tree, and *attach it* somewhere else.
+In other words: _Cut off_ your branch from its tree, and _attach it_ somewhere else.
 
 There's two main applications:
 
@@ -143,7 +143,7 @@ git rebase -m upstream/master
 ```
 
 - If you want to fix an older commit of yours, or merge several commits into a single one (**squash** them), rebase interactively.
-  We ***don't*** want to have a commit history like this:
+  We _**don't**_ want to have a commit history like this:
 
   - `add stuff`
   - `fix typo in stuff`

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,21 +11,21 @@ rustic - fast, encrypted, deduplicated backups powered by Rust
 """
 
 [package]
-version = { workspace = true }
 name = "rustic-rs"
+version = { workspace = true }
 authors = ["Alexander Weiss"]
-description = { workspace = true }
+categories = { workspace = true }
+documentation = "https://docs.rs/rustic-rs"
 edition = { workspace = true }
-resolver = "2"
-rust-version = "1.65.0"
+homepage = { workspace = true }
+include = ["src/**/*", "LICENSE-*", "README.md"]
+keywords = { workspace = true }
 license = { workspace = true }
 readme = "README.md"
-documentation = "https://docs.rs/rustic-rs"
-homepage = { workspace = true }
 repository = { workspace = true }
-keywords = { workspace = true }
-categories = { workspace = true }
-include = ["src/**/*", "LICENSE-*", "README.md"]
+resolver = "2"
+rust-version = "1.65.0"
+description = { workspace = true }
 
 [workspace]
 members = ["crates/rustic_core", "crates/rustic_testing", "xtask"]
@@ -38,22 +38,22 @@ bench = true
 doc = true
 harness = true
 edition = "2021"
-#required-features = []  
+# required-features = []
 
 [dependencies]
-rustic_core = { workspace = true }
 abscissa_core = { workspace = true }
+rustic_core = { workspace = true }
 
 # errors
 anyhow = { workspace = true }
 thiserror = { workspace = true }
 
 # macros
-derive_more = { workspace = true }
 derivative = { workspace = true }
+derive_more = { workspace = true }
 derive_setters = { workspace = true }
 
-#logging
+# logging
 log = { workspace = true }
 tracing-appender = { workspace = true }
 tracing-error = { workspace = true }
@@ -64,10 +64,10 @@ semver = { workspace = true }
 
 # parallelize
 crossbeam-channel = { workspace = true }
-rayon = { workspace = true }
 pariter = { workspace = true }
+rayon = { workspace = true }
 
-#crypto
+# crypto
 aes256ctr_poly1305aes = { workspace = true }
 rand = { workspace = true }
 scrypt = { workspace = true }
@@ -79,57 +79,56 @@ integer-sqrt = { workspace = true }
 binrw = { workspace = true }
 hex = { workspace = true }
 serde = { workspace = true }
-serde_with = { workspace = true }
-serde_json = { workspace = true }
 serde-aux = { workspace = true }
+serde_json = { workspace = true }
+serde_with = { workspace = true }
 
 # other dependencies
 bytes = { workspace = true }
 chrono = { workspace = true }
-zstd = { workspace = true }
 enum-map = { workspace = true }
 enum-map-derive = { workspace = true }
 self_update = { workspace = true }
+zstd = { workspace = true }
 
 # local backend
-walkdir = { workspace = true }
+aho-corasick = { workspace = true }
+filetime = { workspace = true }
 ignore = { workspace = true }
 nix = { workspace = true }
-filetime = { workspace = true }
-aho-corasick = { workspace = true }
+walkdir = { workspace = true }
 
 # cache
-dirs = { workspace = true }
 cachedir = { workspace = true }
+dirs = { workspace = true }
 
 # commands
 clap = { workspace = true }
 clap_complete = { workspace = true }
 merge = { workspace = true }
 
-directories = { workspace = true }
-shell-words = { workspace = true }
-dialoguer = "0.10.4"
 bytesize = { workspace = true }
-indicatif = { workspace = true }
-path-dedot = { workspace = true }
+comfy-table = { workspace = true }
+dialoguer = "0.10.4"
+directories = { workspace = true }
 dunce = { workspace = true }
 gethostname = { workspace = true }
 humantime = { workspace = true }
+indicatif = { workspace = true }
 itertools = { workspace = true }
-simplelog = { workspace = true }
-comfy-table = { workspace = true }
+path-dedot = { workspace = true }
 rhai = { workspace = true }
+shell-words = { workspace = true }
+simplelog = { workspace = true }
 
 [dev-dependencies]
-rustic_testing = { path = "crates/rustic_testing" }
-once_cell = { workspace = true }
-pretty_assertions = { workspace = true }
-tempfile = { workspace = true }
 aho-corasick = { workspace = true }
 dircmp = { workspace = true }
+once_cell = { workspace = true }
+pretty_assertions = { workspace = true }
+rustic_testing = { path = "crates/rustic_testing" }
+tempfile = { workspace = true }
 toml = { workspace = true }
-
 
 [target.'cfg(not(windows))'.dependencies]
 sha2 = { version = "0.10", features = ["asm"] }
@@ -143,9 +142,7 @@ sha2 = "0.10"
 xattr = "1"
 
 [workspace.dependencies]
-rustic_core = { path = "crates/rustic_core/", features = [
-    "cli",
-], version = "0" }
+rustic_core = { path = "crates/rustic_core/", features = ["cli"], version = "0" }
 abscissa_core = "0.7.0"
 
 # logging
@@ -163,7 +160,7 @@ derive_more = "0.99"
 derivative = "2"
 derive_setters = "0.1"
 
-#logging
+# logging
 log = "0.4"
 
 # parallelize
@@ -171,7 +168,7 @@ crossbeam-channel = "0.5"
 rayon = "1"
 pariter = "0.5"
 
-#crypto
+# crypto
 aes256ctr_poly1305aes = "0.1"
 rand = "0.8"
 scrypt = { version = "0.11", default-features = false }
@@ -190,18 +187,13 @@ serde-aux = "4"
 # local backend
 walkdir = "2"
 ignore = "0.4"
-cached = {version = "0.44", default-features = false, features = ["proc_macro"]} 
+cached = { version = "0.44", default-features = false, features = ["proc_macro"] }
 nix = "0.26"
 filetime = "0.2"
 aho-corasick = "1"
 
 # rest backend
-reqwest = { version = "0.11", default-features = false, features = [
-    "json",
-    "rustls-tls-native-roots",
-    "stream",
-    "blocking",
-] }
+reqwest = { version = "0.11", default-features = false, features = ["json", "rustls-tls-native-roots", "stream", "blocking"] }
 backoff = "0.4"
 url = "2.3.1"
 
@@ -210,21 +202,11 @@ semver = "1"
 
 # other dependencies
 bytes = "1"
-chrono = { version = "0.4", default-features = false, features = [
-    "clock",
-    "serde",
-] }
+chrono = { version = "0.4", default-features = false, features = ["clock", "serde"] }
 zstd = "0.12"
 enum-map = "2"
 enum-map-derive = "0.13"
-rhai = { version = "1.15", features = [
-    "sync",
-    "serde",
-    "no_optimize",
-    "no_module",
-    "no_custom_syntax",
-    "only_i64",
-] }
+rhai = { version = "1.15", features = ["sync", "serde", "no_optimize", "no_module", "no_custom_syntax", "only_i64"] }
 simplelog = "0.12"
 comfy-table = "6.1.4"
 
@@ -246,11 +228,7 @@ humantime = "2"
 clap_complete = "4"
 clap = { version = "4", features = ["derive", "env", "wrap_help"] }
 once_cell = "1.17"
-self_update = { version = "0.36", default-features = false, features = [
-    "rustls",
-    "archive-tar",
-    "compression-flate2",
-] }
+self_update = { version = "0.36", default-features = false, features = ["rustls", "archive-tar", "compression-flate2"] }
 
 # dev dependencies
 rstest = "0.17"
@@ -273,7 +251,7 @@ codegen-units = 4
 
 [profile.release]
 opt-level = 3
-debug = false            # true for profiling
+debug = false # true for profiling
 rpath = false
 lto = "fat"
 debug-assertions = false
@@ -291,7 +269,7 @@ codegen-units = 4
 
 [profile.bench]
 opt-level = 3
-debug = true             # true for profiling
+debug = true # true for profiling
 rpath = false
 lto = true
 debug-assertions = false

--- a/README.md
+++ b/README.md
@@ -7,11 +7,11 @@
 
 ## Contact
 
-Contact          | Where?
------------------|-------
-Issue Tracker    | [GitHub Issues](https://github.com/rustic-rs/rustic/issues)
-Discord | [![](https://dcbadge.vercel.app/api/server/WRUWENZnzQ)](https://discord.gg/WRUWENZnzQ)
-Discussions      | [GitHub Discussions](https://github.com/rustic-rs/rustic/discussions)
+| Contact       | Where?                                                                                 |
+| ------------- | -------------------------------------------------------------------------------------- |
+| Issue Tracker | [GitHub Issues](https://github.com/rustic-rs/rustic/issues)                            |
+| Discord       | [![](https://dcbadge.vercel.app/api/server/WRUWENZnzQ)](https://discord.gg/WRUWENZnzQ) |
+| Discussions   | [GitHub Discussions](https://github.com/rustic-rs/rustic/discussions)                  |
 
 ## About
 
@@ -67,16 +67,13 @@ Licensed under either of:
 at your option.
 
 [//]: # (badges)
-
 [crate-image]: https://img.shields.io/crates/v/rustic-rs.svg
 [crate-link]: https://crates.io/crates/rustic-rs
 [docs-image]: https://docs.rs/rustic-rs/badge.svg
 [docs-link]: https://docs.rs/rustic-rs/
 [license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
 [downloads-image]: https://img.shields.io/crates/d/rustic-rs.svg
-
 [//]: # (general links)
-
 [1]: https://github.com/restic/restic
 [2]: https://github.com/restic/restic/blob/master/doc/design.rst
 [3]: https://github.com/rustic-rs/rustic/discussions

--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # rustic - fast, encrypted, deduplicated backups powered by Rust
 
-[![crate][crate-image]][crate-link]
-[![Docs][docs-image]][docs-link]
+[![crate][crate-image]][crate-link] [![Docs][docs-image]][docs-link]
 ![Apache2/MIT licensed][license-image]
 [![Crates.io Downloads][downloads-image]][crate-link]
 
@@ -15,28 +14,36 @@
 
 ## About
 
-Rustic is a backup tool that provides fast, encrypted, deduplicated backups written in [Rust](https://www.rust-lang.org/).
-It reads and writes the [restic][1] repo format described in the [design document][2]
-and can be used as a restic replacement in most cases.
+Rustic is a backup tool that provides fast, encrypted, deduplicated backups
+written in [Rust](https://www.rust-lang.org/). It reads and writes the
+[restic][1] repo format described in the [design document][2] and can be used as
+a restic replacement in most cases.
 
-Rustic supports the major operating systems (Linux, MacOs, *BSD), Windows support is experimental.
+Rustic supports the major operating systems (Linux, MacOs, *BSD), Windows
+support is experimental.
 
 Note that rustic currently is in a beta release and misses regression tests.
 
-You can ask questions in the [Discussions][3] or have a look at the [FAQ](docs/FAQ.md).
+You can ask questions in the [Discussions][3] or have a look at the
+[FAQ](docs/FAQ.md).
 
 ## Features
 
 - Backup data is deduplicated and encrypted.
 - Backup storage can be local or cloud storages, including cold storages.
-- Allows multiple clients to concurrently access a backup repository using lock-free operations.
+- Allows multiple clients to concurrently access a backup repository using
+  lock-free operations.
 - Backups by default are append-only on the repository.
-- The operations are robustly designed and can be safely aborted and efficiently resumed.
-- Snapshot organization is possible by hostname, backup paths, label and tags. Also a rich set of metadata is saved with each snapshot.
+- The operations are robustly designed and can be safely aborted and efficiently
+  resumed.
+- Snapshot organization is possible by hostname, backup paths, label and tags.
+  Also a rich set of metadata is saved with each snapshot.
 - Retention policies and cleaning of old backups can be highly customized.
-- Follow-up backups only process changed files, but still create a complete backup snapshot.
+- Follow-up backups only process changed files, but still create a complete
+  backup snapshot.
 - In-place restore only modifies files which are changed.
-- Can use config files for easy configuration of all every-day commands, see [example config files](/config/).
+- Can use config files for easy configuration of all every-day commands, see
+  [example config files](/config/).
 
 ## Quick start
 
@@ -45,7 +52,8 @@ You can ask questions in the [Discussions][3] or have a look at the [FAQ](docs/F
 ## Are binaries available?
 
 Sure. Check out the [releases](https://github.com/rustic-rs/rustic/releases).
-Binaries for the latest development version are available [here](https://github.com/rustic-rs/rustic-beta).
+Binaries for the latest development version are available
+[here](https://github.com/rustic-rs/rustic-beta).
 
 ## What is the difference between rustic and restic?
 

--- a/config/README.md
+++ b/config/README.md
@@ -1,8 +1,14 @@
 # Rustic Configuration Specification
 
-`rustic` is a backup tool that allows users to define their backup options using a TOML configuration file. The configuration file consists of various sections and attributes that control the behavior of `rustic` for different commands and sources.
+`rustic` is a backup tool that allows users to define their backup options using
+a TOML configuration file. The configuration file consists of various sections
+and attributes that control the behavior of `rustic` for different commands and
+sources.
 
-This specification covers all the available sections and attributes in the `rustic` configuration file and includes their corresponding environment variable names. Users can customize their backup behavior by modifying these attributes according to their needs.
+This specification covers all the available sections and attributes in the
+`rustic` configuration file and includes their corresponding environment
+variable names. Users can customize their backup behavior by modifying these
+attributes according to their needs.
 
 ## Merge Precedence
 
@@ -10,132 +16,145 @@ The merge precedence for values is:
 
     Commandline Arguments >> Environment Variables >> Configuration File
 
-Values parsed from the `configuration file` can be overwritten by `environment variables`, which can be overwritten by `commandline arguments` options. Therefore `commandline arguments` have the highest precedence.
+Values parsed from the `configuration file` can be overwritten by
+`environment variables`, which can be overwritten by `commandline arguments`
+options. Therefore `commandline arguments` have the highest precedence.
 
 **NOTE**: There are the following restrictions:
 
-- You can overwrite values, but for most values, you cannot "unset" them on a higher priority level.
+- You can overwrite values, but for most values, you cannot "unset" them on a
+  higher priority level.
 
-- For some integer values, you cannot even overwrite with the value `0`, e.g. `keep-weekly = 5` in the `[forget]` section of the config file cannot be overwritten by `--keep-weekly 0`.
+- For some integer values, you cannot even overwrite with the value `0`, e.g.
+  `keep-weekly = 5` in the `[forget]` section of the config file cannot be
+  overwritten by `--keep-weekly 0`.
 
 ## Profiles
 
-Configuration files can be placed in the user's local config directory, e.g. `~/.config/rustic/`.
-You can use a different config files, e.g. `myconfig.toml` and use the `-P` option to specify the profile name, e.g. `rustic -P myconfig.toml`.
-Examples for different configuration files can be found here in the [/config/](/config) directory.
+Configuration files can be placed in the user's local config directory, e.g.
+`~/.config/rustic/`. You can use a different config files, e.g. `myconfig.toml`
+and use the `-P` option to specify the profile name, e.g.
+`rustic -P myconfig.toml`. Examples for different configuration files can be
+found here in the [/config/](/config) directory.
 
 ## Sections and Attributes
 
 ### Global Options
 
-| Attribute         | Description                                            | Default Value  | Example Value | Environment Variable |
-|-------------------|--------------------------------------------------------|----------------|---------------|---------------|
-| dry-run           | If true, performs a dry run without making any changes. | false       || RUSTIC_DRY_RUN |
-| log-level         | Logging level. Possible values: "off", "error", "warn", "info", "debug", "trace". | "info" || RUSTIC_LOG_LEVEL |
-| log-file          | Path to the log file.                                 | No log file | "/log/rustic.log" | RUSTIC_LOG_FILE |
-| no-progress       | If true, disables progress indicators.               | false          || RUSTIC_NO_PROGRESS |
-| progress-interval | The interval at which progress indicators are shown. | "100ms"        | "1m" | RUSTIC_PROGRESS_INTERVAL |
-| use-profile       | An array of profiles to use.                           | Empty array    || RUSTIC_USE_PROFILE |
+| Attribute         | Description                                                                       | Default Value | Example Value     | Environment Variable     |
+| ----------------- | --------------------------------------------------------------------------------- | ------------- | ----------------- | ------------------------ |
+| dry-run           | If true, performs a dry run without making any changes.                           | false         |                   | RUSTIC_DRY_RUN           |
+| log-level         | Logging level. Possible values: "off", "error", "warn", "info", "debug", "trace". | "info"        |                   | RUSTIC_LOG_LEVEL         |
+| log-file          | Path to the log file.                                                             | No log file   | "/log/rustic.log" | RUSTIC_LOG_FILE          |
+| no-progress       | If true, disables progress indicators.                                            | false         |                   | RUSTIC_NO_PROGRESS       |
+| progress-interval | The interval at which progress indicators are shown.                              | "100ms"       | "1m"              | RUSTIC_PROGRESS_INTERVAL |
+| use-profile       | An array of profiles to use.                                                      | Empty array   |                   | RUSTIC_USE_PROFILE       |
 
 ### Repository Options
 
-| Attribute         | Description                                            | Default Value  | Example Value | Environment Variable |
-|-------------------|--------------------------------------------------------|----------------|---------------|---------------|
-| cache-dir         | Path to the cache directory.                          | ~/.cache/rustic/$REPO_ID | ~/.cache/my_own_cache/ | RUSTIC_CACHE_DIR |
-| no-cache          | If true, disables caching.                            | false          || RUSTIC_NO_CACHE |
-| repository        | The path to the repository. Required.                 | Not set        | "/tmp/rustic" | RUSTIC_REPOSITORY |
-| repo-hot          | The path to the hot repository.                       | Not set        || RUSTIC_REPO_HOT |
-| password          | The password for the repository.                      | Not set        | "mySecretPassword" | RUSTIC_PASSWORD |
-| password-file     | Path to a file containing the password for the repository. | Not set     || RUSTIC_PASSWORD_FILE |
-| password-command  | Command to retrieve the password for the repository.   | Not set        || RUSTIC_PASSWORD_COMMAND |
-| warm-up           | If true, warms up the repository by file access.      | false          ||
-| warm-up-command   | Command to warm up the repository.                    | Not set        ||
-| warm-up-wait      | The wait time for warming up the repository.          | Not set        ||
+| Attribute        | Description                                                | Default Value            | Example Value          | Environment Variable    |
+| ---------------- | ---------------------------------------------------------- | ------------------------ | ---------------------- | ----------------------- |
+| cache-dir        | Path to the cache directory.                               | ~/.cache/rustic/$REPO_ID | ~/.cache/my_own_cache/ | RUSTIC_CACHE_DIR        |
+| no-cache         | If true, disables caching.                                 | false                    |                        | RUSTIC_NO_CACHE         |
+| repository       | The path to the repository. Required.                      | Not set                  | "/tmp/rustic"          | RUSTIC_REPOSITORY       |
+| repo-hot         | The path to the hot repository.                            | Not set                  |                        | RUSTIC_REPO_HOT         |
+| password         | The password for the repository.                           | Not set                  | "mySecretPassword"     | RUSTIC_PASSWORD         |
+| password-file    | Path to a file containing the password for the repository. | Not set                  |                        | RUSTIC_PASSWORD_FILE    |
+| password-command | Command to retrieve the password for the repository.       | Not set                  |                        | RUSTIC_PASSWORD_COMMAND |
+| warm-up          | If true, warms up the repository by file access.           | false                    |                        |                         |
+| warm-up-command  | Command to warm up the repository.                         | Not set                  |                        |                         |
+| warm-up-wait     | The wait time for warming up the repository.               | Not set                  |                        |                         |
 
 ### Repository Options (Additional)
 
-| Attribute         | Description                                            | Default Value  | Example Value |
-|-------------------|--------------------------------------------------------|----------------|---------------|
-| post-create-command   | Command to execute after creating a snapshot in the local backend. | Not set        | "par2create -qq -n1 -r5 %file" |
-| post-delete-command   | Command to execute after deleting a snapshot in the local backend. | Not set        | "sh -c \"rm -f %file*.par2\"" |
+| Attribute           | Description                                                        | Default Value | Example Value                  |
+| ------------------- | ------------------------------------------------------------------ | ------------- | ------------------------------ |
+| post-create-command | Command to execute after creating a snapshot in the local backend. | Not set       | "par2create -qq -n1 -r5 %file" |
+| post-delete-command | Command to execute after deleting a snapshot in the local backend. | Not set       | "sh -c \"rm -f %file*.par2\""  |
 
 ### Snapshot-Filter Options
 
-| Attribute         | Description                                            | Default Value  | Example Value |
-|-------------------|--------------------------------------------------------|----------------|---------------|
-| filter-fn         | Custom filter function for snapshots.                 | Not set        ||
-| filter-host       | Array of hosts to filter snapshots.                   | Not set        | ["myhost"]     |
-| filter-label      | Array of labels to filter snapshots.                  | No label filter ||
-| filter-paths      | Array of paths to filter snapshots.                   | No paths filter ||
-| filter-tags       | Array of tags to filter snapshots.                    | No tags filter  ||
+| Attribute    | Description                           | Default Value   | Example Value |
+| ------------ | ------------------------------------- | --------------- | ------------- |
+| filter-fn    | Custom filter function for snapshots. | Not set         |               |
+| filter-host  | Array of hosts to filter snapshots.   | Not set         | ["myhost"]    |
+| filter-label | Array of labels to filter snapshots.  | No label filter |               |
+| filter-paths | Array of paths to filter snapshots.   | No paths filter |               |
+| filter-tags  | Array of tags to filter snapshots.    | No tags filter  |               |
 
 ### Backup Options
 
-**Note**: Some options are not source-specific, but if set here, they apply for all sources, although they can be overwritten in the source-specifc configuration.
+**Note**: Some options are not source-specific, but if set here, they apply for
+all sources, although they can be overwritten in the source-specifc
+configuration.
 
-| Attribute         | Description                                            | Default Value  | Example Value |
-|-------------------|--------------------------------------------------------|----------------|---------------|
-| description            | Description for the backup.                           | Not set        ||
-| description-from       | Path to a file containing the description for the backup. | Not set    ||
-| delete-never           | If true, never delete the backup.                     | false          ||
-| delete-after           | Time duration after which the backup will be deleted. | Not set        ||
+| Attribute        | Description                                               | Default Value | Example Value |
+| ---------------- | --------------------------------------------------------- | ------------- | ------------- |
+| description      | Description for the backup.                               | Not set       |               |
+| description-from | Path to a file containing the description for the backup. | Not set       |               |
+| delete-never     | If true, never delete the backup.                         | false         |               |
+| delete-after     | Time duration after which the backup will be deleted.     | Not set       |               |
 
 ### Backup Sources
 
-| Attribute         | Description                                            | Default Value  | Example Value |
-|-------------------|--------------------------------------------------------|----------------|---------------|
-| source                 | Source directory or file to back up.                  | Not set        | "/tmp/dir/to_backup/" |
+| Attribute | Description                          | Default Value | Example Value         |
+| --------- | ------------------------------------ | ------------- | --------------------- |
+| source    | Source directory or file to back up. | Not set       | "/tmp/dir/to_backup/" |
 
 #### Source-specific options
 
-**Note**: The following options can be specified for each source individually in the source-individual section, see below. If they are specified here, they provide default values for all sources but can still be overwritten in the source-individual section.
+**Note**: The following options can be specified for each source individually in
+the source-individual section, see below. If they are specified here, they
+provide default values for all sources but can still be overwritten in the
+source-individual section.
 
-| Attribute         | Description                                            | Default Value  |
-|-------------------|--------------------------------------------------------|----------------|
-| as-path                | Specifies the path for the backup when the source contains a single path. | Not set |
-| exclude-if-present     | Array of filenames to exclude from the backup if they are present. | Not set |
-| force                  | If true, forces the backup even if no changes are detected. | Not set |
-| git-ignore             | If true, use .gitignore rules to exclude files from the backup in the source directory. | true |
-| glob-file              | Array of glob files specifying additional files to include in the backup. | Not set |
-| group-by               | Grouping strategy for the backup.                     | Not set |
-| host                   | Host name for the backup.                             | Not set |
-| ignore-ctime           | If true, ignores file change time (ctime) for the backup. | Not set |
-| ignore-inode           | If true, ignores file inode for the backup.           | Not set |
-| label                  | Label for the backup.                                 | Not set        |
-| one-file-system        | If true, only backs up files from the same filesystem as the source. | Not set |
-| parent                 | Parent snapshot ID for the backup.                    | Not set |
-| stdin-filename         | File name to be used when reading from stdin.         | Not set |
-| tag                    | Array of tags for the backup.                         | Not set |
-| with-atime             | If true, includes file access time (atime) in the backup. | Not set |
+| Attribute          | Description                                                                             | Default Value |
+| ------------------ | --------------------------------------------------------------------------------------- | ------------- |
+| as-path            | Specifies the path for the backup when the source contains a single path.               | Not set       |
+| exclude-if-present | Array of filenames to exclude from the backup if they are present.                      | Not set       |
+| force              | If true, forces the backup even if no changes are detected.                             | Not set       |
+| git-ignore         | If true, use .gitignore rules to exclude files from the backup in the source directory. | true          |
+| glob-file          | Array of glob files specifying additional files to include in the backup.               | Not set       |
+| group-by           | Grouping strategy for the backup.                                                       | Not set       |
+| host               | Host name for the backup.                                                               | Not set       |
+| ignore-ctime       | If true, ignores file change time (ctime) for the backup.                               | Not set       |
+| ignore-inode       | If true, ignores file inode for the backup.                                             | Not set       |
+| label              | Label for the backup.                                                                   | Not set       |
+| one-file-system    | If true, only backs up files from the same filesystem as the source.                    | Not set       |
+| parent             | Parent snapshot ID for the backup.                                                      | Not set       |
+| stdin-filename     | File name to be used when reading from stdin.                                           | Not set       |
+| tag                | Array of tags for the backup.                                                           | Not set       |
+| with-atime         | If true, includes file access time (atime) in the backup.                               | Not set       |
 
 ### Forget Options
 
-| Attribute         | Description                                            | Default Value  | Example Value |
-|-------------------|--------------------------------------------------------|----------------|---------------|
-| filter-host            | Array of hosts to filter snapshots.                   | Not set        | ["forgethost"] |
-| keep-daily             | Number of daily backups to keep.                      | Not set        ||
-| keep-within-daily      | The time duration within which daily backups will be kept. | Not set | "7 days"     |
-| keep-hourly            | Number of hourly backups to keep.                     | Not set        ||
-| keep-monthly           | Number of monthly backups to keep.                    | Not set        ||
-| keep-weekly            | Number of weekly backups to keep.                     | Not set        ||
-| keep-yearly            | Number of yearly backups to keep.                     | Not set        ||
-| keep-tags              | Array of tags to keep.                                | Not set        | ["mytag"]      |
+| Attribute         | Description                                                | Default Value | Example Value  |
+| ----------------- | ---------------------------------------------------------- | ------------- | -------------- |
+| filter-host       | Array of hosts to filter snapshots.                        | Not set       | ["forgethost"] |
+| keep-daily        | Number of daily backups to keep.                           | Not set       |                |
+| keep-within-daily | The time duration within which daily backups will be kept. | Not set       | "7 days"       |
+| keep-hourly       | Number of hourly backups to keep.                          | Not set       |                |
+| keep-monthly      | Number of monthly backups to keep.                         | Not set       |                |
+| keep-weekly       | Number of weekly backups to keep.                          | Not set       |                |
+| keep-yearly       | Number of yearly backups to keep.                          | Not set       |                |
+| keep-tags         | Array of tags to keep.                                     | Not set       | ["mytag"]      |
 
 ### Copy Targets
 
-**Note**: Copy-targets are simply repositories with the same defaults as within the repository section.
+**Note**: Copy-targets are simply repositories with the same defaults as within
+the repository section.
 
-| Attribute         | Description                                            | Default Value  | Example Value |
-|-------------------|--------------------------------------------------------|----------------|---------------|
-| cache-dir              | Path to the cache directory for the target repository. | ~/.cache/rustic/$REPO_ID | ~/.cache/my_own_cache/ |
-| no-cache               | If true, disables caching for the target repository.  | false          ||
-| password               | The password for the target repository.               | Not set        ||
-| password-file          | Path to a file containing the password for the target repository. | Not set   ||
-| password-command       | Command to retrieve the password for the target repository. | Not set   ||
-| post-create-command    | Command to execute after creating a snapshot in the target repository. | Not set   ||
-| post-delete-command    | Command to execute after deleting a snapshot in the target repository. | Not set   ||
-| repository             | The path or URL to the target repository.             | Not set        ||
-| repo-hot               | The path or URL to the hot target repository.         | Not set        ||
-| warm-up                | If true, warms up the target repository by file access. | Not set     ||
-| warm-up-command        | Command to warm up the target repository.            | Not set        ||
-| warm-up-wait           | The wait time for warming up the target repository.   | Not set        ||
+| Attribute           | Description                                                            | Default Value            | Example Value          |
+| ------------------- | ---------------------------------------------------------------------- | ------------------------ | ---------------------- |
+| cache-dir           | Path to the cache directory for the target repository.                 | ~/.cache/rustic/$REPO_ID | ~/.cache/my_own_cache/ |
+| no-cache            | If true, disables caching for the target repository.                   | false                    |                        |
+| password            | The password for the target repository.                                | Not set                  |                        |
+| password-file       | Path to a file containing the password for the target repository.      | Not set                  |                        |
+| password-command    | Command to retrieve the password for the target repository.            | Not set                  |                        |
+| post-create-command | Command to execute after creating a snapshot in the target repository. | Not set                  |                        |
+| post-delete-command | Command to execute after deleting a snapshot in the target repository. | Not set                  |                        |
+| repository          | The path or URL to the target repository.                              | Not set                  |                        |
+| repo-hot            | The path or URL to the hot target repository.                          | Not set                  |                        |
+| warm-up             | If true, warms up the target repository by file access.                | Not set                  |                        |
+| warm-up-command     | Command to warm up the target repository.                              | Not set                  |                        |
+| warm-up-wait        | The wait time for warming up the target repository.                    | Not set                  |                        |

--- a/config/copy_example.toml
+++ b/config/copy_example.toml
@@ -17,5 +17,5 @@ no-cache = true
 [[copy.targets]]
 repository = "rclone:ovh:backup"
 repo-hot = "clone:ovh:backup-hot"
-password-file =  "/root/key-rustic-ovh"
-cache-dir = "/var/lib/cache/rustic" # explicitly specify cache dir for remote repository 
+password-file = "/root/key-rustic-ovh"
+cache-dir = "/var/lib/cache/rustic" # explicitly specify cache dir for remote repository

--- a/config/full.toml
+++ b/config/full.toml
@@ -1,11 +1,11 @@
-# Full rustic config file containing all options which are available through the config file. 
+# Full rustic config file containing all options which are available through the config file.
 #
 # This file should be placed in the user's local config dir (~/.config/rustic/)
-# If you save it under NAME.toml, use "rustic -P NAME" to access this profile. 
+# If you save it under NAME.toml, use "rustic -P NAME" to access this profile.
 #
 # Note that most options can be overwritten by the corresponding command line option.
 
-# Global options: These options are used for all commands. 
+# Global options: These options are used for all commands.
 [global]
 use-profile = []
 log-level = "info" # any of "off", "error", "warn", "info", "debug", "trace"; default: "info"
@@ -14,7 +14,7 @@ no-progress = false
 progress-interval = "100ms"
 dry-run = false
 
-# Repository options: These options define which backend to use and which password to use. 
+# Repository options: These options define which backend to use and which password to use.
 [repository]
 repository = "/repo/rustic" # Must be set
 repo-hot = "/my/hot/repo" # Default: not set
@@ -32,7 +32,7 @@ warm-up-wait = "10min" # Default: not set
 # Additional repository options - depending on backend. These can be only set in the config file.
 [repository.options]
 post-create-command = "par2create -qq -n1 -r5 %file" # Only local backend; Default: not set
-post-delete-command = "sh -c \"rm -f %file*.par2\"" # Only local backend; Default: not set 
+post-delete-command = "sh -c \"rm -f %file*.par2\"" # Only local backend; Default: not set
 retry = "default" # Only rest/rclone backend; Allowed values: "false"/"off", "default" or number of retries
 timeout = "10min" # Only rest/rclone backend
 
@@ -44,7 +44,7 @@ filter-tags = ["tag1,tag2", "tag3"] # Default: no tags filger
 filter-paths = ["path1", "path2,path3"] # Default: no paths filter
 filter-fn = '|sn| {sn.host == "host1" || sn.description.contains("test")}' # Default: no filter function
 
-# Backup options: These options are used for all sources when calling the backup command. 
+# Backup options: These options are used for all sources when calling the backup command.
 # They can be overwritten by source-specific options (see below) or command line options.
 [backup]
 label = "label" # Default: not set
@@ -120,7 +120,10 @@ filter-paths = ["path1", "path2,path3"] # Default: no paths filter
 filter-fn = '|sn| {sn.host == "host1" || sn.description.contains("test")}' # Default: no filter function
 # The retention options follow. All of these are not set by default.
 keep-tags = ["tag1", "tag2,tag3"]
-keep-ids = ["123abc", "11122233"] # Keep all snapshots whose ID starts with any of these strings
+keep-ids = [
+  "123abc",
+  "11122233",
+] # Keep all snapshots whose ID starts with any of these strings
 keep-last = 0
 keep-daily = 3
 keep-weekly = 0

--- a/config/local.toml
+++ b/config/local.toml
@@ -5,7 +5,7 @@
 #
 [repository]
 repository = "/backup/rustic"
-password-file =  "/root/key-rustic"
+password-file = "/root/key-rustic"
 no-cache = true # no cache needed for local repository
 
 [forget]

--- a/config/ovh-hot-cold.toml
+++ b/config/ovh-hot-cold.toml
@@ -7,8 +7,8 @@
 [repository]
 repository = "rclone:ovh:backup-home"
 repo-hot = "rclone:ovh:backup-home-hot"
-password-file =  "/root/key-rustic-ovh"
-cache-dir = "/var/lib/cache/rustic" # explicitly specify cache dir for remote repository 
+password-file = "/root/key-rustic-ovh"
+cache-dir = "/var/lib/cache/rustic" # explicitly specify cache dir for remote repository
 warm-up = true # cold storage needs warm-up, just trying to access a file is sufficient to start the warm-up
 warm-up-wait = "10m" # in my examples, 10 minutes wait-time was sufficient, according to docu it can be up to 12h
 

--- a/config/par2.toml
+++ b/config/par2.toml
@@ -1,6 +1,6 @@
 # This is an example how to use the post-create-command and post-delete-command hooks to add
 # error correction files using par2create to a local repository.
-# The commands can use the variable %file, %type and %id which are replaced by the filename, the 
+# The commands can use the variable %file, %type and %id which are replaced by the filename, the
 # file type and the file id before calling the command.
 [repository]
 repository = "/tmp/repo"
@@ -13,6 +13,3 @@ post-create-command = "par2create -qq -n1 -r5 %file"
 # after removing a file from the repo, this command is called.
 # Note that we want to use a "*" in the rm command, hence we have to call sh to resolve the wildcard!
 post-delete-command = "sh -c \"rm -f %file*.par2\""
-
-
-

--- a/config/rustic.toml
+++ b/config/rustic.toml
@@ -1,25 +1,25 @@
-# Example rustic config file. 
+# Example rustic config file.
 #
 # This file should be placed in the user's local config dir (~/.config/rustic/)
-# If you save it under NAME.toml, use "rustic -P NAME" to access this profile. 
+# If you save it under NAME.toml, use "rustic -P NAME" to access this profile.
 #
 # Note that most options can be overwritten by the corresponding command line option.
 
-# global options: These options are used for all commands. 
+# global options: These options are used for all commands.
 [global]
 log-level = "debug"
 log-file = "/log/rustic.log"
 
-# repository options: These options define which backend to use and which password to use. 
+# repository options: These options define which backend to use and which password to use.
 [repository]
 repository = "/tmp/rustic"
-password = "mySecretPassword" 
+password = "mySecretPassword"
 
 # snapshot-filter options: These options apply to all commands that use snapshot filters
 [snapshot-filter]
 filter-host = ["myhost"]
 
-# backup options: These options are used for all sources when calling the backup command. 
+# backup options: These options are used for all sources when calling the backup command.
 # They can be overwritten by source-specific options (see below) or command line options.
 [backup]
 git-ignore = true
@@ -27,8 +27,8 @@ git-ignore = true
 # backup options can be given for specific sources. These options only apply
 # when calling "rustic backup SOURCE".
 #
-# Note that if you call "rustic backup" without any source, all sources from this config 
-# file will be processed. 
+# Note that if you call "rustic backup" without any source, all sources from this config
+# file will be processed.
 [[backup.sources]]
 source = "/data/dir"
 
@@ -38,7 +38,9 @@ glob = ["!/home/*/Downloads/*"]
 
 # forget options
 [forget]
-filter-host = ["forgethost"] # <- this overwrites the snapshot-filter option defined above
+filter-host = [
+  "forgethost",
+] # <- this overwrites the snapshot-filter option defined above
 keep-tags = ["mytag"]
 keep-within-daily = "7 days"
 keep-monthly = 5

--- a/crates/rustic_core/Cargo.toml
+++ b/crates/rustic_core/Cargo.toml
@@ -1,16 +1,16 @@
 [package]
-publish = false                                                           # Don't publish until we fix/stabilize public api!!!
 name = "rustic_core"
 version = "0.6.0"
+authors = ["Alexander Weiss"]
 edition = { workspace = true }
+homepage = { workspace = true }
+include = ["src/**/*", "LICENSE-*", "README.md"]
+keywords = ["backup", "restic", "deduplication", "encryption", "library"]
+license = { workspace = true }
+publish = false # Don't publish until we fix/stabilize public api!!!
+readme = "README.md"
 resolver = "2"
 description = { workspace = true }
-authors = ["Alexander Weiss"]
-license = { workspace = true }
-homepage = { workspace = true }
-readme = "README.md"
-keywords = ["backup", "restic", "deduplication", "encryption", "library"]
-include = ["src/**/*", "LICENSE-*", "README.md"]
 # categories = []
 
 [lib]
@@ -35,19 +35,19 @@ displaydoc = { workspace = true }
 thiserror = { workspace = true }
 
 # macros
-derive_more = { workspace = true }
 derivative = { workspace = true }
+derive_more = { workspace = true }
 derive_setters = { workspace = true }
 
-#logging
+# logging
 log = { workspace = true }
 
 # parallelize
 crossbeam-channel = { workspace = true }
-rayon = { workspace = true }
 pariter = { workspace = true }
+rayon = { workspace = true }
 
-#crypto
+# crypto
 aes256ctr_poly1305aes = { workspace = true }
 rand = { workspace = true }
 scrypt = { workspace = true }
@@ -59,50 +59,50 @@ integer-sqrt = { workspace = true }
 binrw = { workspace = true }
 hex = { workspace = true }
 serde = { workspace = true }
-serde_with = { workspace = true }
-serde_json = { workspace = true }
 serde-aux = { workspace = true }
+serde_json = { workspace = true }
+serde_with = { workspace = true }
 
 # other dependencies
 bytes = { workspace = true }
 chrono = { workspace = true }
-zstd = { workspace = true }
 enum-map = { workspace = true }
 enum-map-derive = { workspace = true }
+zstd = { workspace = true }
 
 # local backend
-walkdir = { workspace = true }
-ignore = { workspace = true }
-cached = { workspace = true }
-nix = { workspace = true }
-filetime = { workspace = true }
 aho-corasick = { workspace = true }
+cached = { workspace = true }
+filetime = { workspace = true }
+ignore = { workspace = true }
+nix = { workspace = true }
+walkdir = { workspace = true }
 
 # rest backend
-reqwest = { workspace = true }
 backoff = { workspace = true }
+reqwest = { workspace = true }
 url = { workspace = true }
 
 # rclone backend
 semver = { workspace = true }
 
 # cache
-dirs = { workspace = true }
 cachedir = { workspace = true }
+dirs = { workspace = true }
 
 # cli
 clap = { workspace = true, optional = true }
 clap_complete = { workspace = true, optional = true }
 
-merge = { workspace = true, optional = true }
+bytesize = { workspace = true }
 directories = { workspace = true }
-shell-words = { workspace = true }
-path-dedot = { workspace = true }
 dunce = { workspace = true }
 gethostname = { workspace = true }
-bytesize = { workspace = true }
-itertools = { workspace = true }
 humantime = { workspace = true }
+itertools = { workspace = true }
+merge = { workspace = true, optional = true }
+path-dedot = { workspace = true }
+shell-words = { workspace = true }
 
 [target.'cfg(not(windows))'.dependencies]
 sha2 = { version = "0.10", features = ["asm"] }
@@ -115,14 +115,14 @@ sha2 = "0.10"
 xattr = "1"
 
 [dev-dependencies]
-rustup-toolchain = "0.1.4"
-rustdoc-json = "0.8.7"
-public-api = "0.31.3"
-rstest = { workspace = true }
 expect-test = "1.4.1"
+pretty_assertions = { workspace = true }
+public-api = "0.31.3"
 quickcheck = { workspace = true }
 quickcheck_macros = { workspace = true }
-pretty_assertions = { workspace = true }
+rstest = { workspace = true }
+rustdoc-json = "0.8.7"
+rustup-toolchain = "0.1.4"
 simplelog = { workspace = true }
 
 [profile.dev]
@@ -135,7 +135,7 @@ codegen-units = 4
 
 [profile.release]
 opt-level = 3
-debug = false            # true for profiling
+debug = false # true for profiling
 rpath = false
 lto = "fat"
 debug-assertions = false
@@ -152,7 +152,7 @@ codegen-units = 4
 
 [profile.bench]
 opt-level = 3
-debug = true             # true for profiling
+debug = true # true for profiling
 rpath = false
 lto = true
 debug-assertions = false

--- a/crates/rustic_core/README.md
+++ b/crates/rustic_core/README.md
@@ -6,5 +6,5 @@ Library powering rustic-rs
 
 Licensed under either of:
 
-* [Apache License, Version 2.0](./LICENSE-APACHE)
-* [MIT license](./LICENSE-MIT)
+- [Apache License, Version 2.0](./LICENSE-APACHE)
+- [MIT license](./LICENSE-MIT)

--- a/crates/rustic_core/src/cdc/README.md
+++ b/crates/rustic_core/src/cdc/README.md
@@ -1,6 +1,6 @@
 # cdc
 
-A library for performing *Content-Defined Chunking* (CDC) on data streams. Implemented using generic iterators, very easy to use.
+A library for performing _Content-Defined Chunking_ (CDC) on data streams. Implemented using generic iterators, very easy to use.
 
 - [API Documentation](https://docs.rs/cdc/)
 

--- a/crates/rustic_core/src/cdc/README.md
+++ b/crates/rustic_core/src/cdc/README.md
@@ -1,6 +1,7 @@
 # cdc
 
-A library for performing _Content-Defined Chunking_ (CDC) on data streams. Implemented using generic iterators, very easy to use.
+A library for performing *Content-Defined Chunking* (CDC) on data streams.
+Implemented using generic iterators, very easy to use.
 
 - [API Documentation](https://docs.rs/cdc/)
 
@@ -16,13 +17,15 @@ A library for performing _Content-Defined Chunking_ (CDC) on data streams. Imple
   }
 ```
 
-Each module is documented via an example which you can find in the `config/` folder.
+Each module is documented via an example which you can find in the `config/`
+folder.
 
 To run them, use a command like:
 
 `cargo run --example separator --release`
 
-**Note:** Some examples are looking for a file named `myLargeFile.bin` which I didn't upload to Github. Please use your own files for testing.
+**Note:** Some examples are looking for a file named `myLargeFile.bin` which I
+didn't upload to Github. Please use your own files for testing.
 
 ## What's in the crate
 
@@ -30,29 +33,40 @@ From low level to high level:
 
 - A `RollingHash64` trait, for rolling hash with a 64 bits hash value.
 
-- `Rabin64`, an implementation of the Rabin Fingerprint rolling hash with a 64 bits hash value.
+- `Rabin64`, an implementation of the Rabin Fingerprint rolling hash with a 64
+  bits hash value.
 
-- `Separator`, a struct which describes a place in a data stream identified as a separator.
+- `Separator`, a struct which describes a place in a data stream identified as a
+  separator.
 
-- `SeparatorIter`, an adaptor which takes an `Iterator<Item=u8>` as input and which enumerates all the separators found.
+- `SeparatorIter`, an adaptor which takes an `Iterator<Item=u8>` as input and
+  which enumerates all the separators found.
 
 - `Chunk`, a struct which describes a piece of the data stream (index and size).
 
-- `ChunkIter`, an adaptor which takes an `Iterator<Item=Separator>` as input and which enumerates chunks.
+- `ChunkIter`, an adaptor which takes an `Iterator<Item=Separator>` as input and
+  which enumerates chunks.
 
 ## Implementation details
 
-- The library is not cutting any files, it only provides information on how to do it.
+- The library is not cutting any files, it only provides information on how to
+  do it.
 
-- You can change the default window size used by `Rabin64`, and how the `SeparatorIter` is choosing the separator.
+- You can change the default window size used by `Rabin64`, and how the
+  `SeparatorIter` is choosing the separator.
 
-- The design of this crate may be subject to changes sometime in the future. I am waiting for some features of `Rust` to mature up, specially the [`impl Trait`](https://github.com/rust-lang/rust/issues/34511) feature.
+- The design of this crate may be subject to changes sometime in the future. I
+  am waiting for some features of `Rust` to mature up, specially the
+  [`impl Trait`](https://github.com/rust-lang/rust/issues/34511) feature.
 
 ## Performance
 
-There is a **huge** difference between the debug build and the release build in terms of performance. Remember that when you test the lib, use `cargo run --release`.
+There is a **huge** difference between the debug build and the release build in
+terms of performance. Remember that when you test the lib, use
+`cargo run --release`.
 
-I may try to improve the performance of the lib at some point, but for now it is good enough for most usages.
+I may try to improve the performance of the lib at some point, but for now it is
+good enough for most usages.
 
 ## License
 

--- a/crates/rustic_testing/Cargo.toml
+++ b/crates/rustic_testing/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
-publish = false
 name = "rustic_testing"
 version = "0.1.0"
 edition = "2021"
+publish = false
 
 [dependencies]
+aho-corasick = { workspace = true }
 once_cell = { workspace = true }
 tempfile = { workspace = true }
-aho-corasick = { workspace = true }

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -3,7 +3,8 @@
 ## What are the differences between rustic and restic?
 
 - Written in Rust instead of golang
-- Optimized for small resource usage (in particular memory usage, but also overall CPU usage)
+- Optimized for small resource usage (in particular memory usage, but also
+  overall CPU usage)
 - Philosophy of development (release new features early)
 - New features (e.g. hot/cold repositories, lock-free pruning)
 - Some commands or options act a bit different or have slightly different syntax
@@ -15,46 +16,55 @@ This is a very good fit for a backup tool.
 
 ## How does rustic work with cold storages like AWS Glacier?
 
-If you want to use cold storage, make sure you always specify an extra repository `--repo-hot` which
-contains the hot data. This repository acts like a cache for all metadata, i.e. config/key/snapshot/index
-files and tree packs. As all commands except `restore` only need to access the metadata, they are fully
-functional but only need the cold storage to list files while everything else is read from the "hot repo".
-Note that the "hot repo" on its own is not a valid rustic repository. The "cold repo", however, contains
-all files and is nothing but a standard rustic repository.
+If you want to use cold storage, make sure you always specify an extra
+repository `--repo-hot` which contains the hot data. This repository acts like a
+cache for all metadata, i.e. config/key/snapshot/index files and tree packs. As
+all commands except `restore` only need to access the metadata, they are fully
+functional but only need the cold storage to list files while everything else is
+read from the "hot repo". Note that the "hot repo" on its own is not a valid
+rustic repository. The "cold repo", however, contains all files and is nothing
+but a standard rustic repository.
 
-If you additionally use a cache, you effectively have a first level cache on your local disc and a second
-level cache with the "hot repo". Note that the "hot repo" can be also a remote repo, so hot/cold repositories
-also work for multiple rustic clients backing up to the same repository.
+If you additionally use a cache, you effectively have a first level cache on
+your local disc and a second level cache with the "hot repo". Note that the "hot
+repo" can be also a remote repo, so hot/cold repositories also work for multiple
+rustic clients backing up to the same repository.
 
 ## How does the lock-free prune work?
 
-Like the prune within restic, rustic decides for each pack whether to keep it, remove it or repack it.
-Instead of removing packs, it however only marks the packs to remove in a separate index structure.
-Packs which are marked for removal are checked if they are really not needed and have been marked
-long enough ago. Depending on these checks they are either finally removed, recovered or kept in the
-state of being marked for removal.
+Like the prune within restic, rustic decides for each pack whether to keep it,
+remove it or repack it. Instead of removing packs, it however only marks the
+packs to remove in a separate index structure. Packs which are marked for
+removal are checked if they are really not needed and have been marked long
+enough ago. Depending on these checks they are either finally removed, recovered
+or kept in the state of being marked for removal.
 
-This two-phase deletion is needed for rustic to work lock-free: If a `backup` runs parallel to a `prune`
-run (or `forget --prune`), it could be that prune decides that some blobs can be removed, but the parallel
-backup uses these blobs for the newly generated snapshot.
+This two-phase deletion is needed for rustic to work lock-free: If a `backup`
+runs parallel to a `prune` run (or `forget --prune`), it could be that prune
+decides that some blobs can be removed, but the parallel backup uses these blobs
+for the newly generated snapshot.
 
-The time to hold marked packs should be long enough to guarantee that a possibly parallel backup run has
-finished in between. It can be set by the `--keep-delete` option and defaults to 23 hours. In any case, packs
-will be kept marked and only deleted by the next prune run.
+The time to hold marked packs should be long enough to guarantee that a possibly
+parallel backup run has finished in between. It can be set by the
+`--keep-delete` option and defaults to 23 hours. In any case, packs will be kept
+marked and only deleted by the next prune run.
 
-Note that there is the option `--instant-delete` which circumvents this two-phase deletion. Only use this
-option, if you **REALLY KNOW** that there is no parallel access to your repo, else you risk losing data!
+Note that there is the option `--instant-delete` which circumvents this
+two-phase deletion. Only use this option, if you **REALLY KNOW** that there is
+no parallel access to your repo, else you risk losing data!
 
 ## You said "rustic uses less resources than restic" but I'm observing the opposite
 
-In general rustic uses less resources, but there may be some exceptions. For instance the crypto libraries
-of Rust and golang both have optimizations for some CPUs. But it might be that your CPU benefits from a
-golang optimization which is not present in the Rust implementation.
-If you observe some unexpected resource usage, please don't hesitate to submit an issue.
+In general rustic uses less resources, but there may be some exceptions. For
+instance the crypto libraries of Rust and golang both have optimizations for
+some CPUs. But it might be that your CPU benefits from a golang optimization
+which is not present in the Rust implementation. If you observe some unexpected
+resource usage, please don't hesitate to submit an issue.
 
 ## How to install shell completions
 
-All completion files are generated by invoking `rustic completions` command. So run:
+All completion files are generated by invoking `rustic completions` command. So
+run:
 
 ### Bash
 
@@ -70,8 +80,9 @@ rustic completions fish > $HOME/.config/fish/completions/rustic.fish
 
 ### Zsh
 
-ZSH completions are commonly stored in any directory listed in your `$fpath` variable. To use these completions,
-write completions script (`_rustic`) to one of those directories, or add your own to this list.
+ZSH completions are commonly stored in any directory listed in your `$fpath`
+variable. To use these completions, write completions script (`_rustic`) to one
+of those directories, or add your own to this list.
 
 This list includes, for example, these directories:
 

--- a/docs/comparison-restic.md
+++ b/docs/comparison-restic.md
@@ -2,26 +2,26 @@
 
 Improvements implemented in rustic:
 
-* Allows using cold storage (e.g. AWS Glacier) repos which are only read in the `restore` command + supports warm-up
-* All operations are completely lock-free as rustic supports two-phase-pruning (prune option `instant-delete` is available)
-* Supports configuration in a config file
-([example config files](https://github.com/rustic-rs/rustic/tree/main/config))
-* Huge decrease in memory requirement
-* Already faster than restic for most operations (but not yet fully speed optimized)
-* Cleaner concept of logging output; possibility to write logs to a log file
-* `rustic repair` command allows to repair some kinds of broken repositories
-* `backup` command can use `.gitignore` files
-* `restore` uses existing files; also option `--delete` available
-* Snapshots save much more information, available in `snapshots` command
-* Integrates the [Rhai](https://rhai.rs/) script language for snapshot filtering
-* Allows to save repository options in the repository config file via the command `config`
-* New command `merge`
-* New command `repo-info`
-* `check` command checks and uses cache; option `--trust-cache` is available
-* Option `prune --fast-repack` for faster repacking
-* Syntax `<SNAPSHOT>[:PATH]` is available for many commands
+- Allows using cold storage (e.g. AWS Glacier) repos which are only read in the `restore` command + supports warm-up
+- All operations are completely lock-free as rustic supports two-phase-pruning (prune option `instant-delete` is available)
+- Supports configuration in a config file
+  ([example config files](https://github.com/rustic-rs/rustic/tree/main/config))
+- Huge decrease in memory requirement
+- Already faster than restic for most operations (but not yet fully speed optimized)
+- Cleaner concept of logging output; possibility to write logs to a log file
+- `rustic repair` command allows to repair some kinds of broken repositories
+- `backup` command can use `.gitignore` files
+- `restore` uses existing files; also option `--delete` available
+- Snapshots save much more information, available in `snapshots` command
+- Integrates the [Rhai](https://rhai.rs/) script language for snapshot filtering
+- Allows to save repository options in the repository config file via the command `config`
+- New command `merge`
+- New command `repo-info`
+- `check` command checks and uses cache; option `--trust-cache` is available
+- Option `prune --fast-repack` for faster repacking
+- Syntax `<SNAPSHOT>[:PATH]` is available for many commands
 
 ## Missing points
 
-* [ ] tests and benchmarks
-* [ ] missing commands: find, mount
+- [ ] tests and benchmarks
+- [ ] missing commands: find, mount

--- a/docs/comparison-restic.md
+++ b/docs/comparison-restic.md
@@ -2,19 +2,23 @@
 
 Improvements implemented in rustic:
 
-- Allows using cold storage (e.g. AWS Glacier) repos which are only read in the `restore` command + supports warm-up
-- All operations are completely lock-free as rustic supports two-phase-pruning (prune option `instant-delete` is available)
+- Allows using cold storage (e.g. AWS Glacier) repos which are only read in the
+  `restore` command + supports warm-up
+- All operations are completely lock-free as rustic supports two-phase-pruning
+  (prune option `instant-delete` is available)
 - Supports configuration in a config file
   ([example config files](https://github.com/rustic-rs/rustic/tree/main/config))
 - Huge decrease in memory requirement
-- Already faster than restic for most operations (but not yet fully speed optimized)
+- Already faster than restic for most operations (but not yet fully speed
+  optimized)
 - Cleaner concept of logging output; possibility to write logs to a log file
 - `rustic repair` command allows to repair some kinds of broken repositories
 - `backup` command can use `.gitignore` files
 - `restore` uses existing files; also option `--delete` available
 - Snapshots save much more information, available in `snapshots` command
 - Integrates the [Rhai](https://rhai.rs/) script language for snapshot filtering
-- Allows to save repository options in the repository config file via the command `config`
+- Allows to save repository options in the repository config file via the
+  command `config`
 - New command `merge`
 - New command `repo-info`
 - `check` command checks and uses cache; option `--trust-cache` is available

--- a/dprint.json
+++ b/dprint.json
@@ -9,13 +9,21 @@
     "toml": {
         "lineWidth": 80
     },
+    "json": {
+        "lineWidth": 80,
+        "indentWidth": 4
+    },
     "includes": [
         "**/*.{md}",
-        "**/*.{toml}"
+        "**/*.{toml}",
+        "**/*.{json}"
     ],
-    "excludes": [],
+    "excludes": [
+        "target/**/*"
+    ],
     "plugins": [
         "https://plugins.dprint.dev/markdown-0.15.2.wasm",
-        "https://plugins.dprint.dev/toml-0.5.4.wasm"
+        "https://plugins.dprint.dev/toml-0.5.4.wasm",
+        "https://plugins.dprint.dev/json-0.17.4.wasm"
     ]
 }

--- a/dprint.json
+++ b/dprint.json
@@ -1,11 +1,21 @@
 {
     "lineWidth": 80,
-    "markdown": {},
+    "markdown": {
+        "lineWidth": 80,
+        "emphasisKind": "asterisks",
+        "strongKind": "asterisks",
+        "textWrap": "always"
+    },
+    "toml": {
+        "lineWidth": 80
+    },
     "includes": [
-        "**/*.{md}"
+        "**/*.{md}",
+        "**/*.{toml}"
     ],
     "excludes": [],
     "plugins": [
-        "https://plugins.dprint.dev/markdown-0.15.2.wasm"
+        "https://plugins.dprint.dev/markdown-0.15.2.wasm",
+        "https://plugins.dprint.dev/toml-0.5.4.wasm"
     ]
 }

--- a/dprint.json
+++ b/dprint.json
@@ -1,0 +1,11 @@
+{
+    "lineWidth": 80,
+    "markdown": {},
+    "includes": [
+        "**/*.{md}"
+    ],
+    "excludes": [],
+    "plugins": [
+        "https://plugins.dprint.dev/markdown-0.15.2.wasm"
+    ]
+}

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -1,15 +1,15 @@
 [package]
-publish = false
 name = "xtask"
 version = "0.1.0"
 edition = "2021"
+publish = false
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
 anyhow.workspace = true
 clap.workspace = true
+dialoguer = "0.10.4"
 duct = "0.13.6"
 fs_extra = "1.3.0"
 glob = "0.3.1"
-dialoguer = "0.10.4"


### PR DESCRIPTION
For our documentation efforts within the repository, it makes sense to introduce a common style that is easy to uphold using `dprint`. Also, because `dprint` is just a `cargo install dprint`/`scoop install dprint` away.