### PR TITLE
fix: ls: Remove printing trailing space

### DIFF
--- a/src/commands/ls.rs
+++ b/src/commands/ls.rs
@@ -141,7 +141,7 @@ impl LsCmd {
             if self.long {
                 print_node(&node, &path, self.numeric_id);
             } else {
-                println!("{path:?}");
+                println!("{}", path.display());
             }
         }
 

--- a/src/commands/ls.rs
+++ b/src/commands/ls.rs
@@ -141,7 +141,7 @@ impl LsCmd {
             if self.long {
                 print_node(&node, &path, self.numeric_id);
             } else {
-                println!("{path:?} ");
+                println!("{path:?}");
             }
         }
 


### PR DESCRIPTION
Paths are separated by a newline, printing space only hinders parsing. Also paths are now displayed using `Path::display()`.