### PR TITLE
feat!(command): copy: Use config profile as target

### DIFF
--- a/config/README.md
+++ b/config/README.md
@@ -181,21 +181,11 @@ source-specific option and then only apply to this source.
 
 ### Copy Targets
 
-**Note**: Copy-targets are simply repositories with the same defaults as within
-the repository section.
+**Note**: Copy-targets must be defined in their own config profile files.
 
-| Attribute        | Description                                                       | Default Value            | Example Value          |
-| ---------------- | ----------------------------------------------------------------- | ------------------------ | ---------------------- |
-| cache-dir        | Path to the cache directory for the target repository.            | ~/.cache/rustic/$REPO_ID | ~/.cache/my_own_cache/ |
-| no-cache         | If true, disables caching for the target repository.              | false                    |                        |
-| password         | The password for the target repository.                           | Not set                  |                        |
-| password-file    | Path to a file containing the password for the target repository. | Not set                  |                        |
-| password-command | Command to retrieve the password for the target repository.       | Not set                  |                        |
-| repository       | The path or URL to the target repository.                         | Not set                  |                        |
-| repo-hot         | The path or URL to the hot target repository.                     | Not set                  |                        |
-| warm-up          | If true, warms up the target repository by file access.           | Not set                  |                        |
-| warm-up-command  | Command to warm up the target repository.                         | Not set                  |                        |
-| warm-up-wait     | The wait time for warming up the target repository.               | Not set                  |                        |
+| Attribute | Description        | Default Value | Example Value                            |
+| --------- | ------------------ | ------------- | ---------------------------------------- |
+| target    | One or more target | Not set       | "remote_host" / ["profile1", "profile2"] |
 
 ### WebDAV Options
 

--- a/config/copy_example.toml
+++ b/config/copy_example.toml
@@ -8,14 +8,6 @@
 repository = "/tmp/repo"
 password = "test"
 
-# you can specify multiple targets
-[[copy.targets]]
-repository = "/tmp/repo2"
-password = "test"
-no-cache = true
-
-[[copy.targets]]
-repository = "rclone:ovh:backup"
-repo-hot = "clone:ovh:backup-hot"
-password-file = "/root/key-rustic-ovh"
-cache-dir = "/var/lib/cache/rustic" # explicitly specify cache dir for remote repository
+# you can specify multiple targets. Note that each target must be configured via a config profile file
+[copy]
+target = ["full", "rustic"]

--- a/config/full-one.toml
+++ b/config/full-one.toml
@@ -143,25 +143,8 @@ keep-withing-quarter-yearly = "0 year"
 keep-withing-half-yearly = "1 year"
 keep-within-yearly = "10 years"
 
-# Multiple targets are available for the copy command. Each specify a repository with exactly identical options as in
-# the [repository] section.
-[[copy.targets]]
-repository = "/repo/rustic" # Must be set
-repo-hot = "/my/hot/repo" # Default: not set
-# one of the three password options must be set
-password = "mySecretPassword"
-password-file = "/my/password.txt"
-password-command = "my_command.sh"
-no-cache = false
-cache-dir = "/my/rustic/cachedir" # Default: Applications default cache dir, e.g. ~/.cache/rustic
-# use either warm-up (warm-up by file access) or warm-up-command to specify warming up
-warm-up = false
-warm-up-command = "warmup.sh %id" # Default: not set
-warm-up-wait = "10min" # Default: not set
-
-[[copy.targets]]
-repository = "/repo/rustic2" # Must be set
-# ...
+[copy]
+target = "target_profile" # Default: not set
 
 [webdav]
 address = "localhost:8000"

--- a/config/full.toml
+++ b/config/full.toml
@@ -150,25 +150,8 @@ keep-withing-quarter-yearly = "0 year"
 keep-withing-half-yearly = "1 year"
 keep-within-yearly = "10 years"
 
-# Multiple targets are available for the copy command. Each specify a repository with exactly identical options as in
-# the [repository] section.
-[[copy.targets]]
-repository = "/repo/rustic" # Must be set
-repo-hot = "/my/hot/repo" # Default: not set
-# one of the three password options must be set
-password = "mySecretPassword"
-password-file = "/my/password.txt"
-password-command = "my_command.sh"
-no-cache = false
-cache-dir = "/my/rustic/cachedir" # Default: Applications default cache dir, e.g. ~/.cache/rustic
-# use either warm-up (warm-up by file access) or warm-up-command to specify warming up
-warm-up = false
-warm-up-command = "warmup.sh %id" # Default: not set
-warm-up-wait = "10min" # Default: not set
-
-[[copy.targets]]
-repository = "/repo/rustic2" # Must be set
-# ...
+[copy]
+target = ["profile1", "profile2"] # Default: not set
 
 [webdav]
 address = "localhost:8000"

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -269,6 +269,7 @@ impl Configurable<RusticConfig> for EntryPoint {
 
         match &self.commands {
             RusticCmd::Forget(cmd) => cmd.override_config(config),
+            RusticCmd::Copy(cmd) => cmd.override_config(config),
             #[cfg(feature = "webdav")]
             RusticCmd::Webdav(cmd) => cmd.override_config(config),
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -24,7 +24,7 @@ use serde_with::{serde_as, OneOrMany};
 #[cfg(feature = "webdav")]
 use crate::commands::webdav::WebDavCmd;
 use crate::{
-    commands::{backup::BackupCmd, copy::Targets, forget::ForgetOptions},
+    commands::{backup::BackupCmd, copy::CopyCmd, forget::ForgetOptions},
     config::progress_options::ProgressOptions,
     filtering::SnapshotFilter,
 };
@@ -56,7 +56,7 @@ pub struct RusticConfig {
 
     /// Copy options
     #[clap(skip)]
-    pub copy: Targets,
+    pub copy: CopyCmd,
 
     /// Forget options
     #[clap(skip)]

--- a/tests/show-config-fixtures/empty.txt
+++ b/tests/show-config-fixtures/empty.txt
@@ -51,7 +51,7 @@ sources = []
 source = []
 
 [copy]
-targets = []
+target = []
 
 [forget]
 prune = false


### PR DESCRIPTION
Breaking change:

Targets for the `copy` command must now be given by using config profile(s).