### PR TITLE
fix: show log filename if open/creation failed

### DIFF
--- a/src/commands.rs
+++ b/src/commands.rs
@@ -244,7 +244,16 @@ impl Configurable<RusticConfig> for EntryPoint {
                 WriteLogger::new(
                     level_filter,
                     simplelog::Config::default(),
-                    File::options().create(true).append(true).open(file)?,
+                    File::options()
+                        .create(true)
+                        .append(true)
+                        .open(file)
+                        .map_err(|e| {
+                            FrameworkErrorKind::PathError {
+                                name: Some(file.clone()),
+                            }
+                            .context(e)
+                        })?,
                 ),
             ])
             .map_err(|e| FrameworkErrorKind::ConfigError.context(e))?,


### PR DESCRIPTION
If opening or creating the logfile fails, rustic now shows the filename to allow users debug the error.

closes #1105 