### PR TITLE
feat: Add environment variable substitution in config files

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4312,6 +4312,7 @@ dependencies = [
  "serde_json",
  "serde_with",
  "simplelog",
+ "subst",
  "tar",
  "tempfile",
  "thiserror 2.0.16",
@@ -5116,6 +5117,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.106",
+]
+
+[[package]]
+name = "subst"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a9a86e5144f63c2d18334698269a8bfae6eece345c70b64821ea5b35054ec99"
+dependencies = [
+ "memchr",
+ "unicode-width 0.1.14",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -139,6 +139,7 @@ opentelemetry = { version = "0.30.0", default-features = false, features = ["met
 opentelemetry-otlp = { version = "0.30.0", features = ["metrics"], optional = true }
 opentelemetry_sdk = { version = "0.30.0", default-features = false, features = ["metrics"], optional = true }
 rhai = { version = "1", features = ["sync", "serde", "no_optimize", "no_module", "no_custom_syntax", "only_i64"], optional = true }
+subst = "0.3.8"
 
 [dev-dependencies]
 abscissa_core = { version = "0.8.2", default-features = false, features = ["testing"] }


### PR DESCRIPTION
closes #942 

This PR brings support for environment variable substitution in config files. This simply uses the [subst](https://github.com/fizyr/subst) crate to parse all environment variables before parsing the toml, this allows to define toml values in environment variables for more flexibility.