### PR TITLE
#950: Enable RPM file build target

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -204,5 +204,5 @@ codegen-units = 1
 # will result in a file like target/generate-rpm/rustic-rs-0.6.1-1.x86_64.rpm
 [package.metadata.generate-rpm]
 assets = [
-    { source = "target/release/rustic", dest = "/usr/bin/rustic", mode = "0755", config = false, doc = false, user = "root", group = "root" }
+  { source = "target/release/rustic", dest = "/usr/bin/rustic", mode = "0755", config = false, doc = false, user = "root", group = "root" },
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -198,3 +198,11 @@ rpath = false
 lto = true
 debug-assertions = false
 codegen-units = 1
+
+# Allows quick RPM file generation, if "cargo-generate-rpm" is installed:
+#  cargo build --release; cargo generate-rpm
+# will result in a file like target/generate-rpm/rustic-rs-0.6.1-1.x86_64.rpm
+[package.metadata.generate-rpm]
+assets = [
+    { source = "target/release/rustic", dest = "/usr/bin/rustic", mode = "0755", config = false, doc = false, user = "root", roup = "root" }
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -204,5 +204,5 @@ codegen-units = 1
 # will result in a file like target/generate-rpm/rustic-rs-0.6.1-1.x86_64.rpm
 [package.metadata.generate-rpm]
 assets = [
-    { source = "target/release/rustic", dest = "/usr/bin/rustic", mode = "0755", config = false, doc = false, user = "root", roup = "root" }
+    { source = "target/release/rustic", dest = "/usr/bin/rustic", mode = "0755", config = false, doc = false, user = "root", group = "root" }
 ]


### PR DESCRIPTION
For #950: If one has "cargo-generate-rpm" installed, then this makes it easy to create an RPM file from the result of a release build. If one doesn't have "cargo-generate-rpm" installed, the extra Cargo.toml lines don't make a difference.

closes #950 