### PR TITLE
feat: shut down gracefully with ctrl+c

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1114,6 +1114,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "ctrlc"
+version = "3.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90eeab0aa92f3f9b4e87f258c72b139c207d251f9cbc1080a0086b86a8870dd3"
+dependencies = [
+ "nix",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "curve25519-dalek"
 version = "4.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4170,6 +4180,7 @@ dependencies = [
  "conflate",
  "convert_case",
  "crossterm",
+ "ctrlc",
  "dateparser",
  "dav-server",
  "derive_more",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -101,6 +101,7 @@ clap = { version = "4", features = ["derive", "env", "wrap_help"] }
 clap_complete = "4"
 conflate = "0.3.1"
 convert_case = "0.6.0"
+ctrlc = { version = "3.4.5", features = ["termination"] }
 dateparser = "0.2.1"
 derive_more = { version = "1", features = ["debug"] }
 dialoguer = "0.11.0"
@@ -117,7 +118,6 @@ open = "5.3.0"
 self_update = { version = "0.39.0", default-features = false, optional = true, features = ["rustls", "archive-tar", "compression-flate2"] } # FIXME: Downgraded to 0.39.0 due to https://github.com/jaemk/self_update/issues/136
 tar = "0.4.42"
 toml = "0.8"
-ctrlc = { version = "3.4.5", features = ["termination"] }
 
 [dev-dependencies]
 abscissa_core = { version = "0.8.1", default-features = false, features = ["testing"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -117,6 +117,7 @@ open = "5.3.0"
 self_update = { version = "0.39.0", default-features = false, optional = true, features = ["rustls", "archive-tar", "compression-flate2"] } # FIXME: Downgraded to 0.39.0 due to https://github.com/jaemk/self_update/issues/136
 tar = "0.4.42"
 toml = "0.8"
+ctrlc = { version = "3.4.5", features = ["termination"] }
 
 [dev-dependencies]
 abscissa_core = { version = "0.8.1", default-features = false, features = ["testing"] }

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -35,6 +35,7 @@ use std::fmt::Debug;
 use std::fs::File;
 use std::path::PathBuf;
 use std::str::FromStr;
+use std::sync::mpsc::channel;
 
 #[cfg(feature = "mount")]
 use crate::commands::mount::MountCmd;
@@ -63,8 +64,9 @@ use clap::builder::{
     Styles,
 };
 use convert_case::{Case, Casing};
+use ctrlc;
 use human_panic::setup_panic;
-use log::{log, Level};
+use log::{info, log, Level};
 use simplelog::{CombinedLogger, LevelFilter, TermLogger, TerminalMode, WriteLogger};
 
 use self::find::FindCmd;
@@ -179,6 +181,20 @@ impl Runnable for EntryPoint {
         // Set up panic hook for better error messages and logs
         setup_panic!();
 
+        // Set up Ctrl-C handler
+        let (tx, rx) = channel();
+
+        ctrlc::set_handler(move || tx.send(()).expect("Could not send signal on channel."))
+            .expect("Error setting Ctrl-C handler");
+
+        _ = std::thread::spawn(move || {
+            // Wait for Ctrl-C
+            rx.recv().expect("Could not receive from channel.");
+            info!("Ctrl-C received, shutting down...");
+            RUSTIC_APP.shutdown(Shutdown::Graceful)
+        });
+
+        // Run the subcommand
         self.commands.run();
         RUSTIC_APP.shutdown(Shutdown::Graceful)
     }

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -64,7 +64,6 @@ use clap::builder::{
     Styles,
 };
 use convert_case::{Case, Casing};
-use ctrlc;
 use human_panic::setup_panic;
 use log::{info, log, Level};
 use simplelog::{CombinedLogger, LevelFilter, TermLogger, TerminalMode, WriteLogger};


### PR DESCRIPTION
If you have a long-running process, like `webdav` or `backup` or others, pressing CTRL+C usually results in a non-zero exit code:

`process didn't exit successfully: P:\CARGO\.cargo-target-win\debug\rustic.exe -P <PROFILE> webdav (exit code: 0xc000013a, STATUS_CONTROL_C_EXIT)`

This shouldn't be the case, as it was user initiated and we can shut down gracefully.

This PR adds this functionality, so CTRL+C shuts down `rustic` gracefully and exits with a 0 exit-code.

