### PR TITLE
Feature: Add s3 backend

### DIFF
--- a/.devenv.flake.nix
+++ b/.devenv.flake.nix
@@ -1,0 +1,83 @@
+{
+  inputs = {
+    pre-commit-hooks.url = "github:cachix/pre-commit-hooks.nix";
+    pre-commit-hooks.inputs.nixpkgs.follows = "nixpkgs";
+    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+    devenv.url = "github:cachix/devenv?dir=src/modules";
+  } // (if builtins.pathExists ./.devenv/flake.json 
+       then builtins.fromJSON (builtins.readFile ./.devenv/flake.json)
+       else {});
+
+  outputs = { nixpkgs, ... }@inputs:
+    let
+      devenv = if builtins.pathExists ./.devenv/devenv.json
+        then builtins.fromJSON (builtins.readFile ./.devenv/devenv.json)
+        else {};
+      getOverlays = inputName: inputAttrs:
+        map (overlay: let
+            input = inputs.${inputName} or (throw "No such input `${inputName}` while trying to configure overlays.");
+          in input.overlays.${overlay} or (throw "Input `${inputName}` has no overlay called `${overlay}`. Supported overlays: ${nixpkgs.lib.concatStringsSep ", " (builtins.attrNames input.overlays)}"))
+          inputAttrs.overlays or [];
+      overlays = nixpkgs.lib.flatten (nixpkgs.lib.mapAttrsToList getOverlays (devenv.inputs or {}));
+      pkgs = import nixpkgs {
+        system = "x86_64-linux";
+        config = {
+          allowUnfree = devenv.allowUnfree or false;
+          permittedInsecurePackages = devenv.permittedInsecurePackages or [];
+        };
+        inherit overlays;
+      };
+      lib = pkgs.lib;
+      importModule = path:
+        if lib.hasPrefix "./" path
+        then if lib.hasSuffix ".nix" path
+             then ./. + (builtins.substring 1 255 path)
+             else ./. + (builtins.substring 1 255 path) + "/devenv.nix"
+        else if lib.hasPrefix "../" path 
+            then throw "devenv: ../ is not supported for imports"
+            else let
+              paths = lib.splitString "/" path;
+              name = builtins.head paths;
+              input = inputs.${name} or (throw "Unknown input ${name}");
+              subpath = "/${lib.concatStringsSep "/" (builtins.tail paths)}";
+              devenvpath = "${input}" + subpath + "/devenv.nix";
+              in if builtins.pathExists devenvpath
+                then devenvpath
+                else throw (devenvpath + " file does not exist for input ${name}.");
+      project = pkgs.lib.evalModules {
+        specialArgs = inputs // { inherit inputs pkgs; };
+        modules = [
+          (inputs.devenv.modules + /top-level.nix)
+          { devenv.cliVersion = "0.6.3"; }
+        ] ++ (map importModule (devenv.imports or [])) ++ [
+          ./devenv.nix
+          (devenv.devenv or {})
+          (if builtins.pathExists ./devenv.local.nix then ./devenv.local.nix else {})
+        ];
+      };
+      config = project.config;
+
+      options = pkgs.nixosOptionsDoc {
+        options = builtins.removeAttrs project.options [ "_module" ];
+        # Unpack Nix types, e.g. literalExpression, mDoc.
+        transformOptions =
+          let isDocType = v: builtins.elem v [ "literalDocBook" "literalExpression" "literalMD" "mdDoc" ];
+          in lib.attrsets.mapAttrs (_: v:
+            if v ? _type && isDocType v._type then
+              v.text
+            else if v ? _type && v._type == "derivation" then
+              v.name
+            else
+              v
+          );
+      };
+    in {
+      packages."x86_64-linux" = {
+        optionsJSON = options.optionsJSON;
+        inherit (config) info procfileScript procfileEnv procfile;
+        ci = config.ciDerivation;
+      };
+      devenv.containers = config.containers;
+      devShell."x86_64-linux" = config.shell;
+    };
+}

