### PR TITLE
more interactive improvements

### DIFF
--- a/src/commands/tui/ls.rs
+++ b/src/commands/tui/ls.rs
@@ -1,4 +1,4 @@
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use anyhow::Result;
 use crossterm::event::{Event, KeyCode, KeyEventKind};
@@ -199,11 +199,23 @@ impl<'a, P: ProgressBars, S: IndexedFull> Snapshot<'a, P, S> {
                     Char('n') => self.toggle_numeric(),
                     Char('r') => {
                         if let Some(node) = self.selected_node() {
+                            let is_absolute = self
+                                .snapshot
+                                .paths
+                                .iter()
+                                .any(|p| Path::new(p).is_absolute());
                             let path = self.path.join(node.name());
+                            let path = path.display();
+                            let default_targt = if is_absolute {
+                                format!("/{path}")
+                            } else {
+                                format!("{path}")
+                            };
                             let restore = Restore::new(
                                 self.repo,
                                 node.clone(),
-                                format!("{}:{}", self.snapshot.id, path.display()),
+                                format!("{}:/{path}", self.snapshot.id),
+                                &default_targt,
                             );
                             self.current_screen = CurrentScreen::Restore(restore);
                         }

--- a/src/commands/tui/restore.rs
+++ b/src/commands/tui/restore.rs
@@ -33,10 +33,10 @@ pub(crate) struct Restore<'a, P, S> {
 }
 
 impl<'a, P: ProgressBars, S: IndexedFull> Restore<'a, P, S> {
-    pub fn new(repo: &'a Repository<P, S>, node: Node, source: String) -> Self {
+    pub fn new(repo: &'a Repository<P, S>, node: Node, source: String, path: &str) -> Self {
         let opts = RestoreOptions::default();
         let title = format!("restore {} to:", source);
-        let popup = popup_input(title, "enter restore destination", "", 1);
+        let popup = popup_input(title, "enter restore destination", path, 1);
         Self {
             current_screen: CurrentScreen::GetDestination(popup),
             node,
@@ -47,7 +47,10 @@ impl<'a, P: ProgressBars, S: IndexedFull> Restore<'a, P, S> {
         }
     }
 
-    pub fn compute_plan(&mut self, dest: String, dry_run: bool) -> Result<RestorePlan> {
+    pub fn compute_plan(&mut self, mut dest: String, dry_run: bool) -> Result<RestorePlan> {
+        if dest.is_empty() {
+            dest = ".".to_string();
+        }
         self.dest = dest;
         let dest = LocalDestination::new(&self.dest, true, !self.node.is_dir())?;
         // for restore, always recurse into tree

--- a/src/commands/tui/snapshots.rs
+++ b/src/commands/tui/snapshots.rs
@@ -795,7 +795,7 @@ impl<'a, P: ProgressBars, S: IndexedFull> Snapshots<'a, P, S> {
                                 Char('p') => self.set_delete_protection(),
                                 Char('w') => {
                                     let msg = format!(
-                                        "Do you want to write {} modified and remove {} snapshots?",
+                                        "Do you want to write {} modified and remove {} snapshots? (y/n)",
                                         self.count_modified_snaps(),
                                         self.count_forget_snaps()
                                     );


### PR DESCRIPTION
restore:
- propose path from snapshot as target
- handle empty target

write snapshots:
- clarify that you can enter (y/n)