### PR TITLE
change!: Remove --filter-fn from default

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ rustic - fast, encrypted, deduplicated backups powered by Rust
 """
 
 [features]
-default = ["jq", "prometheus", "opentelemetry", "rhai", "tui", "webdav"]
+default = ["jq", "prometheus", "opentelemetry", "tui", "webdav"]
 release = ["default", "self-update"]
 
 # Allocators

--- a/config/README.md
+++ b/config/README.md
@@ -168,22 +168,22 @@ See [Global Hooks](#global-hooks-globalhooks).
 
 ### Snapshot-Filter Options `[snapshot-filter]`
 
-| Attribute          | Description                                                            | Default Value | Example Value              | CLI Option           |
-| ------------------ | ---------------------------------------------------------------------- | ------------- | -------------------------- | -------------------- |
-| filter-hosts       | Array of hosts to filter snapshots.                                    | Not set       | ["myhost", "host2"]        | --filter-host        |
-| filter-labels      | Array of labels to filter snapshots.                                   | Not set       | ["mylabal"]                | --filter-label       |
-| filter-paths       | Array of pathlists to filter snapshots.                                | Not set       | ["/home,/root"]            | --filter-paths       |
-| filter-paths-exact | Array or string of paths to filter snapshots. Exact match.             | Not set       | ["path1,path2", "path3"]   | --filter-paths-exact |
-| filter-tags        | Array of taglists to filter snapshots.                                 | Not set       | ["tag1,tag2"]              | --filter-tags        |
-| filter-tags-exact  | Array or string of tags to filter snapshots. Exact match.              | Not set       | ["tag1,tag2", "tag3"]      | --filter-tags-exact  |
-| filter-before      | Filter snapshots before the given date/time                            | Not set       | "2024-01-01"               | --filter-before      |
-| filter-after       | Filter snapshots after the given date/time                             | Not set       | "2023-01-01 11:15:23"      | --filter-after       |
-| filter-size        | Filter snapshots for a total size in the size range.                   | Not set       | "1MB..1GB"                 | --filter-size        |
-|                    | If a single value is given, this is taken as lower bound.              |               | "500 k"                    |                      |
-| filter-size-added  | Filter snapshots for a size added to the repository in the size range. | Not set       | "1MB..1GB"                 | --filter-size-added  |
-|                    | If a single value is given, this is taken as lower bound.              |               | "500 k"                    |                      |
-| filter-fn          | Custom filter function for snapshots.                                  | Not set       |                            | --filter-fn          |
-| filter-jq          | Custom filter jq function for snapshots. Should return bool            | Not set       | ".summary.files_added > 1" | --filter-jq          |
+| Attribute          | Description                                                                   | Default Value | Example Value              | CLI Option           |
+| ------------------ | ----------------------------------------------------------------------------- | ------------- | -------------------------- | -------------------- |
+| filter-hosts       | Array of hosts to filter snapshots.                                           | Not set       | ["myhost", "host2"]        | --filter-host        |
+| filter-labels      | Array of labels to filter snapshots.                                          | Not set       | ["mylabal"]                | --filter-label       |
+| filter-paths       | Array of pathlists to filter snapshots.                                       | Not set       | ["/home,/root"]            | --filter-paths       |
+| filter-paths-exact | Array or string of paths to filter snapshots. Exact match.                    | Not set       | ["path1,path2", "path3"]   | --filter-paths-exact |
+| filter-tags        | Array of taglists to filter snapshots.                                        | Not set       | ["tag1,tag2"]              | --filter-tags        |
+| filter-tags-exact  | Array or string of tags to filter snapshots. Exact match.                     | Not set       | ["tag1,tag2", "tag3"]      | --filter-tags-exact  |
+| filter-before      | Filter snapshots before the given date/time                                   | Not set       | "2024-01-01"               | --filter-before      |
+| filter-after       | Filter snapshots after the given date/time                                    | Not set       | "2023-01-01 11:15:23"      | --filter-after       |
+| filter-size        | Filter snapshots for a total size in the size range.                          | Not set       | "1MB..1GB"                 | --filter-size        |
+|                    | If a single value is given, this is taken as lower bound.                     |               | "500 k"                    |                      |
+| filter-size-added  | Filter snapshots for a size added to the repository in the size range.        | Not set       | "1MB..1GB"                 | --filter-size-added  |
+|                    | If a single value is given, this is taken as lower bound.                     |               | "500 k"                    |                      |
+| filter-fn          | Custom filter function for snapshots. (only when compiled with `rhai`feature) | Not set       |                            | --filter-fn          |
+| filter-jq          | Custom filter jq function for snapshots. Should return bool                   | Not set       | ".summary.files_added > 1" | --filter-jq          |
 
 ### Backup Options `[backup]`
 

--- a/config/full.toml
+++ b/config/full.toml
@@ -104,7 +104,6 @@ filter-after = "2024-01-01" # Default: not set
 filter-before = "2024-02-05 12:15" # Default: not set
 filter-size = "200MiB" # Default: not set
 filter-size-added = "1 MB..10MB" # Default: not set
-filter-fn = '|sn| {sn.host == "host1" || sn.description.contains("test")}' # Default: no filter function
 filter-jq = '.description | contains ("test")' # Default: no jq filter function
 
 # Backup options: These options are used for all sources when calling the backup command.
@@ -191,7 +190,6 @@ filter-after = "2024-01-01" # Default: not set
 filter-before = "2024-02-05 12:15" # Default: not set
 filter-size = "200MiB" # Default: not set
 filter-size-added = "1 MB..10MB" # Default: not set
-filter-fn = '|sn| {sn.host == "host1" || sn.description.contains("test")}' # Default: no filter function
 filter-jq = '.description | contains ("test")' # Default: no jq filter function
 # The retention options follow. All of these are not set by default.
 keep-tags = ["tag1", "tag2,tag3"] # Default: not set

--- a/src/error.rs
+++ b/src/error.rs
@@ -2,6 +2,7 @@
 
 #[cfg(feature = "rhai")]
 use rhai::EvalAltResult;
+#[cfg(feature = "rhai")]
 use thiserror::Error;
 
 /// Kinds of [`rhai`] errors

--- a/src/snapshots/rustic_rs__config__tests__default_config_passes.snap
+++ b/src/snapshots/rustic_rs__config__tests__default_config_passes.snap
@@ -65,7 +65,6 @@ RusticConfig {
         filter_before: None,
         filter_size: None,
         filter_size_added: None,
-        filter_fn: None,
         filter_jq: None,
     },
     backup: BackupCmd {
@@ -172,7 +171,6 @@ RusticConfig {
             filter_before: None,
             filter_size: None,
             filter_size_added: None,
-            filter_fn: None,
             filter_jq: None,
         },
         keep: KeepOptions {

--- a/src/snapshots/rustic_rs__config__tests__global_env_roundtrip_passes-3.snap
+++ b/src/snapshots/rustic_rs__config__tests__global_env_roundtrip_passes-3.snap
@@ -76,7 +76,6 @@ RusticConfig {
         filter_before: None,
         filter_size: None,
         filter_size_added: None,
-        filter_fn: None,
         filter_jq: None,
     },
     backup: BackupCmd {
@@ -183,7 +182,6 @@ RusticConfig {
             filter_before: None,
             filter_size: None,
             filter_size_added: None,
-            filter_fn: None,
             filter_jq: None,
         },
         keep: KeepOptions {


### PR DESCRIPTION
By default, rhai support for filtering snapshots (`--filter-fn`) is now not compiled in, but the compile feature still exists.

In future we might remove it completely as we now have `filter-jq` with similar possibilities.