### PR TITLE
ci: add missing feature self-update to tests and checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,7 @@ jobs:
           components: clippy
       - uses: Swatinem/rust-cache@23bce251a8cd2ffc3c1075eaa2367cf899916d84 # v2
       - name: Run clippy
-        run: cargo clippy --locked --all-targets --features ${{ matrix.feature }} -- -D warnings
+        run: cargo clippy --locked --all-targets --features ${{ matrix.feature }} --features self-update -- -D warnings
 
   test:
     name: Test
@@ -79,7 +79,7 @@ jobs:
           toolchain: stable
       - uses: Swatinem/rust-cache@23bce251a8cd2ffc3c1075eaa2367cf899916d84 # v2
       - name: Run Cargo Test
-        run: cargo test -r --all-targets --features ${{ matrix.feature }} --workspace
+        run: cargo test -r --all-targets --features ${{ matrix.feature }} --features self-update --workspace
 
   docs:
     name: Build docs

--- a/.github/workflows/cross-ci.yml
+++ b/.github/workflows/cross-ci.yml
@@ -28,7 +28,7 @@ jobs:
       fail-fast: false
       matrix:
         rust: [stable]
-        feature: [default, self-update]
+        feature: [default]
         job:
           - os: windows-latest
             os-name: windows
@@ -93,6 +93,7 @@ jobs:
           use-cross: ${{ matrix.job.use-cross }}
           all-features: "false"
           feature: ${{ matrix.feature }}
+          extra-cargo-build-args: --features self-update
 
   result:
     name: Result (Cross-CI)

--- a/.github/workflows/cross-ci.yml
+++ b/.github/workflows/cross-ci.yml
@@ -28,7 +28,7 @@ jobs:
       fail-fast: false
       matrix:
         rust: [stable]
-        feature: [default]
+        feature: [default, self-update]
         job:
           - os: windows-latest
             os-name: windows


### PR DESCRIPTION
Currently, we are not testing with all features, as `self-update` is missing. This PR adds it back.