### PR TITLE
build(docker): support arm64 docker image

### DIFF
--- a/.github/workflows/cross-ci.yml
+++ b/.github/workflows/cross-ci.yml
@@ -67,6 +67,11 @@ jobs:
             use-cross: true
           - os: ubuntu-latest
             os-name: linux
+            target: aarch64-unknown-linux-musl
+            architecture: arm64
+            use-cross: true
+          - os: ubuntu-latest
+            os-name: linux
             target: i686-unknown-linux-gnu
             architecture: i686
             use-cross: true

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -69,6 +69,12 @@ jobs:
             use-cross: true
           - os: ubuntu-latest
             os-name: linux
+            target: aarch64-unknown-linux-musl
+            architecture: arm64
+            binary-postfix: ""
+            use-cross: true
+          - os: ubuntu-latest
+            os-name: linux
             target: i686-unknown-linux-gnu
             architecture: i686
             binary-postfix: ""

--- a/.github/workflows/release-cd.yml
+++ b/.github/workflows/release-cd.yml
@@ -74,6 +74,12 @@ jobs:
             use-cross: true
           - os: ubuntu-latest
             os-name: linux
+            target: aarch64-unknown-linux-musl
+            architecture: arm64
+            binary-postfix: ""
+            use-cross: true
+          - os: ubuntu-latest
+            os-name: linux
             target: i686-unknown-linux-gnu
             architecture: i686
             binary-postfix: ""

--- a/.github/workflows/release-image.yml
+++ b/.github/workflows/release-image.yml
@@ -20,5 +20,6 @@ jobs:
       uses: docker/build-push-action@4f58ea79222b3b9dc2c8bbdd6debcef730109a75 # v6
       with:
         push: true
+        platforms: linux/amd64,linux/arm64
         tags: ghcr.io/rustic-rs/rustic:latest,ghcr.io/rustic-rs/rustic:${{ github.ref_name }}
         build-args: RUSTIC_VERSION=${{ github.ref_name }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,13 @@
 FROM alpine AS builder
 ARG RUSTIC_VERSION
-RUN wget https://github.com/rustic-rs/rustic/releases/download/${RUSTIC_VERSION}/rustic-${RUSTIC_VERSION}-x86_64-unknown-linux-musl.tar.gz && \
-    tar -xzf rustic-${RUSTIC_VERSION}-x86_64-unknown-linux-musl.tar.gz && \
+ARG TARGETARCH
+RUN if [ "$TARGETARCH" = "amd64" ]; then \
+        ASSET="rustic-${RUSTIC_VERSION}-x86_64-unknown-linux-musl.tar.gz";\
+    elif [ "$TARGETARCH" = "arm64" ]; then \
+        ASSET="rustic-${RUSTIC_VERSION}-aarch64-unknown-linux-musl.tar.gz"; \
+    fi; \
+    wget https://github.com/rustic-rs/rustic/releases/download/${RUSTIC_VERSION}/${ASSET} && \
+    tar -xzf ${ASSET} && \
     mkdir /etc_files && \
     touch /etc_files/passwd && \
     touch /etc_files/group

--- a/build-dependencies.just
+++ b/build-dependencies.just
@@ -5,6 +5,11 @@ install-default-x86_64-unknown-linux-musl:
     sudo apt-get update
     sudo apt-get install -y musl-tools
 
+# Install dependencies for the default feature on aarch64-unknown-linux-musl
+install-default-aarch64-unknown-linux-musl:
+    sudo apt-get update
+    sudo apt-get install -y musl-tools
+
 ### MOUNT ###
 
 # Install dependencies for the mount feature on x86_64-unknown-linux-gnu
@@ -19,11 +24,6 @@ install-mount-aarch64-unknown-linux-gnu:
 
 # Install dependencies for the mount feature on i686-unknown-linux-gnu
 install-mount-i686-unknown-linux-gnu:
-    sudo apt-get update
-    sudo apt-get install -y fuse3 libfuse3-dev pkg-config
-
-# Install dependencies for the mount feature on x86_64-unknown-linux-musl
-install-mount-x86_64-unknown-linux-musl:
     sudo apt-get update
     sudo apt-get install -y fuse3 libfuse3-dev pkg-config
 


### PR DESCRIPTION
This PR create a new building target `aarch64-unknonw-linux-musl`, as `aarch64-unknonw-linux-gnu` is not competible with the docker base image `scratch`. 

Follows the current step, the arm64 docker image will be built after Github release.