### PR TITLE
`cargo-install-update` + `cargo-binstall`: Failed to parse cargo manifest

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -152,7 +152,7 @@ dircmp = "0.2"
 [package.metadata.binstall]
 pkg-url = "{ repo }/releases/download/v{ version }/{ repo }-v{ version }-{ target }{ archive-suffix }"
 bin-dir = "{ bin }-{ target }/{ bin }{ binary-ext }"
-pkg-fmt = "tar.gz"
+pkg-fmt = "tgz"
 
 [package.metadata.binstall.signing]
 algorithm = "minisign"


### PR DESCRIPTION
While invoking `cargo-install-update -a`, and having `rustic-rs` installed:

```plain
ERROR Fatal error:
  × For crate rustic-rs: Failed to parse cargo manifest: TOML parse error at line 44, column 11
  │    |
  │ 44 | pkg-fmt = "tar.gz"
  │    |           ^^^^^^^^
  │ unknown variant `tar.gz`, expected one of `tar`, `tbz2`, `tgz`, `txz`, `tzstd`, `zip`, `bin`
  │
  ├─▶ Failed to parse cargo manifest: TOML parse error at line 44, column 11
  │      |
  │   44 | pkg-fmt = "tar.gz"
  │      |           ^^^^^^^^
  │   unknown variant `tar.gz`, expected one of `tar`, `tbz2`, `tgz`, `txz`, `tzstd`, `zip`, `bin`
  │
  ├─▶ TOML parse error at line 44, column 11
  │      |
  │   44 | pkg-fmt = "tar.gz"
  │      |           ^^^^^^^^
  │   unknown variant `tar.gz`, expected one of `tar`, `tbz2`, `tgz`, `txz`, `tzstd`, `zip`, `bin`
  │
  ╰─▶ TOML parse error at line 44, column 11
         |
      44 | pkg-fmt = "tar.gz"
         |           ^^^^^^^^
      unknown variant `tar.gz`, expected one of `tar`, `tbz2`, `tgz`, `txz`, `tzstd`, `zip`, `bin`
```

This PR changes the value to `tgz`.