### PR TITLE
build: reintroduce stack unwinding, don't abort on panic

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -148,7 +148,6 @@ lto = "fat"
 debug-assertions = false
 codegen-units = 1
 strip = true
-panic = "abort"
 
 [profile.test]
 opt-level = 1


### PR DESCRIPTION
We have aborting on panic in our rustic `Cargo.toml`. For `rustic` this may affect the stack traces that `human-panic` spits out. This will make it easier, to find bugs, that are reported to us by the users, having their stack traces. Reintroducing the unwinding code will impact the binary size, which is currently around 8 MiB, and it may go up a few MiBs.