### PR TITLE
feat(commands): Add lock command

### DIFF
--- a/src/commands.rs
+++ b/src/commands.rs
@@ -12,6 +12,7 @@ pub(crate) mod forget;
 pub(crate) mod init;
 pub(crate) mod key;
 pub(crate) mod list;
+pub(crate) mod lock;
 pub(crate) mod ls;
 pub(crate) mod merge;
 pub(crate) mod prune;
@@ -35,9 +36,10 @@ use crate::{
     commands::{
         backup::BackupCmd, cat::CatCmd, check::CheckCmd, completions::CompletionsCmd,
         config::ConfigCmd, copy::CopyCmd, diff::DiffCmd, dump::DumpCmd, forget::ForgetCmd,
-        init::InitCmd, key::KeyCmd, list::ListCmd, ls::LsCmd, merge::MergeCmd, prune::PruneCmd,
-        repair::RepairCmd, repoinfo::RepoInfoCmd, restore::RestoreCmd, self_update::SelfUpdateCmd,
-        show_config::ShowConfigCmd, snapshots::SnapshotCmd, tag::TagCmd,
+        init::InitCmd, key::KeyCmd, list::ListCmd, lock::LockCmd, ls::LsCmd, merge::MergeCmd,
+        prune::PruneCmd, repair::RepairCmd, repoinfo::RepoInfoCmd, restore::RestoreCmd,
+        self_update::SelfUpdateCmd, show_config::ShowConfigCmd, snapshots::SnapshotCmd,
+        tag::TagCmd,
     },
     config::{progress_options::ProgressOptions, AllRepositoryOptions, RusticConfig},
     {Application, RUSTIC_APP},
@@ -102,6 +104,9 @@ enum RusticCmd {
 
     /// List repository files
     List(ListCmd),
+
+    /// Lock snapshots
+    Lock(LockCmd),
 
     /// List file contents of a snapshot
     Ls(LsCmd),

--- a/src/commands/lock.rs
+++ b/src/commands/lock.rs
@@ -1,0 +1,79 @@
+//! `lock` subcommand
+
+use std::str::FromStr;
+
+use crate::{commands::open_repository, status_err, Application, RUSTIC_APP};
+use abscissa_core::{Command, Runnable, Shutdown};
+
+use anyhow::Result;
+use chrono::{DateTime, Duration, Local};
+
+use rustic_core::LockOptions;
+
+/// `prune` subcommand
+#[allow(clippy::struct_excessive_bools)]
+#[derive(clap::Parser, Command, Debug, Clone)]
+pub(crate) struct LockCmd {
+    /// Extend locks even if the files are already locked long enough
+    #[clap(long)]
+    always_extend_lock: bool,
+
+    #[clap(long)]
+    /// Duration for how long to extend the locks (e.g. "10d"). "forever" is also allowed
+    duration: LockDuration,
+
+    /// Snapshots to lock. If none is given, use filter options to filter from all snapshots
+    #[clap(value_name = "ID")]
+    ids: Vec<String>,
+}
+
+#[derive(Debug, Clone)]
+struct LockDuration(Option<DateTime<Local>>);
+
+impl FromStr for LockDuration {
+    type Err = anyhow::Error;
+    fn from_str(s: &str) -> Result<Self> {
+        match s {
+            "forever" => Ok(Self(None)),
+            d => {
+                let duration = humantime::Duration::from_str(d)?;
+                let duration = Duration::from_std(*duration)?;
+                Ok(Self(Some(Local::now() + duration)))
+            }
+        }
+    }
+}
+
+impl Runnable for LockCmd {
+    fn run(&self) {
+        if let Err(err) = self.inner_run() {
+            status_err!("{}", err);
+            RUSTIC_APP.shutdown(Shutdown::Crash);
+        };
+    }
+}
+
+impl LockCmd {
+    fn inner_run(&self) -> Result<()> {
+        let config = RUSTIC_APP.config();
+        let repo = open_repository(&config.repository)?;
+
+        let snapshots = if self.ids.is_empty() {
+            repo.get_matching_snapshots(|sn| config.snapshot_filter.matches(sn))?
+        } else {
+            repo.get_snapshots(&self.ids)?
+        };
+
+        if config.global.dry_run {
+            println!("lock is not supported in dry-run mode");
+        } else {
+            let lock_opts = LockOptions::default()
+                .always_extend_lock(self.always_extend_lock)
+                .until(self.duration.0);
+
+            repo.lock(&lock_opts, &snapshots)?;
+        }
+
+        Ok(())
+    }
+}

--- a/src/commands/snapshots.rs
+++ b/src/commands/snapshots.rs
@@ -169,6 +169,10 @@ impl PrintTable for SnapshotFile {
             DeleteOption::NotSet => "not set".to_string(),
             DeleteOption::Never => "never".to_string(),
             DeleteOption::After(t) => format!("after {}", t.format("%Y-%m-%d %H:%M:%S")),
+            DeleteOption::LockedUntil(t) => {
+                format!("locked until {}", t.format("%Y-%m-%d %H:%M:%S"))
+            }
+            DeleteOption::LockedForever => "locked forever".to_string(),
         };
         add_entry("Delete", delete);
         add_entry("Paths", self.paths.formatln());

--- a/src/commands/tag.rs
+++ b/src/commands/tag.rs
@@ -104,7 +104,7 @@ impl TagCmd {
                 println!("would have modified the following snapshots:\n {old_snap_ids:?}");
             }
             (false, false) => {
-                repo.save_snapshots(snapshots)?;
+                _ = repo.save_snapshots(snapshots)?;
                 repo.delete_snapshots(&old_snap_ids)?;
             }
         }


### PR DESCRIPTION
see #1050 

depends on https://github.com/rustic-rs/rustic_core/pull/163

Also fixes the handling of delete-protected snapshots in the `forget` command when snapshots are explicitly given