### PR TITLE
fix: Substitute environment variables in profiles only if explicitly opted-in

### DIFF
--- a/src/snapshots/rustic_rs__config__tests__default_config_display_passes.snap
+++ b/src/snapshots/rustic_rs__config__tests__default_config_display_passes.snap
@@ -3,6 +3,7 @@ source: src/config.rs
 expression: config
 ---
 [global]
+profile-substitute-env = false
 use-profiles = []
 dry-run = false
 check-index = false

--- a/src/snapshots/rustic_rs__config__tests__default_config_passes.snap
+++ b/src/snapshots/rustic_rs__config__tests__default_config_passes.snap
@@ -4,6 +4,7 @@ expression: config
 ---
 RusticConfig {
     global: GlobalOptions {
+        profile_substitute_env: false,
         use_profiles: [],
         group_by: None,
         dry_run: false,

--- a/src/snapshots/rustic_rs__config__tests__global_env_roundtrip_passes-2.snap
+++ b/src/snapshots/rustic_rs__config__tests__global_env_roundtrip_passes-2.snap
@@ -3,6 +3,7 @@ source: src/config.rs
 expression: deserialized
 ---
 [global]
+profile-substitute-env = false
 use-profiles = []
 dry-run = false
 check-index = false

--- a/src/snapshots/rustic_rs__config__tests__global_env_roundtrip_passes-3.snap
+++ b/src/snapshots/rustic_rs__config__tests__global_env_roundtrip_passes-3.snap
@@ -4,6 +4,7 @@ expression: deserialized
 ---
 RusticConfig {
     global: GlobalOptions {
+        profile_substitute_env: false,
         use_profiles: [],
         group_by: None,
         dry_run: false,

--- a/src/snapshots/rustic_rs__config__tests__global_env_roundtrip_passes.snap
+++ b/src/snapshots/rustic_rs__config__tests__global_env_roundtrip_passes.snap
@@ -3,6 +3,7 @@ source: src/config.rs
 expression: serialized
 ---
 [global]
+profile-substitute-env = false
 use-profiles = []
 dry-run = false
 check-index = false

--- a/tests/snapshots/show_config__show_config_passes.snap
+++ b/tests/snapshots/show_config__show_config_passes.snap
@@ -3,6 +3,7 @@ source: tests/show-config.rs
 expression: output
 ---
 [global]
+profile-substitute-env = false
 use-profiles = []
 dry-run = false
 check-index = false


### PR DESCRIPTION
Hi!

This PR fix the regression introduced in #1577 by adding an opt-in flag for environment variable substitution in profile files. Users can still use `$` in their file if they enable substitution by escaping them (`\$`).

This PR closes #1598 and #942 