### PR TITLE
feat(commands)!: Extend logging

### DIFF
--- a/src/commands.rs
+++ b/src/commands.rs
@@ -164,9 +164,13 @@ fn styles() -> Styles {
         .placeholder(AnsiColor::Green.on_default())
 }
 
+fn version() -> &'static str {
+    option_env!("PROJECT_VERSION").unwrap_or(env!("CARGO_PKG_VERSION"))
+}
+
 /// Entry point for the application. It needs to be a struct to allow using subcommands!
 #[derive(clap::Parser, Command, Debug)]
-#[command(author, about, name="rustic", styles=styles(), version = option_env!("PROJECT_VERSION").unwrap_or(env!("CARGO_PKG_VERSION")))]
+#[command(author, about, name="rustic", styles=styles(), version=version())]
 pub struct EntryPoint {
     #[command(flatten)]
     pub config: RusticConfig,
@@ -294,6 +298,8 @@ impl Configurable<RusticConfig> for EntryPoint {
                     WriteLogger::new(level_filter, file_config, file),
                 ])
                 .map_err(|e| FrameworkErrorKind::ConfigError.context(e))?;
+                info!("rustic {}", version());
+                info!("command: {:?}", std::env::args_os().collect::<Vec<_>>());
             }
         }
 

--- a/src/commands/backup.rs
+++ b/src/commands/backup.rs
@@ -318,28 +318,28 @@ impl BackupCmd {
             println!("{table}");
         } else if !self.quiet {
             let summary = snap.summary.as_ref().unwrap();
-            println!(
+            info!(
                 "Files:       {} new, {} changed, {} unchanged",
                 summary.files_new, summary.files_changed, summary.files_unmodified
             );
-            println!(
+            info!(
                 "Dirs:        {} new, {} changed, {} unchanged",
                 summary.dirs_new, summary.dirs_changed, summary.dirs_unmodified
             );
             debug!("Data Blobs:  {} new", summary.data_blobs);
             debug!("Tree Blobs:  {} new", summary.tree_blobs);
-            println!(
+            info!(
                 "Added to the repo: {} (raw: {})",
                 bytes_size_to_string(summary.data_added_packed),
                 bytes_size_to_string(summary.data_added)
             );
 
-            println!(
+            info!(
                 "processed {} files, {}",
                 summary.total_files_processed,
                 bytes_size_to_string(summary.total_bytes_processed)
             );
-            println!("snapshot {} successfully saved.", snap.id);
+            info!("snapshot {} successfully saved.", snap.id);
         }
 
         #[cfg(feature = "prometheus")]

--- a/src/commands/forget.rs
+++ b/src/commands/forget.rs
@@ -6,9 +6,9 @@ use crate::{Application, RUSTIC_APP, RusticConfig, helpers::table_with_titles, s
 use abscissa_core::{Command, FrameworkError, Runnable};
 use abscissa_core::{Shutdown, config::Override};
 use anyhow::Result;
-
 use chrono::Local;
 use conflate::Merge;
+use log::info;
 use serde::{Deserialize, Serialize};
 use serde_with::{DisplayFromStr, serde_as};
 
@@ -150,9 +150,9 @@ impl ForgetCmd {
         let forget_snaps = groups.into_forget_ids();
 
         match (forget_snaps.is_empty(), config.global.dry_run, self.json) {
-            (true, _, false) => println!("nothing to remove"),
+            (true, _, false) => info!("nothing to remove"),
             (false, true, false) => {
-                println!("would have removed the following snapshots:\n {forget_snaps:?}");
+                info!("would have removed the following snapshots:\n {forget_snaps:?}");
             }
             (false, false, _) => {
                 repo.delete_snapshots(&forget_snaps)?;
@@ -177,9 +177,6 @@ impl ForgetCmd {
 /// * `groups` - forget groups to print
 fn print_groups(groups: &ForgetGroups) {
     for ForgetGroup { group, snapshots } in &groups.0 {
-        if !group.is_empty() {
-            println!("snapshots for {group}");
-        }
         let mut table = table_with_titles([
             "ID", "Time", "Host", "Label", "Tags", "Paths", "Action", "Reason",
         ]);
@@ -207,8 +204,10 @@ fn print_groups(groups: &ForgetGroups) {
             ]);
         }
 
-        println!();
-        println!("{table}");
-        println!();
+        if !group.is_empty() {
+            info!("snapshots for {group}:\n{table}");
+        } else {
+            info!("snapshots:\n{table}");
+        }
     }
 }

--- a/src/commands/prune.rs
+++ b/src/commands/prune.rs
@@ -4,7 +4,7 @@ use crate::{
     Application, RUSTIC_APP, helpers::bytes_size_to_string, repository::CliOpenRepo, status_err,
 };
 use abscissa_core::{Command, Runnable, Shutdown};
-use log::debug;
+use log::{debug, info};
 
 use anyhow::Result;
 
@@ -81,65 +81,63 @@ fn print_stats(stats: &PruneStats) {
         bytes_size_to_string(size_stat.total())
     );
 
-    println!(
+    info!(
         "to repack: {:>10} packs, {:>10} blobs, {:>10}",
         pack_stat.repack,
         blob_stat.repack,
         bytes_size_to_string(size_stat.repack)
     );
-    println!(
+    info!(
         "this removes:                {:>10} blobs, {:>10}",
         blob_stat.repackrm,
         bytes_size_to_string(size_stat.repackrm)
     );
-    println!(
+    info!(
         "to delete: {:>10} packs, {:>10} blobs, {:>10}",
         pack_stat.unused,
         blob_stat.remove,
         bytes_size_to_string(size_stat.remove)
     );
-    if !stats.packs_unref > 0 {
-        println!(
+    if stats.packs_unref > 0 {
+        info!(
             "unindexed: {:>10} packs,         ?? blobs, {:>10}",
             stats.packs_unref,
             bytes_size_to_string(stats.size_unref)
         );
     }
 
-    println!(
+    info!(
         "total prune:                 {:>10} blobs, {:>10}",
         blob_stat.repackrm + blob_stat.remove,
         bytes_size_to_string(size_stat.repackrm + size_stat.remove + stats.size_unref)
     );
-    println!(
+    info!(
         "remaining:                   {:>10} blobs, {:>10}",
         blob_stat.total_after_prune(),
         bytes_size_to_string(size_stat.total_after_prune())
     );
-    println!(
+    info!(
         "unused size after prune: {:>10} ({:.2}% of remaining size)",
         bytes_size_to_string(size_stat.unused_after_prune()),
         size_stat.unused_after_prune() as f64 / size_stat.total_after_prune() as f64 * 100.0
     );
 
-    println!();
-
-    println!(
+    info!(
         "packs marked for deletion: {:>10}, {:>10}",
         stats.packs_to_delete.total(),
         bytes_size_to_string(stats.size_to_delete.total()),
     );
-    println!(
+    info!(
         " - complete deletion:      {:>10}, {:>10}",
         stats.packs_to_delete.remove,
         bytes_size_to_string(stats.size_to_delete.remove),
     );
-    println!(
+    info!(
         " - keep marked:            {:>10}, {:>10}",
         stats.packs_to_delete.keep,
         bytes_size_to_string(stats.size_to_delete.keep),
     );
-    println!(
+    info!(
         " - recover:                {:>10}, {:>10}",
         stats.packs_to_delete.recover,
         bytes_size_to_string(stats.size_to_delete.recover),

--- a/tests/backup_restore.rs
+++ b/tests/backup_restore.rs
@@ -58,7 +58,7 @@ fn test_backup_and_check_passes() -> TestResult<()> {
             .arg(&backup)
             .assert()
             .success()
-            .stdout(predicate::str::contains("successfully saved."));
+            .stderr(predicate::str::contains("successfully saved."));
     }
 
     {
@@ -77,8 +77,8 @@ fn test_backup_and_check_passes() -> TestResult<()> {
             .arg(backup)
             .assert()
             .success()
-            .stdout(predicate::str::contains("Added to the repo: 0 B"))
-            .stdout(predicate::str::contains("successfully saved."));
+            .stderr(predicate::str::contains("Added to the repo: 0 B"))
+            .stderr(predicate::str::contains("successfully saved."));
     }
 
     {
@@ -118,7 +118,7 @@ fn test_backup_and_restore_passes() -> TestResult<()> {
             .arg("/")
             .assert()
             .success()
-            .stdout(predicate::str::contains("successfully saved."));
+            .stderr(predicate::str::contains("successfully saved."));
     }
     {
         // Run `restore`


### PR DESCRIPTION
This PR extends the logging. For `backup`, `forget`, `prune` the stdout output is now printed via an INFO log which allows to see this information also in the log file.
Moreover, when using a log file, rustic now also logs the version and the used command.

closes #1454
closes #1080 