--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,2 @@
+# shellcheck disable=SC2148
+use flake --impure

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@
 mutants.out
 cargo-test*
 coverage/*lcov
+.devenv/
+.direnv/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2269,6 +2269,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "rstest_reuse"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88530b681abe67924d42cca181d070e3ac20e0740569441a9e35a7cedd2b34a4"
+dependencies = [
+ "quote",
+ "rand",
+ "rustc_version",
+ "syn 2.0.28",
+]
+
+[[package]]
 name = "rustc-demangle"
 version = "0.1.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2351,6 +2363,8 @@ dependencies = [
  "rand",
  "rayon",
  "rhai",
+ "rstest",
+ "rstest_reuse",
  "rustic_core",
  "rustic_testing",
  "scrypt",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -94,6 +94,17 @@ dependencies = [
 
 [[package]]
 name = "ahash"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcb51a0695d8f838b1ee009b3fbf66bda078cd64590202a864a8f3e8c4315c47"
+dependencies = [
+ "getrandom",
+ "once_cell",
+ "version_check",
+]
+
+[[package]]
+name = "ahash"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c99f64d1e06488f620f932677e24bc6e2897582980441ae90a671415bd7ec2f"
@@ -197,10 +208,63 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d62b7694a562cdf5a74227903507c56ab2cc8bdd1f781ed5cb4cf9c9f810bfc"
 
 [[package]]
+name = "async-trait"
+version = "0.1.73"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc00ceb34980c03614e35a3a4e218276a0a824e911d07651cd0d858a51e8c0f0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.28",
+]
+
+[[package]]
+name = "attohttpc"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fcf00bc6d5abb29b5f97e3c61a90b6d3caa12f3faf897d4a3e3607c050a35a7"
+dependencies = [
+ "http",
+ "log",
+ "rustls 0.20.9",
+ "serde",
+ "serde_json",
+ "url",
+ "webpki",
+ "webpki-roots",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
+
+[[package]]
+name = "aws-creds"
+version = "0.34.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3776743bb68d4ad02ba30ba8f64373f1be4e082fe47651767171ce75bb2f6cf5"
+dependencies = [
+ "attohttpc",
+ "dirs 4.0.0",
+ "log",
+ "quick-xml 0.26.0",
+ "rust-ini",
+ "serde",
+ "thiserror",
+ "time",
+ "url",
+]
+
+[[package]]
+name = "aws-region"
+version = "0.25.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "056557a61427d0e5ba29dd931031c8ffed4ee7a550e7cd55692a9d8deb0a9dba"
+dependencies = [
+ "thiserror",
+]
 
 [[package]]
 name = "backoff"
@@ -227,6 +291,12 @@ dependencies = [
  "object",
  "rustc-demangle",
 ]
+
+[[package]]
+name = "base64"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
 
 [[package]]
 name = "base64"
@@ -888,7 +958,16 @@ version = "5.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a49173b84e034382284f27f1af4dcbbd231ffa358c0fe316541a7337f376a35"
 dependencies = [
- "dirs-sys",
+ "dirs-sys 0.4.1",
+]
+
+[[package]]
+name = "dirs"
+version = "4.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca3aa72a6f96ea37bbc5aa912f6788242832f75369bdfdadcb0e38423f100059"
+dependencies = [
+ "dirs-sys 0.3.7",
 ]
 
 [[package]]
@@ -897,7 +976,18 @@ version = "5.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44c45a9d03d6676652bcb5e724c7e988de1acad23a711b5217ab9cbecbec2225"
 dependencies = [
- "dirs-sys",
+ "dirs-sys 0.4.1",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b1d1d91c932ef41c0f2663aa8b0ca0342d444d842c06914aa0a7e352d0bada6"
+dependencies = [
+ "libc",
+ "redox_users",
+ "winapi",
 ]
 
 [[package]]
@@ -928,6 +1018,12 @@ name = "dissimilar"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "86e3bdc80eee6e16b2b6b0f87fbc98c04bee3455e35174c0de1a125d0688c632"
+
+[[package]]
+name = "dlv-list"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0688c2a7f92e427f44895cd63841bff7b29f8d7a1648b9e7e07a4a365b2e1257"
 
 [[package]]
 name = "duct"
@@ -1281,6 +1377,9 @@ name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+dependencies = [
+ "ahash 0.7.6",
+]
 
 [[package]]
 name = "hashbrown"
@@ -1397,7 +1496,7 @@ dependencies = [
  "futures-util",
  "http",
  "hyper",
- "rustls",
+ "rustls 0.21.7",
  "tokio",
  "tokio-rustls",
 ]
@@ -1637,6 +1736,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "maybe-async"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f1b8c13cb1f814b634a96b2c725449fe7ed464a7b8781de8688be5ffbd3f305"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "md5"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "490cc448043f947bae3cbee9c203358d62dbee0db12107a74be5c30ccfd09771"
+
+[[package]]
 name = "memchr"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1799,6 +1915,16 @@ name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
+name = "ordered-multimap"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccd746e37177e1711c20dd619a1620f34f5c8b569c53590a72dedd5344d8924a"
+dependencies = [
+ "dlv-list",
+ "hashbrown 0.12.3",
+]
 
 [[package]]
 name = "os_pipe"
@@ -1994,6 +2120,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "quick-xml"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f50b1c63b38611e7d4d7f68b82d3ad0cc71a2ad2e7f61fc10f1328d917c93cd"
+dependencies = [
+ "memchr",
+ "serde",
+]
+
+[[package]]
 name = "quickcheck"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2161,7 +2297,7 @@ version = "0.11.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cde824a14b7c14f85caff81225f411faacc04a2013f41670f41443742b1c1c55"
 dependencies = [
- "base64",
+ "base64 0.21.2",
  "bytes",
  "encoding_rs",
  "futures-core",
@@ -2178,7 +2314,7 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
- "rustls",
+ "rustls 0.21.7",
  "rustls-native-certs",
  "rustls-pemfile",
  "serde",
@@ -2203,7 +2339,7 @@ version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c2a11a646ef5d4e4a9d5cf80c7e4ecb20f9b1954292d5c5e6d6cbc8d33728ec"
 dependencies = [
- "ahash",
+ "ahash 0.8.3",
  "bitflags 1.3.2",
  "instant",
  "num-traits",
@@ -2281,6 +2417,45 @@ dependencies = [
 ]
 
 [[package]]
+name = "rust-ini"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6d5f2436026b4f6e79dc829837d467cc7e9a55ee40e750d716713540715a2df"
+dependencies = [
+ "cfg-if",
+ "ordered-multimap",
+]
+
+[[package]]
+name = "rust-s3"
+version = "0.33.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b2ac5ff6acfbe74226fa701b5ef793aaa054055c13ebb7060ad36942956e027"
+dependencies = [
+ "async-trait",
+ "attohttpc",
+ "aws-creds",
+ "aws-region",
+ "base64 0.13.1",
+ "bytes",
+ "cfg-if",
+ "hex",
+ "hmac",
+ "http",
+ "log",
+ "maybe-async",
+ "md5",
+ "percent-encoding",
+ "quick-xml 0.26.0",
+ "serde",
+ "serde_derive",
+ "sha2",
+ "thiserror",
+ "time",
+ "url",
+]
+
+[[package]]
 name = "rustc-demangle"
 version = "0.1.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2340,7 +2515,7 @@ dependencies = [
  "dialoguer",
  "dircmp",
  "directories",
- "dirs",
+ "dirs 5.0.1",
  "dunce",
  "enum-map",
  "enum-map-derive",
@@ -2365,6 +2540,7 @@ dependencies = [
  "rhai",
  "rstest",
  "rstest_reuse",
+ "rust-s3",
  "rustic_core",
  "rustic_testing",
  "scrypt",
@@ -2408,7 +2584,7 @@ dependencies = [
  "derive_more",
  "derive_setters",
  "directories",
- "dirs",
+ "dirs 5.0.1",
  "displaydoc",
  "dunce",
  "enum-map",
@@ -2434,6 +2610,7 @@ dependencies = [
  "rayon",
  "reqwest",
  "rstest",
+ "rust-s3",
  "rustdoc-json",
  "rustup-toolchain",
  "scrypt",
@@ -2491,9 +2668,21 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.21.6"
+version = "0.20.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d1feddffcfcc0b33f5c6ce9a29e341e4cd59c3f78e7ee45f4a40c038b1d6cbb"
+checksum = "1b80e3dec595989ea8510028f30c408a4630db12c9cbb8de34203b89d6577e99"
+dependencies = [
+ "log",
+ "ring",
+ "sct",
+ "webpki",
+]
+
+[[package]]
+name = "rustls"
+version = "0.21.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd8d6c9f025a446bc4d18ad9632e69aec8f287aa84499ee335599fabd20c3fd8"
 dependencies = [
  "log",
  "ring",
@@ -2519,7 +2708,7 @@ version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2d3987094b1d07b653b7dfdc3f70ce9a1da9c51ac18c1b06b662e4f9a0e9f4b2"
 dependencies = [
- "base64",
+ "base64 0.21.2",
 ]
 
 [[package]]
@@ -2651,7 +2840,7 @@ dependencies = [
  "hyper",
  "indicatif",
  "log",
- "quick-xml",
+ "quick-xml 0.23.1",
  "regex",
  "reqwest",
  "semver",
@@ -2739,7 +2928,7 @@ version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1402f54f9a3b9e2efe71c1cea24e648acce55887983553eeb858cf3115acfd49"
 dependencies = [
- "base64",
+ "base64 0.21.2",
  "chrono",
  "hex",
  "indexmap 1.9.3",
@@ -3138,7 +3327,7 @@ version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
 dependencies = [
- "rustls",
+ "rustls 0.21.7",
  "tokio",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -126,6 +126,8 @@ aho-corasick = { workspace = true }
 dircmp = { workspace = true }
 once_cell = { workspace = true }
 pretty_assertions = { workspace = true }
+rstest = { workspace = true }
+rstest_reuse.workspace = true
 rustic_testing = { path = "crates/rustic_testing" }
 tempfile = { workspace = true }
 toml = { workspace = true }
@@ -232,6 +234,7 @@ self_update = { version = "0.37", default-features = false, features = ["rustls"
 
 # dev dependencies
 rstest = "0.18"
+rstest_reuse = "0.6.0"
 quickcheck = "1"
 quickcheck_macros = "1"
 tempfile = "3.8"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,6 +62,9 @@ tracing-subscriber = { workspace = true }
 # rclone backend
 semver = { workspace = true }
 
+# s3 backend
+rust-s3 = { workspace = true }
+
 # parallelize
 crossbeam-channel = { workspace = true }
 pariter = { workspace = true }
@@ -201,6 +204,11 @@ url = "2.4.0"
 
 # rclone backend
 semver = "1"
+
+# s3 backend
+rust-s3 = { version = "0.33.0", features = [
+    "sync-rustls-tls",
+], default-features = false }
 
 # other dependencies
 bytes = "1"

--- a/crates/rustic_core/Cargo.toml
+++ b/crates/rustic_core/Cargo.toml
@@ -94,6 +94,9 @@ url = { workspace = true }
 # rclone backend
 semver = { workspace = true }
 
+# s3 backend
+rust-s3 = { workspace = true }
+
 # cache
 cachedir = { workspace = true }
 dirs = { workspace = true }
@@ -144,7 +147,7 @@ codegen-units = 4
 
 [profile.release]
 opt-level = 3
-debug = false # true for profiling
+debug = false            # true for profiling
 rpath = false
 lto = "fat"
 debug-assertions = false
@@ -161,7 +164,7 @@ codegen-units = 4
 
 [profile.bench]
 opt-level = 3
-debug = true # true for profiling
+debug = true             # true for profiling
 rpath = false
 lto = true
 debug-assertions = false

--- a/crates/rustic_core/src/backend.rs
+++ b/crates/rustic_core/src/backend.rs
@@ -8,6 +8,7 @@ pub(crate) mod local;
 pub(crate) mod node;
 pub(crate) mod rclone;
 pub(crate) mod rest;
+pub(crate) mod s3;
 pub(crate) mod stdin;
 
 use std::{io::Read, path::PathBuf};

--- a/crates/rustic_core/src/backend/choose.rs
+++ b/crates/rustic_core/src/backend/choose.rs
@@ -2,8 +2,8 @@ use bytes::Bytes;
 
 use crate::{
     backend::{
-        local::LocalBackend, rclone::RcloneBackend, rest::RestBackend, FileType, ReadBackend,
-        WriteBackend,
+        local::LocalBackend, rclone::RcloneBackend, rest::RestBackend, s3::S3Backend, FileType,
+        ReadBackend, WriteBackend,
     },
     error::BackendErrorKind,
     error::RusticResult,
@@ -19,6 +19,7 @@ pub enum ChooseBackend {
     Rest(RestBackend),
     /// Rclone backend.
     Rclone(RcloneBackend),
+    S3(S3Backend),
 }
 
 impl ChooseBackend {
@@ -41,6 +42,7 @@ impl ChooseBackend {
             Some(("rclone", path)) => Self::Rclone(RcloneBackend::new(path)?),
             Some(("rest", path)) => Self::Rest(RestBackend::new(path)?),
             Some(("local", path)) => Self::Local(LocalBackend::new(path)?),
+            Some(("s3", path)) => Self::S3(S3Backend::new(path)?),
             Some((backend, _)) => {
                 return Err(BackendErrorKind::BackendNotSupported(backend.to_owned()).into())
             }
@@ -56,6 +58,7 @@ impl ReadBackend for ChooseBackend {
             Self::Local(local) => local.location(),
             Self::Rest(rest) => rest.location(),
             Self::Rclone(rclone) => rclone.location(),
+            Self::S3(s3) => s3.location(),
         }
     }
 
@@ -70,6 +73,7 @@ impl ReadBackend for ChooseBackend {
             Self::Local(local) => local.set_option(option, value),
             Self::Rest(rest) => rest.set_option(option, value),
             Self::Rclone(rclone) => rclone.set_option(option, value),
+            Self::S3(s3) => s3.set_option(option, value),
         }
     }
 
@@ -91,6 +95,7 @@ impl ReadBackend for ChooseBackend {
             Self::Local(local) => local.list_with_size(tpe),
             Self::Rest(rest) => rest.list_with_size(tpe),
             Self::Rclone(rclone) => rclone.list_with_size(tpe),
+            Self::S3(s3) => s3.list_with_size(tpe),
         }
     }
 
@@ -115,6 +120,7 @@ impl ReadBackend for ChooseBackend {
             Self::Local(local) => local.read_full(tpe, id),
             Self::Rest(rest) => rest.read_full(tpe, id),
             Self::Rclone(rclone) => rclone.read_full(tpe, id),
+            Self::S3(s3) => s3.read_full(tpe, id),
         }
     }
 
@@ -143,6 +149,7 @@ impl ReadBackend for ChooseBackend {
             Self::Local(local) => local.read_partial(tpe, id, cacheable, offset, length),
             Self::Rest(rest) => rest.read_partial(tpe, id, cacheable, offset, length),
             Self::Rclone(rclone) => rclone.read_partial(tpe, id, cacheable, offset, length),
+            Self::S3(s3) => s3.read_partial(tpe, id, cacheable, offset, length),
         }
     }
 }
@@ -154,6 +161,7 @@ impl WriteBackend for ChooseBackend {
             Self::Local(local) => local.create(),
             Self::Rest(rest) => rest.create(),
             Self::Rclone(rclone) => rclone.create(),
+            Self::S3(s3) => s3.create(),
         }
     }
 
@@ -170,6 +178,7 @@ impl WriteBackend for ChooseBackend {
             Self::Local(local) => local.write_bytes(tpe, id, cacheable, buf),
             Self::Rest(rest) => rest.write_bytes(tpe, id, cacheable, buf),
             Self::Rclone(rclone) => rclone.write_bytes(tpe, id, cacheable, buf),
+            Self::S3(s3) => s3.write_bytes(tpe, id, cacheable, buf),
         }
     }
 
@@ -185,6 +194,7 @@ impl WriteBackend for ChooseBackend {
             Self::Local(local) => local.remove(tpe, id, cacheable),
             Self::Rest(rest) => rest.remove(tpe, id, cacheable),
             Self::Rclone(rclone) => rclone.remove(tpe, id, cacheable),
+            Self::S3(s3) => s3.remove(tpe, id, cacheable),
         }
     }
 }

--- a/crates/rustic_core/src/backend/s3.rs
+++ b/crates/rustic_core/src/backend/s3.rs
@@ -1,0 +1,355 @@
+use std::time::Duration;
+use std::{collections::HashSet, env};
+
+use crate::{
+    backend::{FileType, ReadBackend, WriteBackend, ALL_FILE_TYPES},
+    error::S3ErrorKind,
+    Id, RusticResult,
+};
+
+use backoff::{backoff::Backoff, ExponentialBackoff, ExponentialBackoffBuilder};
+use log::{info, trace, warn};
+use s3::{
+    bucket::Bucket, creds::Credentials, error::S3Error, request::ResponseData, BucketConfiguration,
+    Region,
+};
+use url::Url;
+
+mod consts {
+    pub(super) const DEFAULT_RETRY: usize = 5;
+}
+
+// trait CheckError to add user-defined method check_error on ResponseData
+pub(crate) trait CheckError {
+    fn check_error(self) -> Result<ResponseData, S3Error>;
+}
+
+impl CheckError for ResponseData {
+    // Check rust-s3 ResponseData for error and convert to error result
+    fn check_error(self) -> Result<ResponseData, S3Error> {
+        match self.status_code() {
+            200..=299 => Ok(self),
+            code => Err(S3Error::Http(code, "error in response".to_owned())),
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+struct WaitForLockBackoff {
+    max_retries: usize,
+    retries: usize,
+    exp: ExponentialBackoff,
+}
+
+impl Default for WaitForLockBackoff {
+    fn default() -> Self {
+        Self {
+            max_retries: consts::DEFAULT_RETRY,
+            retries: 0,
+            exp: ExponentialBackoffBuilder::new()
+                .with_max_elapsed_time(None) // no maximum elapsed time; we count number of retires
+                .build(),
+        }
+    }
+}
+
+impl Backoff for WaitForLockBackoff {
+    fn next_backoff(&mut self) -> Option<Duration> {
+        self.retries += 1;
+        if self.retries > self.max_retries {
+            None
+        } else {
+            self.exp.next_backoff()
+        }
+    }
+
+    fn reset(&mut self) {
+        self.retries = 0;
+        self.exp.reset();
+    }
+}
+
+fn notify(err: S3Error, duration: Duration) {
+    info!("Error {err} at {duration:?}, retrying");
+}
+
+#[derive(Clone, Debug)]
+pub struct S3Backend {
+    bucket: Bucket,
+    backoff: WaitForLockBackoff,
+}
+
+fn parse_s3_url(url: &str) -> RusticResult<(Option<String>, String)> {
+    let url_error = || S3ErrorKind::ParsingS3UrlFailed(url.to_owned());
+
+    if url.contains("://") {
+        let path_style_url: Url = url
+            .parse()
+            .map_err(S3Error::UrlParse)
+            .map_err(S3ErrorKind::S3Error)?;
+
+        let host = path_style_url.host().ok_or_else(url_error)?;
+        let scheme = path_style_url.scheme();
+
+        let valid_schemes = HashSet::from(["http", "https"]);
+
+        if !valid_schemes.contains(&scheme) {
+            return Err(S3ErrorKind::InvalidScheme(scheme.to_owned()).into());
+        }
+
+        let port = path_style_url
+            .port()
+            .map(|p| format!(":{}", p))
+            .unwrap_or_else(|| "".to_string());
+
+        let endpoint = format!("{}://{}{}", scheme, host, port);
+
+        let bucket = path_style_url
+            .path()
+            .strip_prefix("/")
+            .ok_or_else(url_error)?
+            .to_owned();
+
+        if bucket.is_empty() {
+            return Err(S3ErrorKind::MissingBucketName(url.to_owned()).into());
+        }
+
+        return Ok((Some(endpoint), bucket));
+    } else {
+        let bucket = url.to_owned();
+
+        return Ok((None, bucket));
+    }
+}
+
+fn get_s3_region(endpoint: Option<String>) -> RusticResult<Region> {
+    let region = match endpoint {
+        Some(endpoint) => env::var("AWS_REGION")
+            .map(|region| Region::Custom { region, endpoint })
+            .map_err(|e| s3::region::error::RegionError::Env { source: e }),
+        None => Region::from_default_env(),
+    }
+    .map_err(S3ErrorKind::RegionError)?;
+
+    Ok(region)
+}
+
+fn object_path(tpe: FileType, id: Option<&Id>) -> String {
+    match tpe {
+        FileType::Config => format!("{}", tpe.dirname()),
+        FileType::Pack => {
+            if let Some(id) = id {
+                let hex_id = id.to_hex();
+                format!("{}/{}/{}", tpe.dirname(), &hex_id[..2], hex_id.to_string())
+            } else {
+                format!("{}/", tpe.dirname())
+            }
+        }
+        _ => {
+            if let Some(id) = id {
+                format!("{}/{}", tpe.dirname(), id.to_hex().to_string())
+            } else {
+                format!("{}/", tpe.dirname())
+            }
+        }
+    }
+}
+
+impl S3Backend {
+    pub fn new(url: &str) -> RusticResult<Self> {
+        let (endpoint, bucket) = parse_s3_url(url)?;
+
+        let region = get_s3_region(endpoint)?;
+        let credentials = Credentials::default().map_err(S3ErrorKind::CredentialsError)?;
+
+        let bucket = Bucket::new(&bucket, region, credentials)
+            .map_err(S3ErrorKind::S3Error)?
+            .with_path_style();
+
+        let backoff = WaitForLockBackoff::default();
+
+        Ok(Self { bucket, backoff })
+    }
+
+    fn path_style_url(&self) -> String {
+        format!(
+            "{}://{}/{}",
+            self.bucket.scheme(),
+            self.bucket.path_style_host(),
+            self.bucket.name()
+        )
+    }
+
+    fn call_with_retry(
+        &self,
+        f: impl Fn() -> Result<ResponseData, S3Error> + Send + Sync,
+    ) -> RusticResult<ResponseData> {
+        let backoff = self.backoff.clone();
+
+        let retry = || {
+            let response = f().map_err(|err| match err {
+                S3Error::WLCredentials => backoff::Error::Transient {
+                    err,
+                    retry_after: None,
+                },
+                S3Error::RLCredentials => backoff::Error::Transient {
+                    err,
+                    retry_after: None,
+                },
+                _ => {
+                    warn!("call_with_retry failed: {:?}", err);
+                    backoff::Error::Permanent(err)
+                }
+            })?;
+
+            Ok(response)
+        };
+
+        Ok(backoff::retry_notify(backoff, retry, notify)
+            .map_err(S3ErrorKind::BackoffError)?
+            .check_error()
+            .map_err(S3ErrorKind::S3Error)?)
+    }
+}
+
+impl ReadBackend for S3Backend {
+    fn location(&self) -> String {
+        let mut location = "s3:".to_string();
+        location.push_str(&self.path_style_url());
+        location
+    }
+
+    fn set_option(&mut self, _option: &str, _value: &str) -> RusticResult<()> {
+        todo!()
+    }
+
+    fn list_with_size(&self, tpe: FileType) -> RusticResult<Vec<(Id, u32)>> {
+        trace!("listing tpe: {:?}", &tpe);
+
+        if tpe == FileType::Config {
+            let config_response = self
+                .bucket
+                .get_object("config")
+                .map_err(S3ErrorKind::S3Error)?;
+            if config_response.status_code() == 200 {
+                return Ok(vec![(Id::default(), config_response.bytes().len() as u32)]);
+            } else {
+                return Ok(vec![]);
+            }
+        }
+
+        let path = object_path(tpe, None);
+        let list_bucket_result = match self.bucket.list(path, None) {
+            Ok(res) => res,
+            Err(e) => match e {
+                S3Error::SerdeXml(_) => Vec::new(),
+                _ => return Err(S3ErrorKind::S3Error(e).into()),
+            },
+        };
+
+        let walker = list_bucket_result.iter().flat_map(|r| {
+            r.contents.iter().filter_map(|object| {
+                let key = object.key.split("/").last().filter(|s| !s.is_empty());
+
+                let res = match key {
+                    Some(key) => Id::from_hex(key),
+                    None => return None,
+                };
+
+                let size = object.size as u32;
+
+                match res {
+                    Ok(id) => Some((id, size)),
+                    Err(e) => {
+                        warn!("failed to parse id from key: {:?} with error {}", key, e);
+                        None
+                    }
+                }
+            })
+        });
+
+        let res = walker.collect();
+
+        Ok(res)
+    }
+
+    fn read_full(&self, tpe: FileType, id: &Id) -> RusticResult<bytes::Bytes> {
+        trace!("reading tpe: {:?}, id: {}", &tpe, &id);
+
+        let path = object_path(tpe, Some(id));
+        let object = self.call_with_retry(|| self.bucket.get_object(&path))?;
+
+        Ok(object.bytes().to_owned())
+    }
+
+    fn read_partial(
+        &self,
+        tpe: FileType,
+        id: &Id,
+        _cacheable: bool,
+        offset: u32,
+        length: u32,
+    ) -> RusticResult<bytes::Bytes> {
+        trace!("reading tpe: {tpe:?}, id: {id}, offset: {offset}, length: {length}");
+
+        let path = object_path(tpe, Some(id));
+        let object_range = self.call_with_retry(|| {
+            self.bucket
+                .get_object_range(&path, offset as u64, Some((length + offset - 1) as u64))
+        })?;
+
+        Ok(object_range.bytes().to_owned())
+    }
+}
+
+impl WriteBackend for S3Backend {
+    fn create(&self) -> RusticResult<()> {
+        trace!("creating repo at {:?}", self.location());
+
+        let res = Bucket::create_with_path_style(
+            &self.bucket.name,
+            self.bucket.region.clone(),
+            self.bucket.credentials.read().unwrap().clone(),
+            BucketConfiguration::default(),
+        )
+        .map_err(S3ErrorKind::S3Error)?;
+
+        if !res.success() {
+            return Err(
+                // TODO: the response text is formatted as XML. Deserialize it and extract the error message.
+                S3ErrorKind::CreateBucketFailed(res.response_text, res.response_code).into(),
+            );
+        };
+
+        for tpe in ALL_FILE_TYPES {
+            let path = object_path(tpe, None);
+            let _ = self.call_with_retry(|| self.bucket.put_object(&path, &[]))?;
+        }
+
+        Ok(())
+    }
+
+    fn write_bytes(
+        &self,
+        tpe: FileType,
+        id: &Id,
+        _cacheable: bool,
+        buf: bytes::Bytes,
+    ) -> RusticResult<()> {
+        trace!("writing tpe: {:?}, id: {}", &tpe, &id);
+
+        let path = object_path(tpe, Some(id));
+        let _ = self.call_with_retry(|| self.bucket.put_object(&path, &buf))?;
+
+        Ok(())
+    }
+
+    fn remove(&self, tpe: FileType, id: &Id, _cacheable: bool) -> RusticResult<()> {
+        trace!("removing tpe: {:?}, id: {}", &tpe, &id);
+
+        let path = object_path(tpe, Some(id));
+        let _ = self.call_with_retry(|| self.bucket.delete_object(&path))?;
+
+        Ok(())
+    }
+}

--- a/crates/rustic_core/src/error.rs
+++ b/crates/rustic_core/src/error.rs
@@ -135,6 +135,10 @@ pub enum RusticErrorKind {
     #[error(transparent)]
     Rest(#[from] RestErrorKind),
 
+    /// [`S3ErrorKind`] describes the errors that can be returned while dealing with S3
+    #[error(transparent)]
+    S3(#[from] S3ErrorKind),
+
     /// [`StdInErrorKind`] describes the errors that can be returned while dealing IO from CLI
     #[error(transparent)]
     StdIn(#[from] StdInErrorKind),
@@ -742,6 +746,30 @@ pub enum RestErrorKind {
     JoiningUrlFailed(url::ParseError),
 }
 
+/// [`S3ErrorKind`] describes the errors that can be returned while dealing with S3
+#[derive(Error, Debug, Display)]
+pub enum S3ErrorKind {
+    /// `{0:?}`
+    CredentialsError(#[from] s3::creds::error::CredentialsError),
+    /// `{0:?}`
+    #[error(transparent)]
+    S3Error(#[from] s3::error::S3Error),
+    /// `failed to pass url: {0}`
+    ParsingS3UrlFailed(String),
+    /// `No bucket name defined in url: {0:?}`
+    MissingBucketName(String),
+    /// `invalid scheme: {0}`
+    InvalidScheme(String),
+    /// `received status code {0} in response`
+    ResponseStatusError(u16),
+    /// `failed to create bucket with response {1}: {0}`
+    CreateBucketFailed(String, u16),
+    /// backoff failed: {0:?}
+    BackoffError(#[from] backoff::Error<s3::error::S3Error>),
+    /// `{0:?}`
+    RegionError(#[from] s3::region::error::RegionError),
+}
+
 /// [`StdInErrorKind`] describes the errors that can be returned while dealing IO from CLI
 #[derive(Error, Debug, Display)]
 pub enum StdInErrorKind {
@@ -809,6 +837,7 @@ impl RusticErrorMarker for LocalErrorKind {}
 impl RusticErrorMarker for NodeErrorKind {}
 impl RusticErrorMarker for ProviderErrorKind {}
 impl RusticErrorMarker for RestErrorKind {}
+impl RusticErrorMarker for S3ErrorKind {}
 impl RusticErrorMarker for StdInErrorKind {}
 impl RusticErrorMarker for ArchiverErrorKind {}
 impl RusticErrorMarker for CommandErrorKind {}

--- a/devenv.lock
+++ b/devenv.lock
@@ -1,0 +1,156 @@
+{
+  "nodes": {
+    "devenv": {
+      "locked": {
+        "dir": "src/modules",
+        "lastModified": 1693830477,
+        "narHash": "sha256-6j1oNRpjGseDbgg6mJ9H3gmX5U+VAubOLV+iFL9WW30=",
+        "owner": "cachix",
+        "repo": "devenv",
+        "rev": "f839f486b98609f3477c0410b31a6f831b390d48",
+        "type": "github"
+      },
+      "original": {
+        "dir": "src/modules",
+        "owner": "cachix",
+        "repo": "devenv",
+        "type": "github"
+      }
+    },
+    "flake-compat": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1673956053,
+        "narHash": "sha256-4gtG9iQuiKITOjNQQeQIpoIB6b16fm+504Ch3sNKLd8=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "35bb57c0c8d8b62bbfd284272c928ceb64ddbde9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1685518550,
+        "narHash": "sha256-o2d0KcvaXzTrPRIo0kOLV0/QXHhDQ5DTi+OxcjO8xqY=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "a1720a10a6cfe8234c0e93907ffe81be440f4cef",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "gitignore": {
+      "inputs": {
+        "nixpkgs": [
+          "pre-commit-hooks",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1660459072,
+        "narHash": "sha256-8DFJjXG8zqoONA1vXtgeKXy68KdJL5UaXR8NtVMUbx8=",
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "rev": "a20de23b925fd8264fd7fad6454652e142fd7f73",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1693844670,
+        "narHash": "sha256-t69F2nBB8DNQUWHD809oJZJVE+23XBrth4QZuVd6IE0=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "3c15feef7770eb5500a4b8792623e2d6f598c9c1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-stable": {
+      "locked": {
+        "lastModified": 1685801374,
+        "narHash": "sha256-otaSUoFEMM+LjBI1XL/xGB5ao6IwnZOXc47qhIgJe8U=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "c37ca420157f4abc31e26f436c1145f8951ff373",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-23.05",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "pre-commit-hooks": {
+      "inputs": {
+        "flake-compat": "flake-compat",
+        "flake-utils": "flake-utils",
+        "gitignore": "gitignore",
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "nixpkgs-stable": "nixpkgs-stable"
+      },
+      "locked": {
+        "lastModified": 1692274144,
+        "narHash": "sha256-BxTQuRUANQ81u8DJznQyPmRsg63t4Yc+0kcyq6OLz8s=",
+        "owner": "cachix",
+        "repo": "pre-commit-hooks.nix",
+        "rev": "7e3517c03d46159fdbf8c0e5c97f82d5d4b0c8fa",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cachix",
+        "repo": "pre-commit-hooks.nix",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "devenv": "devenv",
+        "nixpkgs": "nixpkgs",
+        "pre-commit-hooks": "pre-commit-hooks"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/devenv.nix
+++ b/devenv.nix
@@ -1,0 +1,18 @@
+{
+  pkgs,
+  config,
+  ...
+}: {
+  env = {
+    AWS_ACCESS_KEY_ID = config.services.minio.accessKey;
+    AWS_SECRET_ACCESS_KEY = config.services.minio.secretKey;
+    AWS_REGION = "us-east-1";
+  };
+
+  services.minio = {
+    enable = true;
+
+    accessKey = "testAccessKey";
+    secretKey = "testSecretKey";
+  };
+}

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,393 @@
+{
+  "nodes": {
+    "advisory-db": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1693837997,
+        "narHash": "sha256-5oUKsBkI8FWn5Nm6nVe/cerxvzq/Yhw1+mPpyosFcTY=",
+        "owner": "rustsec",
+        "repo": "advisory-db",
+        "rev": "53652d63d254dbaa2a91660fdcc169e2226a2b76",
+        "type": "github"
+      },
+      "original": {
+        "owner": "rustsec",
+        "repo": "advisory-db",
+        "type": "github"
+      }
+    },
+    "crane": {
+      "inputs": {
+        "flake-compat": "flake-compat",
+        "flake-utils": "flake-utils",
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "rust-overlay": "rust-overlay"
+      },
+      "locked": {
+        "lastModified": 1693787605,
+        "narHash": "sha256-rwq5U8dy+a9JFny/73L0SJu1GfWwATMPMTp7D+mjHy8=",
+        "owner": "ipetkov",
+        "repo": "crane",
+        "rev": "8b4f7a4dab2120cf41e7957a28a853f45016bd9d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "ipetkov",
+        "repo": "crane",
+        "type": "github"
+      }
+    },
+    "devenv": {
+      "inputs": {
+        "flake-compat": "flake-compat_2",
+        "nix": "nix",
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "pre-commit-hooks": "pre-commit-hooks"
+      },
+      "locked": {
+        "lastModified": 1693830477,
+        "narHash": "sha256-6j1oNRpjGseDbgg6mJ9H3gmX5U+VAubOLV+iFL9WW30=",
+        "owner": "cachix",
+        "repo": "devenv",
+        "rev": "f839f486b98609f3477c0410b31a6f831b390d48",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cachix",
+        "repo": "devenv",
+        "type": "github"
+      }
+    },
+    "fenix": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "rust-analyzer-src": []
+      },
+      "locked": {
+        "lastModified": 1693894882,
+        "narHash": "sha256-t3z7trhpeZKBckwQkXdXG3FvL9spxCyyVAO9LZ9oZyI=",
+        "owner": "nix-community",
+        "repo": "fenix",
+        "rev": "52a05c3c76b3e2b627edc81d57ab35877846bfae",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "fenix",
+        "type": "github"
+      }
+    },
+    "flake-compat": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1673956053,
+        "narHash": "sha256-4gtG9iQuiKITOjNQQeQIpoIB6b16fm+504Ch3sNKLd8=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "35bb57c0c8d8b62bbfd284272c928ceb64ddbde9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "flake-compat_2": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1673956053,
+        "narHash": "sha256-4gtG9iQuiKITOjNQQeQIpoIB6b16fm+504Ch3sNKLd8=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "35bb57c0c8d8b62bbfd284272c928ceb64ddbde9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1692799911,
+        "narHash": "sha256-3eihraek4qL744EvQXsK1Ha6C3CR7nnT8X2qWap4RNk=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "f9e7cf818399d17d347f847525c5a5a8032e4e44",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "flake-utils_2": {
+      "inputs": {
+        "systems": "systems_2"
+      },
+      "locked": {
+        "lastModified": 1685518550,
+        "narHash": "sha256-o2d0KcvaXzTrPRIo0kOLV0/QXHhDQ5DTi+OxcjO8xqY=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "a1720a10a6cfe8234c0e93907ffe81be440f4cef",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "flake-utils_3": {
+      "inputs": {
+        "systems": "systems_3"
+      },
+      "locked": {
+        "lastModified": 1692799911,
+        "narHash": "sha256-3eihraek4qL744EvQXsK1Ha6C3CR7nnT8X2qWap4RNk=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "f9e7cf818399d17d347f847525c5a5a8032e4e44",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "gitignore": {
+      "inputs": {
+        "nixpkgs": [
+          "devenv",
+          "pre-commit-hooks",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1660459072,
+        "narHash": "sha256-8DFJjXG8zqoONA1vXtgeKXy68KdJL5UaXR8NtVMUbx8=",
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "rev": "a20de23b925fd8264fd7fad6454652e142fd7f73",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "type": "github"
+      }
+    },
+    "lowdown-src": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1633514407,
+        "narHash": "sha256-Dw32tiMjdK9t3ETl5fzGrutQTzh2rufgZV4A/BbxuD4=",
+        "owner": "kristapsdz",
+        "repo": "lowdown",
+        "rev": "d2c2b44ff6c27b936ec27358a2653caaef8f73b8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "kristapsdz",
+        "repo": "lowdown",
+        "type": "github"
+      }
+    },
+    "nix": {
+      "inputs": {
+        "lowdown-src": "lowdown-src",
+        "nixpkgs": [
+          "devenv",
+          "nixpkgs"
+        ],
+        "nixpkgs-regression": "nixpkgs-regression"
+      },
+      "locked": {
+        "lastModified": 1676545802,
+        "narHash": "sha256-EK4rZ+Hd5hsvXnzSzk2ikhStJnD63odF7SzsQ8CuSPU=",
+        "owner": "domenkozar",
+        "repo": "nix",
+        "rev": "7c91803598ffbcfe4a55c44ac6d49b2cf07a527f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "domenkozar",
+        "ref": "relaxed-flakes",
+        "repo": "nix",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1693844670,
+        "narHash": "sha256-t69F2nBB8DNQUWHD809oJZJVE+23XBrth4QZuVd6IE0=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "3c15feef7770eb5500a4b8792623e2d6f598c9c1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-regression": {
+      "locked": {
+        "lastModified": 1643052045,
+        "narHash": "sha256-uGJ0VXIhWKGXxkeNnq4TvV3CIOkUJ3PAoLZ3HMzNVMw=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "215d4d0fd80ca5163643b03a33fde804a29cc1e2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "215d4d0fd80ca5163643b03a33fde804a29cc1e2",
+        "type": "github"
+      }
+    },
+    "nixpkgs-stable": {
+      "locked": {
+        "lastModified": 1685801374,
+        "narHash": "sha256-otaSUoFEMM+LjBI1XL/xGB5ao6IwnZOXc47qhIgJe8U=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "c37ca420157f4abc31e26f436c1145f8951ff373",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-23.05",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "pre-commit-hooks": {
+      "inputs": {
+        "flake-compat": [
+          "devenv",
+          "flake-compat"
+        ],
+        "flake-utils": "flake-utils_2",
+        "gitignore": "gitignore",
+        "nixpkgs": [
+          "devenv",
+          "nixpkgs"
+        ],
+        "nixpkgs-stable": "nixpkgs-stable"
+      },
+      "locked": {
+        "lastModified": 1688056373,
+        "narHash": "sha256-2+SDlNRTKsgo3LBRiMUcoEUb6sDViRNQhzJquZ4koOI=",
+        "owner": "cachix",
+        "repo": "pre-commit-hooks.nix",
+        "rev": "5843cf069272d92b60c3ed9e55b7a8989c01d4c7",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cachix",
+        "repo": "pre-commit-hooks.nix",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "advisory-db": "advisory-db",
+        "crane": "crane",
+        "devenv": "devenv",
+        "fenix": "fenix",
+        "flake-utils": "flake-utils_3",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "rust-overlay": {
+      "inputs": {
+        "flake-utils": [
+          "crane",
+          "flake-utils"
+        ],
+        "nixpkgs": [
+          "crane",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1693707092,
+        "narHash": "sha256-HR1EnynBSPqbt+04/yxxqsG1E3n6uXrOl7SPco/UnYo=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "98ccb73e6eefc481da6039ee57ad8818d1ca8d56",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "systems_2": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "systems_3": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,68 @@
+{
+  description = "Build a cargo project";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+
+    devenv = {
+      url = "github:cachix/devenv";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+
+    crane = {
+      url = "github:ipetkov/crane";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+
+    fenix = {
+      url = "github:nix-community/fenix";
+      inputs.nixpkgs.follows = "nixpkgs";
+      inputs.rust-analyzer-src.follows = "";
+    };
+
+    flake-utils.url = "github:numtide/flake-utils";
+
+    advisory-db = {
+      url = "github:rustsec/advisory-db";
+      flake = false;
+    };
+  };
+
+  outputs = {
+    self,
+    nixpkgs,
+    devenv,
+    crane,
+    fenix,
+    flake-utils,
+    advisory-db,
+    ...
+  } @ inputs:
+    flake-utils.lib.eachDefaultSystem (system: let
+      pkgs = import nixpkgs {
+        inherit system;
+      };
+
+      inherit (pkgs) lib;
+    in {
+      devShells = {
+        default = devenv.lib.mkShell {
+          inherit inputs;
+          pkgs = nixpkgs.legacyPackages.${system};
+          modules = [
+            ({
+              pkgs ? (import ./nixpkgs.nix) {},
+              config,
+              ...
+            }: {
+              packages = [devenv.packages.${system}.default];
+              languages.rust = {
+                enable = true;
+              };
+            })
+            ./devenv.nix
+          ];
+        };
+      };
+    });
+}

--- a/nixpkgs.nix
+++ b/nixpkgs.nix
@@ -1,0 +1,9 @@
+# A nixpkgs instance that is grabbed from the pinned nixpkgs commit in the lock file
+# This is useful to avoid using channels when using legacy nix commands
+let
+  lock = (builtins.fromJSON (builtins.readFile ./flake.lock)).nodes.nixpkgs.locked;
+in
+  import (fetchTarball {
+    url = "https://github.com/nixos/nixpkgs/archive/${lock.rev}.tar.gz";
+    sha256 = lock.narHash;
+  })


### PR DESCRIPTION
This PR adds an S3 backend which improves the drop-in-ability of rustic as a replacement for Restic.

When reviewing the code I highly recommend doing it one commit at a time, since some of these will be dropped before the PR is marked as ready. I have included them to show how I have tested the code.

When the PR is ready for review I will also squash the undropped commits into a single one, as per the contribution guidelines.

closes #546 