### PR TITLE
feat(commands): Add `mount` command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -109,7 +109,7 @@ dependencies = [
  "getrandom",
  "once_cell",
  "version_check",
- "zerocopy",
+ "zerocopy 0.7.35",
 ]
 
 [[package]]
@@ -1592,6 +1592,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
+name = "fuse_mt"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e098b8dc4cd32e9ba31d9c8cdfef11271d8191233c64c2a671432ff19d354948"
+dependencies = [
+ "fuser",
+ "libc",
+ "log",
+ "threadpool",
+]
+
+[[package]]
+name = "fuser"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21370f84640642c8ea36dfb2a6bfc4c55941f476fcf431f6fef25a5ddcf0169b"
+dependencies = [
+ "libc",
+ "log",
+ "memchr",
+ "page_size",
+ "pkg-config",
+ "smallvec",
+ "zerocopy 0.6.6",
+]
+
+[[package]]
 name = "futures"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2961,6 +2988,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1b04fb49957986fdce4d6ee7a65027d55d4b6d2265e5848bbb507b58ccfdb6f"
 
 [[package]]
+name = "page_size"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b7663cbd190cfd818d08efa8497f6cd383076688c49a391ef7c0d03cd12b561"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "pariter"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3187,7 +3224,7 @@ version = "0.2.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77957b295656769bb8ad2b6a6b09d897d94f05c41b069aede1fcdaa675eaea04"
 dependencies = [
- "zerocopy",
+ "zerocopy 0.7.35",
 ]
 
 [[package]]
