### PR TITLE
fix: use filtered snapshots for repair command

### DIFF
--- a/src/commands/copy.rs
+++ b/src/commands/copy.rs
@@ -4,7 +4,7 @@ use crate::{
     Application, RUSTIC_APP, RusticConfig,
     commands::init::init_password,
     helpers::table_with_titles,
-    repository::{CliIndexedRepo, CliRepo, get_filtered_snapshots},
+    repository::{CliIndexedRepo, CliRepo, get_snapots_from_ids},
     status_err,
 };
 use abscissa_core::{Command, FrameworkError, Runnable, Shutdown, config::Override};
@@ -76,11 +76,8 @@ impl Runnable for CopyCmd {
 impl CopyCmd {
     fn inner_run(&self, repo: CliIndexedRepo) -> Result<()> {
         let config = RUSTIC_APP.config();
-        let mut snapshots = if self.ids.is_empty() {
-            get_filtered_snapshots(&repo)?
-        } else {
-            repo.get_snapshots_from_strs(&self.ids, |sn| config.snapshot_filter.matches(sn))?
-        };
+        let config = config;
+        let mut snapshots = get_snapots_from_ids(&repo, &self.ids)?;
         // sort for nicer output
         snapshots.sort_unstable();
 

--- a/src/commands/merge.rs
+++ b/src/commands/merge.rs
@@ -2,7 +2,7 @@
 
 use crate::{
     Application, RUSTIC_APP,
-    repository::{CliOpenRepo, get_filtered_snapshots},
+    repository::{CliOpenRepo, get_snapots_from_ids},
     status_err,
 };
 use abscissa_core::{Command, Runnable, Shutdown};
@@ -50,11 +50,7 @@ impl MergeCmd {
         let config = RUSTIC_APP.config();
         let repo = repo.to_indexed_ids()?;
 
-        let snapshots = if self.ids.is_empty() {
-            get_filtered_snapshots(&repo)?
-        } else {
-            repo.get_snapshots_from_strs(&self.ids, |sn| config.snapshot_filter.matches(sn))?
-        };
+        let snapshots = get_snapots_from_ids(&repo, &self.ids)?;
 
         // Handle dry-run mode
         if config.global.dry_run {

--- a/src/commands/repair.rs
+++ b/src/commands/repair.rs
@@ -2,7 +2,7 @@
 
 use crate::{
     Application, RUSTIC_APP,
-    repository::{CliIndexedRepo, CliOpenRepo},
+    repository::{CliIndexedRepo, CliOpenRepo, get_snapots_from_ids},
     status_err,
 };
 use abscissa_core::{Command, Runnable, Shutdown};
@@ -85,11 +85,7 @@ impl Runnable for SnapSubCmd {
 impl SnapSubCmd {
     fn inner_run(&self, repo: CliIndexedRepo) -> Result<()> {
         let config = RUSTIC_APP.config();
-        let snaps = if self.ids.is_empty() {
-            repo.get_all_snapshots()?
-        } else {
-            repo.get_snapshots_from_strs(&self.ids, |_| true)?
-        };
+        let snaps = get_snapots_from_ids(&repo, &self.ids)?;
         repo.repair_snapshots(&self.opts, snaps, config.global.dry_run)?;
         Ok(())
     }

--- a/src/commands/rewrite.rs
+++ b/src/commands/rewrite.rs
@@ -4,7 +4,7 @@ use std::path::PathBuf;
 
 use crate::{
     Application, RUSTIC_APP,
-    repository::{CliOpenRepo, get_filtered_snapshots},
+    repository::{CliOpenRepo, get_snapots_from_ids},
     status_err,
 };
 
@@ -110,12 +110,7 @@ impl Runnable for RewriteCmd {
 impl RewriteCmd {
     fn inner_run(&self, repo: CliOpenRepo) -> Result<()> {
         let config = RUSTIC_APP.config();
-
-        let snapshots = if self.ids.is_empty() {
-            get_filtered_snapshots(&repo)?
-        } else {
-            repo.get_snapshots_from_strs(&self.ids, |sn| config.snapshot_filter.matches(sn))?
-        };
+        let snapshots = get_snapots_from_ids(&repo, &self.ids)?;
 
         let delete = match (
             self.remove_delete,

--- a/src/repository.rs
+++ b/src/repository.rs
@@ -172,6 +172,21 @@ impl<P: Clone + ProgressBars> RusticRepo<P> {
     }
 }
 
+// get snapshots from ids allowing `latest`, if empty use all snapshots respecting the filters.
+pub fn get_snapots_from_ids<P: ProgressBars, S: Open>(
+    repo: &Repository<P, S>,
+    ids: &[String],
+) -> Result<Vec<SnapshotFile>> {
+    let config = RUSTIC_APP.config();
+    let snapshots = if ids.is_empty() {
+        get_filtered_snapshots(repo)?
+    } else {
+        repo.get_snapshots_from_strs(ids, |sn| config.snapshot_filter.matches(sn))?
+    };
+    Ok(snapshots)
+}
+
+// get all snapshots respecting the filters
 pub fn get_filtered_snapshots<P: ProgressBars, S: Open>(
     repo: &Repository<P, S>,
 ) -> Result<Vec<SnapshotFile>> {


### PR DESCRIPTION
`repair` did not use the `filter-*` options to filter snapshots. This is now fixed.