### PR TITLE
fix(commands): remove SIGPIPE default handler

### DIFF
--- a/src/bin/rustic.rs
+++ b/src/bin/rustic.rs
@@ -17,13 +17,5 @@ use rustic_rs::application::RUSTIC_APP;
 
 /// Boot Rustic
 fn main() {
-    // FIXME: this is a workaround until unix_sigpipe (https://github.com/rust-lang/rust/issues/97889) is available.
-    // See also https://github.com/rust-lang/rust/issues/46016
-    #[cfg(not(windows))]
-    #[allow(unsafe_code)]
-    unsafe {
-        libc::signal(libc::SIGPIPE, libc::SIG_DFL);
-    }
-
     abscissa_core::boot(&RUSTIC_APP);
 }


### PR DESCRIPTION
In a complex program the cause of SIGPIPE is unclear, it may come from socket writes, or even socket reads under some conditions, as well as on writes to pipes. As rustic depends on third party libraries to perform IO and handle sockets, it has little power to control the socket and operation flags for all IO to ensure that SIGPIPE has a clear meaning.

Per a comment on #1326 the original intent was to catch a SIGPIPE from a use case such as `command | rustic backup -` however this situation will not create a SIGPIPE anyway, and if it did it would likely result in incomplete data due to command exiting immediately after writing into the pipe buffer, rather than after all pipe buffer data has been read. The behavior of pipes in this case is to EOF after all writers have completed and all data has been read.

The situation the other way around is different, such as `rustic backup | command`, this would generate SIGPIPE when rustic writes to the pipe after command has exited. This signal is however superfluous, and still not terribly useful, as it is often more useful to handle the EPIPE that will be returned from the write call, and gracefully cease operations, in whatever form is required.

closes #1326