### PR TITLE
Add root directory to sftp_hetzner_sbox.toml

### DIFF
--- a/config/services/sftp_hetzner_sbox.toml
+++ b/config/services/sftp_hetzner_sbox.toml
@@ -6,3 +6,4 @@ repository = "opendal:sftp"
 endpoint = "ssh://XXXXX.your-storagebox.de:23"
 user = "XXXXX"
 key = "/root/.ssh/id_XXXXX_ed25519"
+root = "/home/backup" # The storage box' root directory is "/home/".


### PR DESCRIPTION
Adds the `root` config option to the `sftp_hetzner_sbox.toml` sample.

The storage box' default directory is `/home/`, not `/` (even if the `pwd` command in sftp prints `/`). So when setting the `root` option you have to use `/home/subdir`.

This is a detail I've tripped over and spend an hour trying to resolve. I think it makes sense to add this to the sample in case somebody else runs into this issue.