### PR TITLE
fix(config)!: multiple paths in config profile as array

### DIFF
--- a/config/README.md
+++ b/config/README.md
@@ -152,9 +152,9 @@ can be overwritten in the source-specifc configuration, see below.
 **Note**: All of the backup options mentioned before can also be used as
 source-specific option and then only apply to this source.
 
-| Attribute | Description                          | Default Value | Example Value         |
-| --------- | ------------------------------------ | ------------- | --------------------- |
-| source    | Source directory or file to back up. | Not set       | "/tmp/dir/to_backup/" |
+| Attribute | Description                          | Default Value | Example Value               |
+| --------- | ------------------------------------ | ------------- | --------------------------- |
+| source    | Source directory or file to back up. | Not set       | "/dir" , ["/dir1", "/dir2"] |
 
 ### Forget Options
 

--- a/config/full.toml
+++ b/config/full.toml
@@ -113,7 +113,10 @@ label = "label" # Default: not set
 # .. and so on. see [backup]
 
 [[backup.sources]]
-source = "/path/to/source2 /second/path" # multiple local paths are allowd within one source
+source = [
+  "/path/to/source2",
+  "/second/path",
+] # multiple local paths are given as array
 # ...
 
 # forget options

--- a/tests/show-config-fixtures/empty.txt
+++ b/tests/show-config-fixtures/empty.txt
@@ -46,7 +46,7 @@ one-file-system = false
 tag = []
 delete-never = false
 sources = []
-source = ""
+source = []
 
 [copy]
 targets = []


### PR DESCRIPTION
-- BREAKING CHANG --

Using multiple paths for a sources in the config file caused many problems as the syntax was unclear and problems existed in edge cases.

This PR changes the definition of sources in config profile files:
- a single path path can be specified as before, i.e. using `source = "/my/path"`.
- multiple paths must now be given in an array:
```
source = ["/my/path1", "/my/path2"]
```

Note that 
```
source = "/my/path1 /my/path2"
```
is now interpreted a a single path using the dir-tree "my","path1 " (with space), "my", "path2".

closes #1122
closes #1094 