### PR TITLE
fix: Fix progress for copy command

### DIFF
--- a/src/commands/copy.rs
+++ b/src/commands/copy.rs
@@ -65,7 +65,8 @@ impl CopyCmd {
 
         let poly = repo.config().poly()?;
         for target_opt in &config.copy.targets {
-            let repo_dest = Repository::new(target_opt)?;
+            let repo_dest =
+                Repository::new_with_progress(target_opt, config.global.progress_options)?;
 
             let repo_dest = if self.init && repo_dest.config_id()?.is_none() {
                 if config.global.dry_run {


### PR DESCRIPTION
Fixes missing progress information for the `copy` command.
closes #960 