### PR TITLE
fix(deps): update rustic_core to version 0.5.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3863,9 +3863,9 @@ dependencies = [
 
 [[package]]
 name = "rustic_core"
-version = "0.5.2"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31a91fba0db4615610806ee810c26844cfde155ede5e0d32fc8008d0dd52d790"
+checksum = "11529c7b9a74297cb6c36f89d3746eb6a1112b8d309d5b25b338a9fedef0ff02"
 dependencies = [
  "aes256ctr_poly1305aes",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ rustdoc-args = ["--document-private-items", "--generate-link-to-definition"]
 [dependencies]
 abscissa_core = { version = "0.7.0", default-features = false, features = ["application"] }
 rustic_backend = { version = "0.4.1", features = ["cli"] }
-rustic_core = { version = "0.5.2", features = ["cli"] }
+rustic_core = { version = "0.5.3", features = ["cli"] }
 
 # allocators
 jemallocator-global = { version = "0.3.2", optional = true }


### PR DESCRIPTION
This contains an immediate fix for a newly introduced bug in `rustic_core v0.5.2` that involved how the `TreeStreamerOnce` handled errors when a channel was full.

Fixes v0.9.2 breaks prune operations #1313