### PR TITLE
fix(commands): Ask for password in backup and copy command if it is missing

### DIFF
--- a/src/commands/backup.rs
+++ b/src/commands/backup.rs
@@ -3,7 +3,7 @@
 use std::path::PathBuf;
 
 use crate::{
-    commands::{get_repository, init::init},
+    commands::{get_repository, init::init, open_repository},
     helpers::bytes_size_to_string,
     status_err, Application, RUSTIC_APP,
 };
@@ -144,7 +144,7 @@ impl BackupCmd {
             }
             init(repo, &self.key_opts, &self.config_opts)?
         } else {
-            repo.open()?
+            open_repository(&config.repository)?
         }
         .to_indexed_ids()?;
 

--- a/src/commands/copy.rs
+++ b/src/commands/copy.rs
@@ -82,7 +82,7 @@ impl CopyCmd {
                 let pass = repo_dest.password()?.unwrap();
                 repo_dest.init_with_config(&pass, &self.key_opts, config_dest)?
             } else {
-                repo_dest.open()?
+                open_repository(target_opt)?
             };
 
             info!("copying to target {}...", repo_dest.name);


### PR DESCRIPTION
A user discovered that for some commands they are not being asked for a password, although they should. This implements a fix for the backup and copy command so they consistently call the same functionality that is being used for the other commands. Hence, asking for the password, if it's missing.