### PR TITLE
fix: return exitcode

### DIFF
--- a/src/application.rs
+++ b/src/application.rs
@@ -113,8 +113,8 @@ impl Application for RusticApp {
 impl RusticApp {
     /// Shut down this application gracefully, exiting with given exit code.
     fn shutdown_with_exitcode(&self, shutdown: Shutdown, exit_code: i32) -> ! {
-        let result = self.state().components().shutdown(self, shutdown) {
-        if let Err(e) = result
+        let result = self.state().components().shutdown(self, shutdown);
+        if let Err(e) = result {
             fatal_error(self, &e)
         }
 

--- a/src/application.rs
+++ b/src/application.rs
@@ -113,7 +113,8 @@ impl Application for RusticApp {
 impl RusticApp {
     /// Shut down this application gracefully, exiting with given exit code.
     fn shutdown_with_exitcode(&self, shutdown: Shutdown, exit_code: i32) -> ! {
-        if let Err(e) = self.state().components().shutdown(self, shutdown) {
+        let result = self.state().components().shutdown(self, shutdown) {
+        if let Err(e) = result
             fatal_error(self, &e)
         }
 


### PR DESCRIPTION
rustic now returns an error code for failing command.

Note: Some command do not fail yet fail in every cases user would expect is. Most notably the `check` ckommand producing `error` messages may still return error code 0.

closes #927 