### PR TITLE
Run some CI jobs on upstream only

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -16,6 +16,7 @@ on:
 
 jobs:
   audit:
+    if: ${{ github.repository_owner == 'rustic-rs' }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
@@ -34,6 +35,7 @@ jobs:
 
   cargo-deny:
     name: Run cargo-deny
+    if: ${{ github.repository_owner == 'rustic-rs' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
@@ -44,6 +46,7 @@ jobs:
 
   result:
     name: Result (Audit)
+    if: ${{ github.repository_owner == 'rustic-rs' }}
     runs-on: ubuntu-latest
     needs:
       - audit

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -19,7 +19,7 @@ jobs:
   publish:
     name: Publishing ${{ matrix.job.target }}
     runs-on: ${{ matrix.job.os }}
-    if: ${{ github.ref == 'refs/heads/main' }}
+    if: ${{ github.repository_owner == 'rustic-rs' && github.ref == 'refs/heads/main' }}
     strategy:
       fail-fast: false
       matrix:
@@ -115,7 +115,7 @@ jobs:
   publish-nightly:
     name: Publishing nightly builds
     needs: publish
-    if: ${{ github.ref == 'refs/heads/main' }}
+    if: ${{ github.repository_owner == 'rustic-rs' && github.ref == 'refs/heads/main' }}
     runs-on: ubuntu-latest
     steps:
       - name: Download all workflow run artifacts

--- a/.github/workflows/release-ci.yml
+++ b/.github/workflows/release-ci.yml
@@ -35,6 +35,7 @@ jobs:
 
   breaking-cli:
     name: Check breaking CLI changes
+    if: ${{ github.repository_owner == 'rustic-rs' }}
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
Fixes #944 by limiting certain jobs to upstream only:

 - audit/audit
 - audit/cargo-deny
 - audit/result
 - nightly/publish
 - nightly/publish-nightly
 - release-ci/breaking-cli