### PR TITLE
feat: Allow setting extra repository options via env variables

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -605,6 +605,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
 
 [[package]]
+name = "convert_case"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec182b0ca2f35d8fc196cf3404988fd8b8c739a4d270ff118a398feb0cbec1ca"
+dependencies = [
+ "unicode-segmentation",
+]
+
+[[package]]
 name = "core-foundation"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -924,7 +933,7 @@ version = "0.99.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fb810d30a7c1953f91334de7244731fc3f3c10d7fe163338a35b9f640960321"
 dependencies = [
- "convert_case",
+ "convert_case 0.4.0",
  "proc-macro2",
  "quote",
  "rustc_version",
@@ -2876,6 +2885,7 @@ dependencies = [
  "clap",
  "clap_complete",
  "comfy-table",
+ "convert_case 0.6.0",
  "dav-server",
  "dialoguer",
  "dircmp",
@@ -4045,6 +4055,12 @@ checksum = "a56d1686db2308d901306f92a263857ef59ea39678a5458e7cb17f01415101f5"
 dependencies = [
  "tinyvec",
 ]
+
+[[package]]
+name = "unicode-segmentation"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4c87d22b6e3f4a18d4d40ef354e97c90fcb14dd91d7dc0aa9d8a1172ebf7202"
 
 [[package]]
 name = "unicode-width"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,6 +77,7 @@ simplelog = "0.12"
 bytesize = "1"
 clap = { version = "4", features = ["derive", "env", "wrap_help"] }
 clap_complete = "4"
+convert_case = "0.6.0"
 dialoguer = "0.11.0"
 directories = "5"
 gethostname = "0.4"

--- a/config/full.toml
+++ b/config/full.toml
@@ -36,7 +36,9 @@ warm-up = false
 warm-up-command = "warmup.sh %id" # Default: not set
 warm-up-wait = "10min" # Default: not set
 
-# Additional repository options - depending on backend. These can be only set in the config file.
+# Additional repository options - depending on backend. These can be only set in the config file or using env variables.
+# For env variables use upper snake case and prefix with "RUSTIC_REPO_OPT_", e.g. `use-passwort = "true"` becomes
+# `RUSTIC_REPO_OPT_USE_PASSWORT=true`
 [repository.options]
 post-create-command = "par2create -qq -n1 -r5 %file" # Only local backend; Default: not set
 post-delete-command = "sh -c \"rm -f %file*.par2\"" # Only local backend; Default: not set
@@ -48,11 +50,15 @@ rest-url = "http://localhost:8000" # Only rclone; Default: determine REST URL fr
 # Note that opendal backends use several service-dependent options which may be specified here, see
 # https://opendal.apache.org/docs/rust/opendal/services/index.html
 
-# Additional repository options for the hot part - depending on backend. These can be only set in the config file.
+# Additional repository options for the hot part - depending on backend. These can be only set in the config file or
+# using env variables.
+# For env variables use upper snake case and prefix with "RUSTIC_REPO_OPTHOT_"
 [repository.options-hot]
 # see [repository.options]
 
-# Additional repository options for the cold part - depending on backend. These can be only set in the config file.
+# Additional repository options for the cold part - depending on backend. These can be only set in the config file or
+# using env variables.
+# For env variables use upper snake case and prefix with "RUSTIC_REPO_OPTCOLD_"
 [repository.options-cold]
 # see [repository.options]
 

--- a/config/services/b2.toml
+++ b/config/services/b2.toml
@@ -9,7 +9,7 @@ password = "<rustic_passwd>"
 [repository.options]
 # Here, we give the required b2 options, see https://opendal.apache.org/docs/rust/opendal/services/struct.B2.html
 application_key_id = "my_id" # B2 application key ID
-application_key = "my_key" # B2 application key secret
+application_key = "my_key" # B2 application key secret. Can be also set using OPENDAL_APPLICATION_KEY
 bucket = "bucket_name" # B2 bucket name
 bucket_id = "bucket_id" # B2 bucket ID
-# root = "/"                  # Set a repository root directory if not using the root directory of the bucket
+# root = "/" # Set a repository root directory if not using the root directory of the bucket

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -52,6 +52,7 @@ use clap::builder::{
     styling::{AnsiColor, Effects},
     Styles,
 };
+use convert_case::{Case, Casing};
 use dialoguer::Password;
 use human_panic::setup_panic;
 use log::{log, Level};
@@ -184,6 +185,23 @@ impl Configurable<RusticConfig> for EntryPoint {
         // rustic logic and merged with the CLI options.
         // That's why it says `_config`, because it's not read at all and therefore not needed.
         let mut config = self.config.clone();
+
+        // collect "RUSTIC_REPO_OPT*" and "OPENDAL_*" env variables
+        for (var, value) in std::env::vars() {
+            if let Some(var) = var.strip_prefix("RUSTIC_REPO_OPT_") {
+                let var = var.from_case(Case::UpperSnake).to_case(Case::Kebab);
+                _ = config.repository.be.options.insert(var, value);
+            } else if let Some(var) = var.strip_prefix("OPENDAL_") {
+                let var = var.from_case(Case::UpperSnake).to_case(Case::Snake);
+                _ = config.repository.be.options.insert(var, value);
+            } else if let Some(var) = var.strip_prefix("RUSTIC_REPO_OPTHOT_") {
+                let var = var.from_case(Case::UpperSnake).to_case(Case::Kebab);
+                _ = config.repository.be.options_hot.insert(var, value);
+            } else if let Some(var) = var.strip_prefix("RUSTIC_REPO_OPTCOLD_") {
+                let var = var.from_case(Case::UpperSnake).to_case(Case::Kebab);
+                _ = config.repository.be.options_cold.insert(var, value);
+            }
+        }
 
         // collect logs during merging as we start the logger *after* merging
         let mut merge_logs = Vec::new();


### PR DESCRIPTION
Reads the env variables `RUSTIC_REPO_OPT_*`, `RUSTIC_REPO_OPTCOLD_*`, `RUSTIC_REPO_OPTHOT_*` to set repository options. Also reads `OPENDAL_*` variables which may be used to explicitly set opendal options (as they are in snake and not kebab case).

closes #1073