### PR TITLE
feat(diff): show diff statistics

### DIFF
--- a/src/commands/diff.rs
+++ b/src/commands/diff.rs
@@ -2,7 +2,7 @@
 
 use crate::{commands::open_repository_indexed, status_err, Application, RUSTIC_APP};
 
-use abscissa_core::{tracing::warn, Command, Runnable, Shutdown};
+use abscissa_core::{Command, Runnable, Shutdown};
 
 use std::{
     fmt::Display,


### PR DESCRIPTION
closes rustic-rs/rustic#440

### Description

The proposed code contains:
- a DiffStatistics structure used to hold count of stats
  - this structure offers a few helping functions that will look at a given NodeType to increment the associated counter
  - it has a Display implementation used to display the statistics in STDOUT
- this structure is used in the `diff` function

### Exemple

```bash
rustic --log-level debug -r test-repo --password password diff 8e57051d:config ./config
[INFO] using no config file, none of these exist: /home/nardor/.config/rustic/rustic.toml, /etc/rustic/rustic.toml, ./rustic.toml
[INFO] repository local:test-repo: password is correct.
[INFO] using cache at /home/nardor/.cache/rustic/3797e1fe324e97ac068e303e672da3d34af09cd73888bcfd09538cd72692bf7d
[00:00:00] reading index...               ████████████████████████████████████████          2/2                               
[00:00:00] getting snapshot...            ████████████████████████████████████████          0                                
[INFO] getting snapshot...
[00:00:00] getting snapshot...            ████████████████████████████████████████          0                                 
-    "README.md"
M    "bar"
+    "new_dir"
+    "new_dir/new_file"
-    "services"
-    "services/b2.toml"
-    "services/rclone_ovh-hot-cold.toml"
-    "services/s3_aws.toml"
-    "services/s3_idrive.toml"
-    "services/sftp.toml"
-    "services/sftp_hetzner_sbox.toml"
-    "services/webdav_owncloud_nextcloud.toml"
Files:	1 new,	8 removed, 	1 changed
Dirs:	1 new,	1 removed
Others:	0 new,	0 removed
```

### Testing

I am not sure what tests I can add.
Please let me know if you think of any test about this.

Thanks in advance for any feedback.