@@ -3844,6 +3881,7 @@ dependencies = [
  "dircmp",
  "directories",
  "displaydoc",
+ "fuse_mt",
  "gethostname",
  "globset",
  "human-panic",
@@ -4767,6 +4805,15 @@ checksum = "8b9ef9bad013ada3808854ceac7b46812a6465ba368859a37e2100283d2d719c"
 dependencies = [
  "cfg-if 1.0.0",
  "once_cell",
+]
+
+[[package]]
+name = "threadpool"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d050e60b33d41c19108b32cea32164033a9013fe3b46cbd4457559bfbf77afaa"
+dependencies = [
+ "num_cpus",
 ]
 
 [[package]]
@@ -5702,12 +5749,33 @@ checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
 
 [[package]]
 name = "zerocopy"
+version = "0.6.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "854e949ac82d619ee9a14c66a1b674ac730422372ccb759ce0c39cabcf2bf8e6"
+dependencies = [
+ "byteorder",
+ "zerocopy-derive 0.6.6",
+]
+
+[[package]]
+name = "zerocopy"
 version = "0.7.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
 dependencies = [
  "byteorder",
- "zerocopy-derive",
+ "zerocopy-derive 0.7.35",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.6.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "125139de3f6b9d625c39e2efdd73d41bdac468ccd556556440e322be0e1bbd91"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.79",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ jemallocator = ["dep:jemallocator-global"]
 self-update = ["dep:self_update", "dep:semver"]
 tui = ["dep:ratatui", "dep:crossterm", "dep:tui-textarea"]
 webdav = ["dep:dav-server", "dep:warp", "dep:tokio", "rustic_core/webdav"]
+mount = ["dep:fuse_mt"]
 
 [[bin]]
 name = "rustic"
@@ -96,6 +97,7 @@ dateparser = "0.2.1"
 derive_more = { version = "1.0.0", features = ["debug"] }
 dialoguer = "0.11.0"
 directories = "5"
+fuse_mt = { version = "0.6", optional = true }
 gethostname = "0.5"
 globset = "0.4.15"
 human-panic = "2.0.1"

--- a/config/full.toml
+++ b/config/full.toml
@@ -210,5 +210,6 @@ snapshot-path = "latest:/dir" # Default: not set - if not set, generate a virtua
 path-template = "[{hostname}]/[{label}]/{time}" # The path template to use for snapshots. {id}, {id_long}, {time}, {username}, {hostname}, {label}, {tags}, {backup_start}, {backup_end} are replaced. [default: "[{hostname}]/[{label}]/{time}"]. Only relevant if no snapshot-path is given.
 time-template = "%Y-%m-%d_%H-%M-%S" # only relevant if no snapshot-path is given
 no-allow-other = true
+file-access = "read" # Default: "forbidden" for hot/cold repos, else "read"
 mountpoint = "~/mnt"
 snapshot-path = "latest:/dir" # Default: not set - if not set, generate a virtual tree with all snapshots using path-template

--- a/config/full.toml
+++ b/config/full.toml
@@ -205,3 +205,10 @@ time-template = "%Y-%m-%d_%H-%M-%S" # only relevant if no snapshot-path is given
 symlinks = false
 file-access = "read" # Default: "forbidden" for hot/cold repos, else "read"
 snapshot-path = "latest:/dir" # Default: not set - if not set, generate a virtual tree with all snapshots using path-template
+
+[mount]
+path-template = "[{hostname}]/[{label}]/{time}" # The path template to use for snapshots. {id}, {id_long}, {time}, {username}, {hostname}, {label}, {tags}, {backup_start}, {backup_end} are replaced. [default: "[{hostname}]/[{label}]/{time}"]. Only relevant if no snapshot-path is given.
+time-template = "%Y-%m-%d_%H-%M-%S" # only relevant if no snapshot-path is given
+no-allow-other = true
+mountpoint = "~/mnt"
+snapshot-path = "latest:/dir" # Default: not set - if not set, generate a virtual tree with all snapshots using path-template

--- a/deny.toml
+++ b/deny.toml
@@ -101,6 +101,7 @@ allow = [
   "Apache-2.0 WITH LLVM-exception",
   "ISC",
   "Unicode-DFS-2016",
+  "BSD-2-Clause",
   "BSD-3-Clause",
   "MPL-2.0",
   "OpenSSL",

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -70,81 +70,81 @@ use self::find::FindCmd;
 #[derive(clap::Parser, Command, Debug, Runnable)]
 enum RusticCmd {
     /// Backup to the repository
-    Backup(BackupCmd),
+    Backup(Box<BackupCmd>),
 
     /// Show raw data of files and blobs in a repository
-    Cat(CatCmd),
+    Cat(Box<CatCmd>),
 
     /// Change the repository configuration
-    Config(ConfigCmd),
+    Config(Box<ConfigCmd>),
 
     /// Generate shell completions
-    Completions(CompletionsCmd),
+    Completions(Box<CompletionsCmd>),
 
     /// Check the repository
-    Check(CheckCmd),
+    Check(Box<CheckCmd>),
 
     /// Copy snapshots to other repositories
-    Copy(CopyCmd),
+    Copy(Box<CopyCmd>),
 
     /// Compare two snapshots or paths
-    Diff(DiffCmd),
+    Diff(Box<DiffCmd>),
 
     /// Open the documentation
-    Docs(DocsCmd),
+    Docs(Box<DocsCmd>),
 
     /// Dump the contents of a file within a snapshot to stdout
-    Dump(DumpCmd),
+    Dump(Box<DumpCmd>),
 
     /// Find patterns in given snapshots
-    Find(FindCmd),
+    Find(Box<FindCmd>),
 
     /// Remove snapshots from the repository
-    Forget(ForgetCmd),
+    Forget(Box<ForgetCmd>),
 
     /// Initialize a new repository
-    Init(InitCmd),
+    Init(Box<InitCmd>),
 
     /// Manage keys for a repository
-    Key(KeyCmd),
+    Key(Box<KeyCmd>),
 
     /// List repository files by file type
-    List(ListCmd),
+    List(Box<ListCmd>),
 
     /// List file contents of a snapshot
-    Ls(LsCmd),
+    Ls(Box<LsCmd>),
 
     /// Merge snapshots
-    Merge(MergeCmd),
+    Merge(Box<MergeCmd>),
 
     /// Show a detailed overview of the snapshots within the repository
-    Snapshots(SnapshotCmd),
+    Snapshots(Box<SnapshotCmd>),
 
     /// Show the configuration which has been read from the config file(s)
-    ShowConfig(ShowConfigCmd),
+    ShowConfig(Box<ShowConfigCmd>),
 
     /// Update to the latest stable rustic release
     #[cfg_attr(not(feature = "self-update"), clap(hide = true))]
-    SelfUpdate(SelfUpdateCmd),
+    SelfUpdate(Box<SelfUpdateCmd>),
 
     /// Remove unused data or repack repository pack files
-    Prune(PruneCmd),
+    Prune(Box<PruneCmd>),
 
     /// Restore (a path within) a snapshot
-    Restore(RestoreCmd),
+    Restore(Box<RestoreCmd>),
 
     /// Repair a snapshot or the repository index
-    Repair(RepairCmd),
+    Repair(Box<RepairCmd>),
 
     /// Show general information about the repository
-    Repoinfo(RepoInfoCmd),
+    Repoinfo(Box<RepoInfoCmd>),
 
     /// Change tags of snapshots
-    Tag(TagCmd),
+    Tag(Box<TagCmd>),
 
     /// Start a webdav server which allows to access the repository
     #[cfg(feature = "webdav")]
-    Webdav(WebDavCmd),
+    Webdav(Box<WebDavCmd>),
 }
 
 fn styles() -> Styles {

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -117,7 +117,7 @@ enum RusticCmd {
 
     #[cfg(feature = "mount")]
     /// Mount repository
-    Mount(MountCmd),
+    Mount(Box<MountCmd>),
 
     /// List file contents of a snapshot
     Ls(Box<LsCmd>),

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -286,6 +286,8 @@ impl Configurable<RusticConfig> for EntryPoint {
             RusticCmd::Copy(cmd) => cmd.override_config(config),
             #[cfg(feature = "webdav")]
             RusticCmd::Webdav(cmd) => cmd.override_config(config),
+            #[cfg(feature = "mount")]
+            RusticCmd::Mount(cmd) => cmd.override_config(config),
 
             // subcommands that don't need special overrides use a catch all
             _ => Ok(config),

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -16,6 +16,8 @@ pub(crate) mod key;
 pub(crate) mod list;
 pub(crate) mod ls;
 pub(crate) mod merge;
+#[cfg(feature = "mount")]
+pub(crate) mod mount;
 pub(crate) mod prune;
 pub(crate) mod repair;
 pub(crate) mod repoinfo;
@@ -34,6 +36,8 @@ use std::fs::File;
 use std::path::PathBuf;
 use std::str::FromStr;
 
+#[cfg(feature = "mount")]
+use crate::commands::mount::MountCmd;
 #[cfg(feature = "webdav")]
 use crate::commands::webdav::WebDavCmd;
 use crate::{
@@ -110,6 +114,10 @@ enum RusticCmd {
 
     /// List repository files by file type
     List(Box<ListCmd>),
+
+    #[cfg(feature = "mount")]
+    /// Mount repository
+    Mount(MountCmd),
 
     /// List file contents of a snapshot
     Ls(Box<LsCmd>),

--- a/src/commands/mount.rs
+++ b/src/commands/mount.rs
@@ -1,38 +1,58 @@
 //! `mount` subcommand
 mod fusefs;
+use fusefs::FuseFS;
 
 use std::{ffi::OsStr, path::PathBuf};
 
-use crate::{repository::CliIndexedRepo, status_err, Application, RUSTIC_APP};
+use crate::{repository::CliIndexedRepo, status_err, Application, RusticConfig, RUSTIC_APP};
 
-use abscissa_core::{Command, Runnable, Shutdown};
-use anyhow::Result;
+use abscissa_core::{config::Override, Command, FrameworkError, Runnable, Shutdown};
+use anyhow::{anyhow, Result};
+use conflate::Merge;
 use fuse_mt::{mount, FuseMT};
 use rustic_core::vfs::{IdenticalSnapshot, Latest, Vfs};
+use serde::{Deserialize, Serialize};
 
-use fusefs::FuseFS;
-
-#[derive(clap::Parser, Command, Debug)]
-pub(crate) struct MountCmd {
+#[derive(Clone, Command, Default, Debug, clap::Parser, Serialize, Deserialize, Merge)]
+#[serde(default, rename_all = "kebab-case", deny_unknown_fields)]
+pub struct MountCmd {
     /// The path template to use for snapshots. {id}, {id_long}, {time}, {username}, {hostname}, {label}, {tags}, {backup_start}, {backup_end} are replaced. [default: "[{hostname}]/[{label}]/{time}"]
     #[clap(long)]
+    #[merge(strategy=conflate::option::overwrite_none)]
     path_template: Option<String>,
 
     /// The time template to use to display times in the path template. See https://docs.rs/chrono/latest/chrono/format/strftime/index.html for format options. [default: "%Y-%m-%d_%H-%M-%S"]
     #[clap(long)]
+    #[merge(strategy=conflate::option::overwrite_none)]
     time_template: Option<String>,
-
-    #[clap(value_name = "PATH")]
-    /// The mount point to use
-    mountpoint: PathBuf,
-
-    /// Specify directly which path to mount
-    #[clap(value_name = "SNAPSHOT[:PATH]")]
-    snap: Option<String>,
 
     /// Don't allow other users to access the mount point
     #[clap(long)]
+    #[merge(strategy=conflate::bool::overwrite_false)]
     no_allow_other: bool,
+
+    /// The mount point to use
+    #[clap(value_name = "PATH")]
+    #[merge(strategy=conflate::option::overwrite_none)]
+    mountpoint: Option<PathBuf>,
+
+    /// Specify directly which path to mount
+    #[clap(value_name = "SNAPSHOT[:PATH]")]
+    #[merge(strategy=conflate::option::overwrite_none)]
+    snapshot: Option<String>,
+}
+
+impl Override<RusticConfig> for MountCmd {
+    // Process the given command line options, overriding settings from
+    // a configuration file using explicit flags taken from command-line
+    // arguments.
+    fn override_config(&self, mut config: RusticConfig) -> Result<RusticConfig, FrameworkError> {
+        let mut self_config = self.clone();
+        // merge "webdav" section from config file, if given
+        self_config.merge(config.mount);
+        config.mount = self_config;
+        Ok(config)
+    }
 }
 
 impl Runnable for MountCmd {
@@ -51,18 +71,25 @@ impl Runnable for MountCmd {
 impl MountCmd {
     fn inner_run(&self, repo: CliIndexedRepo) -> Result<()> {
         let config = RUSTIC_APP.config();
+        let mountpoint = config
+            .mount
+            .mountpoint
+            .as_ref()
+            .ok_or_else(|| anyhow!("please specify a mountpoint"))?;
 
-        let path_template = self
+        let path_template = config
+            .mount
             .path_template
             .clone()
             .unwrap_or_else(|| "[{hostname}]/[{label}]/{time}".to_string());
-        let time_template = self
+        let time_template = config
+            .mount
             .time_template
             .clone()
             .unwrap_or_else(|| "%Y-%m-%d_%H-%M-%S".to_string());
 
         let sn_filter = |sn: &_| config.snapshot_filter.matches(sn);
-        let vfs = if let Some(snap) = &self.snap {
+        let vfs = if let Some(snap) = &config.mount.snapshot {
             let node = repo.node_from_snapshot_path(snap, sn_filter)?;
             Vfs::from_dir_node(&node)
         } else {
@@ -84,7 +111,7 @@ impl MountCmd {
             OsStr::new("kernel_cache"),
         ];
 
-        if !self.no_allow_other {
+        if !config.mount.no_allow_other {
             options.extend_from_slice(&[
                 OsStr::new("-o"),
                 OsStr::new("allow_other"),
@@ -94,7 +121,7 @@ impl MountCmd {
         }
 
         let fs = FuseMT::new(FuseFS::new(repo, vfs), 1);
-        mount(fs, &self.mountpoint, &options)?;
+        mount(fs, mountpoint, &options)?;
 
         Ok(())
     }

--- a/src/commands/mount.rs
+++ b/src/commands/mount.rs
@@ -36,10 +36,10 @@ pub struct MountCmd {
     #[merge(strategy=conflate::option::overwrite_none)]
     mountpoint: Option<PathBuf>,
 
-    /// Specify directly which path to mount
+    /// Specify directly which snapshot/path to mount
     #[clap(value_name = "SNAPSHOT[:PATH]")]
     #[merge(strategy=conflate::option::overwrite_none)]
-    snapshot: Option<String>,
+    snapshot_path: Option<String>,
 }
 
 impl Override<RusticConfig> for MountCmd {
@@ -89,8 +89,8 @@ impl MountCmd {
             .unwrap_or_else(|| "%Y-%m-%d_%H-%M-%S".to_string());
 
         let sn_filter = |sn: &_| config.snapshot_filter.matches(sn);
-        let vfs = if let Some(snap) = &config.mount.snapshot {
-            let node = repo.node_from_snapshot_path(snap, sn_filter)?;
+        let vfs = if let Some(snap_path) = &config.mount.snapshot_path {
+            let node = repo.node_from_snapshot_path(snap_path, sn_filter)?;
             Vfs::from_dir_node(&node)
         } else {
             let snapshots = repo.get_matching_snapshots(sn_filter)?;

--- a/src/commands/mount.rs
+++ b/src/commands/mount.rs
@@ -1,0 +1,101 @@
+//! `mount` subcommand
+mod fusefs;
+
+use std::{ffi::OsStr, path::PathBuf};
+
+use crate::{repository::CliIndexedRepo, status_err, Application, RUSTIC_APP};
+
+use abscissa_core::{Command, Runnable, Shutdown};
+use anyhow::Result;
+use fuse_mt::{mount, FuseMT};
+use rustic_core::vfs::{IdenticalSnapshot, Latest, Vfs};
+
+use fusefs::FuseFS;
+
+#[derive(clap::Parser, Command, Debug)]
+pub(crate) struct MountCmd {
+    /// The path template to use for snapshots. {id}, {id_long}, {time}, {username}, {hostname}, {label}, {tags}, {backup_start}, {backup_end} are replaced. [default: "[{hostname}]/[{label}]/{time}"]
+    #[clap(long)]
+    path_template: Option<String>,
+
+    /// The time template to use to display times in the path template. See https://docs.rs/chrono/latest/chrono/format/strftime/index.html for format options. [default: "%Y-%m-%d_%H-%M-%S"]
+    #[clap(long)]
+    time_template: Option<String>,
+
+    #[clap(value_name = "PATH")]
+    /// The mount point to use
+    mountpoint: PathBuf,
+
+    /// Specify directly which path to mount
+    #[clap(value_name = "SNAPSHOT[:PATH]")]
+    snap: Option<String>,
+
+    /// Don't allow other users to access the mount point
+    #[clap(long)]
+    no_allow_other: bool,
+}
+
+impl Runnable for MountCmd {
+    fn run(&self) {
+        if let Err(err) = RUSTIC_APP
+            .config()
+            .repository
+            .run_indexed(|repo| self.inner_run(repo))
+        {
+            status_err!("{}", err);
+            RUSTIC_APP.shutdown(Shutdown::Crash);
+        };
+    }
+}
+
+impl MountCmd {
+    fn inner_run(&self, repo: CliIndexedRepo) -> Result<()> {
+        let config = RUSTIC_APP.config();
+
+        let path_template = self
+            .path_template
+            .clone()
+            .unwrap_or_else(|| "[{hostname}]/[{label}]/{time}".to_string());
+        let time_template = self
+            .time_template
+            .clone()
+            .unwrap_or_else(|| "%Y-%m-%d_%H-%M-%S".to_string());
+
+        let sn_filter = |sn: &_| config.snapshot_filter.matches(sn);
+        let vfs = if let Some(snap) = &self.snap {
+            let node = repo.node_from_snapshot_path(snap, sn_filter)?;
+            Vfs::from_dir_node(&node)
+        } else {
+            let snapshots = repo.get_matching_snapshots(sn_filter)?;
+            Vfs::from_snapshots(
+                snapshots,
+                &path_template,
+                &time_template,
+                Latest::AsLink,
+                IdenticalSnapshot::AsLink,
+            )?
+        };
+
+        let name_opt = format!("fsname=rusticfs:{}", repo.config().id);
+        let mut options = vec![
+            OsStr::new("-o"),
+            OsStr::new(&name_opt),
+            OsStr::new("-o"),
+            OsStr::new("kernel_cache"),
+        ];
+
+        if !self.no_allow_other {
+            options.extend_from_slice(&[
+                OsStr::new("-o"),
+                OsStr::new("allow_other"),
+                OsStr::new("-o"),
+                OsStr::new("default_permissions"),
+            ]);
+        }
+
+        let fs = FuseMT::new(FuseFS::new(repo, vfs), 1);
+        mount(fs, &self.mountpoint, &options)?;
+
+        Ok(())
+    }
+}

--- a/src/commands/mount.rs
+++ b/src/commands/mount.rs
@@ -57,7 +57,7 @@ impl Override<RusticConfig> for MountCmd {
     // arguments.
     fn override_config(&self, mut config: RusticConfig) -> Result<RusticConfig, FrameworkError> {
         let mut self_config = self.clone();
-        // merge "webdav" section from config file, if given
+        // merge "mount" section from config file, if given
         self_config.merge(config.mount);
         config.mount = self_config;
         Ok(config)

--- a/src/commands/mount/fusefs.rs
+++ b/src/commands/mount/fusefs.rs
@@ -1,0 +1,235 @@
+use super::Vfs;
+
+#[cfg(not(windows))]
+use std::os::unix::prelude::OsStrExt;
+use std::{
+    collections::BTreeMap,
+    ffi::{CString, OsStr},
+    path::Path,
+    sync::RwLock,
+    time::{Duration, SystemTime},
+};
+
+use rustic_core::{
+    repofile::{Node, NodeType},
+    vfs::OpenFile,
+    IndexedFull, Repository,
+};
+
+use fuse_mt::{
+    CallbackResult, DirectoryEntry, FileAttr, FileType, FilesystemMT, RequestInfo, ResultData,
+    ResultEmpty, ResultEntry, ResultOpen, ResultReaddir, ResultSlice, ResultXattr, Xattr,
+};
+use itertools::Itertools;
+
+pub struct FuseFS<P, S> {
+    repo: Repository<P, S>,
+    vfs: Vfs,
+    open_files: RwLock<BTreeMap<u64, OpenFile>>,
+    now: SystemTime,
+}
+
+impl<P, S: IndexedFull> FuseFS<P, S> {
+    pub(crate) fn new(repo: Repository<P, S>, vfs: Vfs) -> Self {
+        let open_files = RwLock::new(BTreeMap::new());
+
+        Self {
+            repo,
+            vfs,
+            open_files,
+            now: SystemTime::now(),
+        }
+    }
+
+    fn node_from_path(&self, path: &Path) -> Result<Node, i32> {
+        self.vfs
+            .node_from_path(&self.repo, path)
+            .map_err(|_| libc::ENOENT)
+    }
+
+    fn dir_entries_from_path(&self, path: &Path) -> Result<Vec<Node>, i32> {
+        self.vfs
+            .dir_entries_from_path(&self.repo, path)
+            .map_err(|_| libc::ENOENT)
+    }
+}
+
+fn node_to_filetype(node: &Node) -> FileType {
+    match node.node_type {
+        NodeType::File => FileType::RegularFile,
+        NodeType::Dir => FileType::Directory,
+        NodeType::Symlink { .. } => FileType::Symlink,
+        NodeType::Chardev { .. } => FileType::CharDevice,
+        NodeType::Dev { .. } => FileType::BlockDevice,
+        NodeType::Fifo => FileType::NamedPipe,
+        NodeType::Socket => FileType::Socket,
+    }
+}
+
+fn node_type_to_rdev(tpe: &NodeType) -> u32 {
+    u32::try_from(match tpe {
+        NodeType::Dev { device } | NodeType::Chardev { device } => *device,
+        _ => 0,
+    })
+    .unwrap()
+}
+
+fn node_to_linktarget(node: &Node) -> Option<&OsStr> {
+    if node.is_symlink() {
+        Some(node.node_type.to_link().as_os_str())
+    } else {
+        None
+    }
+}
+
+fn node_to_file_attr(node: &Node, now: SystemTime) -> FileAttr {
+    FileAttr {
+        // Size in bytes
+        size: node.meta.size,
+        // Size in blocks
+        blocks: 0,
+        // Time of last access
+        atime: node.meta.atime.map(SystemTime::from).unwrap_or(now),
+        // Time of last modification
+        mtime: node.meta.mtime.map(SystemTime::from).unwrap_or(now),
+        // Time of last metadata change
+        ctime: node.meta.ctime.map(SystemTime::from).unwrap_or(now),
+        // Time of creation (macOS only)
+        crtime: now,
+        // Kind of file (directory, file, pipe, etc.)
+        kind: node_to_filetype(node),
+        // Permissions
+        perm: node.meta.mode.unwrap_or(0o755) as u16,
+        // Number of hard links
+        nlink: node.meta.links.try_into().unwrap_or(1),
+        // User ID
+        uid: node.meta.uid.unwrap_or(0),
+        // Group ID
+        gid: node.meta.gid.unwrap_or(0),
+        // Device ID (if special file)
+        rdev: node_type_to_rdev(&node.node_type),
+        // Flags (macOS only; see chflags(2))
+        flags: 0,
+    }
+}
+
+impl<P, S: IndexedFull> FilesystemMT for FuseFS<P, S> {
+    fn getattr(&self, _req: RequestInfo, path: &Path, _fh: Option<u64>) -> ResultEntry {
+        let node = self.node_from_path(path)?;
+        Ok((Duration::from_secs(1), node_to_file_attr(&node, self.now)))
+    }
+
+    #[cfg(not(windows))]
+    fn readlink(&self, _req: RequestInfo, path: &Path) -> ResultData {
+        let target = node_to_linktarget(&self.node_from_path(path)?)
+            .ok_or(libc::ENOSYS)?
+            .as_bytes()
+            .to_vec();
+
+        Ok(target)
+    }
+
+    fn open(&self, _req: RequestInfo, path: &Path, _flags: u32) -> ResultOpen {
+        let node = self.node_from_path(path)?;
+        let open = self.repo.open_file(&node).map_err(|_| libc::ENOSYS)?;
+        let fh = {
+            let mut open_files = self.open_files.write().unwrap();
+            let fh = open_files.last_key_value().map_or(0, |(fh, _)| *fh + 1);
+            _ = open_files.insert(fh, open);
+            fh
+        };
+        Ok((fh, 0))
+    }
+
+    fn release(
+        &self,
+        _req: RequestInfo,
+        _path: &Path,
+        fh: u64,
+        _flags: u32,
+        _lock_owner: u64,
+        _flush: bool,
+    ) -> ResultEmpty {
+        _ = self.open_files.write().unwrap().remove(&fh);
+        Ok(())
+    }
+
+    fn read(
+        &self,
+        _req: RequestInfo,
+        _path: &Path,
+        fh: u64,
+        offset: u64,
+        size: u32,
+
+        callback: impl FnOnce(ResultSlice<'_>) -> CallbackResult,
+    ) -> CallbackResult {
+        if let Some(open_file) = self.open_files.read().unwrap().get(&fh) {
+            if let Ok(data) =
+                self.repo
+                    .read_file_at(open_file, offset.try_into().unwrap(), size as usize)
+            {
+                return callback(Ok(&data));
+            }
+        }
+        callback(Err(libc::ENOSYS))
+    }
+
+    fn opendir(&self, _req: RequestInfo, _path: &Path, _flags: u32) -> ResultOpen {
+        Ok((0, 0))
+    }
+
+    fn readdir(&self, _req: RequestInfo, path: &Path, _fh: u64) -> ResultReaddir {
+        let nodes = self.dir_entries_from_path(path)?;
+
+        let result = nodes
+            .into_iter()
+            .map(|node| DirectoryEntry {
+                name: node.name(),
+                kind: node_to_filetype(&node),
+            })
+            .collect();
+        Ok(result)
+    }
+
+    fn releasedir(&self, _req: RequestInfo, _path: &Path, _fh: u64, _flags: u32) -> ResultEmpty {
+        Ok(())
+    }
+
+    fn listxattr(&self, _req: RequestInfo, path: &Path, size: u32) -> ResultXattr {
+        let node = self.node_from_path(path)?;
+        let xattrs = node
+            .meta
+            .extended_attributes
+            .into_iter()
+            // convert into null-terminated [u8]
+            .map(|a| CString::new(a.name).unwrap().into_bytes_with_nul())
+            .concat();
+
+        if size == 0 {
+            Ok(Xattr::Size(u32::try_from(xattrs.len()).unwrap()))
+        } else {
+            Ok(Xattr::Data(xattrs))
+        }
+    }
+
+    fn getxattr(&self, _req: RequestInfo, path: &Path, name: &OsStr, size: u32) -> ResultXattr {
+        let node = self.node_from_path(path)?;
+        match node
+            .meta
+            .extended_attributes
+            .into_iter()
+            .find(|a| name == OsStr::new(&a.name))
+        {
+            None => Err(libc::ENOSYS),
+            Some(attr) => {
+                let value = attr.value.unwrap_or_default();
+                if size == 0 {
+                    Ok(Xattr::Size(u32::try_from(value.len()).unwrap()))
+                } else {
+                    Ok(Xattr::Data(value))
+                }
+            }
+        }
+    }
+}

--- a/src/commands/mount/fusefs.rs
+++ b/src/commands/mount/fusefs.rs
@@ -1,5 +1,3 @@
-use super::Vfs;
-
 #[cfg(not(windows))]
 use std::os::unix::prelude::OsStrExt;
 use std::{
@@ -12,7 +10,7 @@ use std::{
 
 use rustic_core::{
     repofile::{Node, NodeType},
-    vfs::OpenFile,
+    vfs::{OpenFile, Vfs},
     IndexedFull, Repository,
 };
 

--- a/src/commands/webdav.rs
+++ b/src/commands/webdav.rs
@@ -3,7 +3,7 @@
 // ignore markdown clippy lints as we use doc-comments to generate clap help texts
 #![allow(clippy::doc_markdown)]
 
-use std::{net::ToSocketAddrs, str::FromStr};
+use std::net::ToSocketAddrs;
 
 use crate::{repository::CliIndexedRepo, status_err, Application, RusticConfig, RUSTIC_APP};
 use abscissa_core::{config::Override, Command, FrameworkError, Runnable, Shutdown};
@@ -124,7 +124,7 @@ impl WebDavCmd {
                     Ok(FilePolicy::Read)
                 }
             },
-            |s| FilePolicy::from_str(s),
+            |s| s.parse(),
         )?;
 
         let dav_server = DavHandler::builder()

--- a/src/config.rs
+++ b/src/config.rs
@@ -18,6 +18,8 @@ use directories::ProjectDirs;
 use itertools::Itertools;
 use log::Level;
 use serde::{Deserialize, Serialize};
+#[cfg(not(all(feature = "mount", feature = "webdav")))]
+use toml::Value;
 
 #[cfg(feature = "mount")]
 use crate::commands::mount::MountCmd;
@@ -64,15 +66,21 @@ pub struct RusticConfig {
     #[clap(skip)]
     pub forget: ForgetOptions,
 
-    #[cfg(feature = "mount")]
     /// mount options
     #[clap(skip)]
+    #[cfg(feature = "mount")]
     pub mount: MountCmd,
+    #[cfg(not(feature = "mount"))]
+    #[merge(skip)]
+    pub mount: Option<Value>,
 
-    #[cfg(feature = "webdav")]
     /// webdav options
     #[clap(skip)]
+    #[cfg(feature = "webdav")]
     pub webdav: WebDavCmd,
+    #[cfg(not(feature = "webdav"))]
+    #[merge(skip)]
+    pub webdav: Option<Value>,
 }
 
 impl RusticConfig {

--- a/src/config.rs
+++ b/src/config.rs
@@ -19,6 +19,8 @@ use itertools::Itertools;
 use log::Level;
 use serde::{Deserialize, Serialize};
 
+#[cfg(feature = "mount")]
+use crate::commands::mount::MountCmd;
 #[cfg(feature = "webdav")]
 use crate::commands::webdav::WebDavCmd;
 
@@ -61,6 +63,11 @@ pub struct RusticConfig {
     /// Forget options
     #[clap(skip)]
     pub forget: ForgetOptions,
+
+    #[cfg(feature = "mount")]
+    /// mount options
+    #[clap(skip)]
+    pub mount: MountCmd,
 
     #[cfg(feature = "webdav")]
     /// webdav options


### PR DESCRIPTION
This PR adds the `mount` command to rustic to access snapshot contents as a read-only filesystem when the feature-flag `mount` is chosen. 

As for the `webdav` command, there are following options:
- Access to a concrete snapshot/path, e.g. `rustic mount /mnt 37a63e5b:/my/path`.
- Access to all snapshots (maybe restricted by filters) by using templates to define a virtual directory structure where snapshots are located. Example: `rustic mount /mnt --path-template "[{hostname}]/[{label}]/{time}" --time-template "%Y-%m-%d_%H-%M-%S"` (these are also defined as default). Note that for all dirs containing only snapshots, also a `latest` entry is generated. `latest` and identical subsequent snapshots are symlinks when using `mount`.

This PR uses fuse_mt which is not optimal as it introduces some overhead (e.g. needs to save whole Paths in-memory).

Note: Requires https://github.com/rustic-rs/rustic_core/pull/331 to properly show all data of files (without it builds and runs, but files are truncated and return error when reading).

Note: Building with the `mount` feature flag requires special dependencies and is only possible on supported platforms, see https://github.com/cberner/fuser

closes #971 