### PR TITLE
docs: Add documentation for `minutely` keep option

### DIFF
--- a/config/README.md
+++ b/config/README.md
@@ -245,6 +245,7 @@ hooks when backing up the defined sources into a snapshot.
 | -------------------------- | ----------------------------------------------------------------------- | ------------------ | ---------------------- | ---------------------------- |
 | group-by                   | Group snapshots by given criteria before applying keep policies.        | "host,label,paths" |                        | --group-by                   |
 | keep-last                  | Number of most recent snapshots to keep.                                | Not set            | 15                     | --keep-last, -l              |
+| keep-minutely, -M          | Number of minutely snapshots to keep.                                   | Not set            |                        | --keep-minutely              |
 | keep-hourly, -H            | Number of hourly snapshots to keep.                                     | Not set            |                        | --keep-hourly                |
 | keep-daily, -d             | Number of daily snapshots to keep.                                      | Not set            | 8                      | --keep-daily                 |
 | keep-weekly, -w            | Number of weekly snapshots to keep.                                     | Not set            |                        | --keep-weekly                |
@@ -252,6 +253,7 @@ hooks when backing up the defined sources into a snapshot.
 | keep-quarter-yearly        | Number of quarter-yearly snapshots to keep.                             | Not set            |                        | --keep-quarter-yearly        |
 | keep-half-yearly           | Number of half-yearly snapshots to keep.                                | Not set            |                        | --keep-half-yearly           |
 | keep-yearly, -y            | Number of yearly snapshots to keep.                                     | Not set            |                        | --keep-yearly                |
+| keep-within-minutely       | The time duration within which minutely snapshots will be kept.         | Not set            | "2 hours"              | --keep-within-minutely       |
 | keep-within-hourly         | The time duration within which hourly snapshots will be kept.           | Not set            | "1 day"                | --keep-within-hourly         |
 | keep-within-daily          | The time duration within which daily snapshots will be kept.            | Not set            | "7 days"               | --keep-within-daily          |
 | keep-within-weekly         | The time duration within which weekly snapshots will be kept.           | Not set            |                        | --keep-within-weekly         |

--- a/config/full.toml
+++ b/config/full.toml
@@ -181,6 +181,7 @@ keep-ids = [
   "11122233",
 ] # Keep all snapshots whose ID starts with any of these strings, default: not set
 keep-last = 0
+keep-minutely = 10
 keep-daily = 3
 keep-weekly = 0
 keep-monthly = 0
@@ -188,6 +189,7 @@ keep-quarter-yearly = 0
 keep-half-yearly = 0
 keep-yearly = 10
 keep-within = "0s"
+keep-within-minutely = "2 hours"
 keep-within-daily = "0 seconds"
 keep-within-weekly = "2 months"
 keep-within-monthly = "1 year"


### PR DESCRIPTION
Adds documentation for the minutely timeline (https://github.com/rustic-rs/rustic_core/pull/374) in `./config/full.toml` and `./config/README.md`