### PR TITLE
fix: error handling when entering passwords

### DIFF
--- a/src/commands.rs
+++ b/src/commands.rs
@@ -257,8 +257,8 @@ fn open_repository(config: &Arc<RusticConfig>) -> Result<Repository<ProgressOpti
                     .interact()?;
                 match repo.clone().open_with_password(&pass) {
                     Ok(repo) => return Ok(repo),
-                    // TODO: fail if error != Password incorrect
-                    Err(_) => continue,
+                    Err(err) if err.is_incorrect_password() => continue,
+                    Err(err) => return Err(err.into()),
                 }
             }
         }


### PR DESCRIPTION
fixes #958 

unfortunately we currently don't have access to the information whether an error is cause by an incorrect password.
Hence, we need to wait with this PR until the next rustic_core release which include https://github.com/rustic-rs/rustic_core/pull/88.