### PR TITLE
chore: add max-perf-at-small-bin profile

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -162,6 +162,10 @@ codegen-units = 1
 strip = true
 panic = "abort"
 
+[profile.max-perf-at-small-bin]
+inherits = "release"
+opt-level = "z"
+
 [profile.test]
 opt-level = 1
 debug = true


### PR DESCRIPTION
Results in 38.5% size reduction on Windows 11, and 33% less on openSuse.

We could also use it in `release`?