### PR TITLE
feat(config): add s3_idrive config and move configs to a services subdirectory

### DIFF
--- a/config/S3_iDrive.toml
+++ b/config/S3_iDrive.toml
@@ -1,0 +1,11 @@
+[repository]
+repository = "opendal:s3"
+password = "password"
+
+[repository.options]
+root = "/"
+bucket = "bucket_name"
+endpoint = "https://p7v1.ldn.idrivee2-40.com"
+region = "gb-ldn"
+access_key_id = "xxx"
+secret_access_key = "xxx"


### PR DESCRIPTION
To documents working toml for iDrive S3.

Discussed here: https://github.com/rustic-rs/rustic/discussions/1044#discussioncomment-8361486