### PR TITLE
fix: log config file logs after reading config files

### DIFF
--- a/src/application.rs
+++ b/src/application.rs
@@ -1,17 +1,14 @@
 //! Rustic Abscissa Application
 use std::env;
-use std::fs::File;
-use std::str::FromStr;
 
 use abscissa_core::{
     application::{self, AppCell},
     config::{self, CfgCell},
-    terminal::{component::Terminal, ColorChoice},
-    Application, Component, FrameworkError, FrameworkErrorKind, StandardPaths,
+    terminal::component::Terminal,
+    Application, Component, FrameworkError, StandardPaths,
 };
 
 use anyhow::Result;
-use simplelog::{CombinedLogger, LevelFilter, TermLogger, TerminalMode, WriteLogger};
 
 // use crate::helpers::*;
 use crate::{commands::EntryPoint, config::RusticConfig};
@@ -96,41 +93,6 @@ impl Application for RusticApp {
         // set all given environment variables
         for (env, value) in config.global.env.iter() {
             env::set_var(env, value);
-        }
-
-        // start logger
-        let level_filter = match &config.global.log_level {
-            Some(level) => LevelFilter::from_str(level)
-                .map_err(|e| FrameworkErrorKind::ConfigError.context(e))?,
-            None => LevelFilter::Info,
-        };
-        match &config.global.log_file {
-            None => TermLogger::init(
-                level_filter,
-                simplelog::ConfigBuilder::new()
-                    .set_time_level(LevelFilter::Off)
-                    .build(),
-                TerminalMode::Stderr,
-                ColorChoice::Auto,
-            )
-            .map_err(|e| FrameworkErrorKind::ConfigError.context(e))?,
-
-            Some(file) => CombinedLogger::init(vec![
-                TermLogger::new(
-                    level_filter.min(LevelFilter::Warn),
-                    simplelog::ConfigBuilder::new()
-                        .set_time_level(LevelFilter::Off)
-                        .build(),
-                    TerminalMode::Stderr,
-                    ColorChoice::Auto,
-                ),
-                WriteLogger::new(
-                    level_filter,
-                    simplelog::Config::default(),
-                    File::options().create(true).append(true).open(file)?,
-                ),
-            ])
-            .map_err(|e| FrameworkErrorKind::ConfigError.context(e))?,
         }
 
         self.config.set_once(config);


### PR DESCRIPTION
This PR logs outputs from reading config files like all other logs. It does so by collecting the messages and once the logger is started (which is after *all* config files have been processed), it performs the logging of all collected messages.
It also changes the severity of missing config files: If no config file is given in the command line, a missing `rustic.toml` is an info error. All other missing config files will produce warnings.

closes #959 