### PR TITLE
feat: Add autocompletion hints

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -560,9 +560,9 @@ dependencies = [
 
 [[package]]
 name = "clap_complete"
-version = "4.5.18"
+version = "4.5.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ee158892bd7ce77aa15c208abbdb73e155d191c287a659b57abd5adb92feb03"
+checksum = "205d5ef6d485fa47606b98b0ddc4ead26eb850aaa86abfb562a94fb3280ecba0"
 dependencies = [
  "clap",
 ]

--- a/src/commands/backup.rs
+++ b/src/commands/backup.rs
@@ -10,6 +10,7 @@ use crate::{
 
 use abscissa_core::{Command, Runnable, Shutdown};
 use anyhow::{bail, Context, Result};
+use clap::ValueHint;
 use log::{debug, info, warn};
 use merge::Merge;
 use serde::{Deserialize, Serialize};
@@ -33,18 +34,18 @@ use rustic_core::{
 pub struct BackupCmd {
     /// Backup source (can be specified multiple times), use - for stdin. If no source is given, uses all
     /// sources defined in the config file
-    #[clap(value_name = "SOURCE")]
+    #[clap(value_name = "SOURCE", value_hint = ValueHint::AnyPath)]
     #[merge(skip)]
     #[serde(skip)]
     cli_sources: Vec<String>,
 
     /// Set filename to be used when backing up from stdin
-    #[clap(long, value_name = "FILENAME", default_value = "stdin")]
+    #[clap(long, value_name = "FILENAME", default_value = "stdin", value_hint = ValueHint::FilePath)]
     #[merge(skip)]
     stdin_filename: String,
 
     /// Manually set backup path in snapshot
-    #[clap(long, value_name = "PATH")]
+    #[clap(long, value_name = "PATH", value_hint = ValueHint::DirPath)]
     as_path: Option<PathBuf>,
 
     /// Ignore save options

--- a/src/commands/diff.rs
+++ b/src/commands/diff.rs
@@ -3,6 +3,7 @@
 use crate::{commands::open_repository_indexed, status_err, Application, RUSTIC_APP};
 
 use abscissa_core::{Command, Runnable, Shutdown};
+use clap::ValueHint;
 
 use std::{
     fmt::Display,
@@ -25,7 +26,7 @@ pub(crate) struct DiffCmd {
     snap1: String,
 
     /// New snapshot/path or local path [default for PATH2: PATH1]
-    #[clap(value_name = "SNAPSHOT2[:PATH2]|PATH2")]
+    #[clap(value_name = "SNAPSHOT2[:PATH2]|PATH2", value_hint = ValueHint::AnyPath)]
     snap2: String,
 
     /// show differences in metadata

--- a/src/commands/find.rs
+++ b/src/commands/find.rs
@@ -6,6 +6,7 @@ use crate::{commands::open_repository_indexed, status_err, Application, RUSTIC_A
 
 use abscissa_core::{Command, Runnable, Shutdown};
 use anyhow::Result;
+use clap::ValueHint;
 use globset::{Glob, GlobBuilder, GlobSetBuilder};
 use itertools::Itertools;
 
@@ -28,7 +29,7 @@ pub(crate) struct FindCmd {
     iglob: Vec<String>,
 
     /// exact path to find
-    #[clap(long, value_name = "PATH")]
+    #[clap(long, value_name = "PATH", value_hint = ValueHint::AnyPath)]
     path: Option<PathBuf>,
 
     /// Snapshots to search in. If none is given, use filter options to filter from all snapshots

--- a/src/config.rs
+++ b/src/config.rs
@@ -11,7 +11,7 @@ use std::{collections::HashMap, path::PathBuf};
 use abscissa_core::config::Config;
 use abscissa_core::path::AbsPathBuf;
 use abscissa_core::FrameworkError;
-use clap::Parser;
+use clap::{Parser, ValueHint};
 use directories::ProjectDirs;
 use itertools::Itertools;
 use log::Level;
@@ -161,7 +161,7 @@ pub struct GlobalOptions {
     /// # Note
     ///
     /// Warnings and errors are still additionally printed unless they are ignored by `--log-level`
-    #[clap(long, global = true, env = "RUSTIC_LOG_FILE", value_name = "LOGFILE")]
+    #[clap(long, global = true, env = "RUSTIC_LOG_FILE", value_name = "LOGFILE", value_hint = ValueHint::FilePath)]
     pub log_file: Option<PathBuf>,
 
     /// Settings to customize progress bars


### PR DESCRIPTION
## Feature

**Add auto completion hints**

This helps some shells to propose better completions.
For instance on `zsh`, no completion were proposed when doing `rustic backup <...>[TAB]`

## Hints added
- `rustic backup <...>[TAB]`
- `rustic backup --as-path [TAB] <...>`
- `rustic backup --stdin-filename [TAB] <...>` This one is for comfort, as the compl might not help (or might), but my opinion is that it's better than nothing.
- `rustic diff <snapshot_id> <...>[TAB]`
- `rustic find --path <...>[TAB]`
- rustic --log-file <...>[TAB]`
