### PR TITLE
Build docker image on release

### DIFF
--- a/.github/workflows/release-image.yml
+++ b/.github/workflows/release-image.yml
@@ -1,0 +1,24 @@
+name: Build and push docker image on release
+
+on: [release]
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
+
+    - name: Login to Docker Hub
+      uses: docker/login-action@v3
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Build and push
+      uses: docker/build-push-action@v6
+      with:
+        push: true
+        tags: ghcr.io/mueckinger/rustic:latest,ghcr.io/mueckinger/rustic:${{ github.ref_name }}
+        build-args: RUSTIC_VERSION=${{ github.ref_name }}

--- a/.github/workflows/release-image.yml
+++ b/.github/workflows/release-image.yml
@@ -20,5 +20,5 @@ jobs:
       uses: docker/build-push-action@v6
       with:
         push: true
-        tags: ghcr.io/mueckinger/rustic:latest,ghcr.io/mueckinger/rustic:${{ github.ref_name }}
+        tags: ghcr.io/rustic-rs/rustic:latest,ghcr.io/rustic-rs/rustic:${{ github.ref_name }}
         build-args: RUSTIC_VERSION=${{ github.ref_name }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,23 +1,12 @@
-# Improve build speed with cached deps
-ARG RUST_VERSION=1.76.0
-FROM lukemathwalker/cargo-chef:latest-rust-${RUST_VERSION} AS chef
-WORKDIR /app
+FROM alpine AS builder
+ARG RUSTIC_VERSION
+RUN wget https://github.com/rustic-rs/rustic/releases/download/${RUSTIC_VERSION}/rustic-${RUSTIC_VERSION}-x86_64-unknown-linux-musl.tar.gz && \
+    tar -xzf rustic-${RUSTIC_VERSION}-x86_64-unknown-linux-musl.tar.gz && \
+    mkdir /etc_files && \
+    touch /etc_files/passwd && \
+    touch /etc_files/group
 
-FROM chef AS planner
-COPY . .
-RUN cargo chef prepare --recipe-path recipe.json
-
-FROM chef AS builder
-COPY --from=planner /app/recipe.json recipe.json
-# Build dependencies - this is the caching Docker layer!
-RUN cargo chef cook --release --recipe-path recipe.json
-# Build application
-COPY . .
-RUN cargo build --release
-
-# why we dont use alpine for base image - https://andygrove.io/2020/05/why-musl-extremely-slow/
-FROM debian:bookworm-slim as runtime
-
-COPY --from=builder /app/target/release/rustic /usr/local/bin
-
-ENTRYPOINT ["/usr/local/bin/rustic"]
+FROM scratch
+COPY --from=builder /rustic /
+COPY --from=builder /etc_files/ /etc/
+ENTRYPOINT ["/rustic"]

--- a/README.md
+++ b/README.md
@@ -97,6 +97,12 @@ Or you can check out the
 Nightly binaries are available
 [here](https://rustic.cli.rs/docs/nightly_builds.html).
 
+### Docker
+
+```bash
+docker pull ghcr.io/rustic-rs/rustic
+```
+
 ### From source
 
 **Beware**: This installs the latest development version, which might be


### PR DESCRIPTION
Hi! Finally I figured out how to automatically build docker images on every new rustic release.
Closes  #1083
Completes tasks discussed in #969 and #1008.

Notes to the maintainers:
- This requires setting Workflow permissions to write access for the GITHUB_TOKEN as described here: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/enabling-features-for-your-repository/managing-github-actions-settings-for-a-repository#configuring-the-default-github_token-permissions
- It makes sense to update the README (added docker install info) in the next rustic release (when the first image is built)
