### PR TITLE
feat: Update copy and add --force

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2006,12 +2006,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "humantime"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "135b12329e5e3ce057a9f972339ea52bc954fe1e9358ef27f95e89716fbc5424"
-
-[[package]]
 name = "hyper"
 version = "0.14.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3662,7 +3656,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools 0.13.0",
  "proc-macro2",
  "quote",
  "syn 2.0.109",
@@ -3675,7 +3669,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9120690fafc389a67ba3803df527d0ec9cbbc9cc45e4cc20b332996dfb672425"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools 0.13.0",
  "proc-macro2",
  "quote",
  "syn 2.0.109",
@@ -4381,7 +4375,7 @@ dependencies = [
 [[package]]
 name = "rustic_backend"
 version = "0.5.4"
-source = "git+https://github.com/rustic-rs/rustic_core#a6f458932e4f13316dfc2daad9f4d2f15c239fb7"
+source = "git+https://github.com/rustic-rs/rustic_core#54463a9a2c785494d97efb10ea112c4e4aed16b1"
 dependencies = [
  "aho-corasick",
  "backon",
@@ -4392,8 +4386,8 @@ dependencies = [
  "derive_setters",
  "displaydoc",
  "hex",
- "humantime",
  "itertools 0.14.0",
+ "jiff",
  "log",
  "opendal",
  "rand 0.9.2",
@@ -4420,7 +4414,7 @@ checksum = "fbcebf2228827bc4b61cb54dfd84cf43aacf06ca2dfe4c014b136a0e32b876e2"
 [[package]]
 name = "rustic_core"
 version = "0.9.0"
-source = "git+https://github.com/rustic-rs/rustic_core#a6f458932e4f13316dfc2daad9f4d2f15c239fb7"
+source = "git+https://github.com/rustic-rs/rustic_core#54463a9a2c785494d97efb10ea112c4e4aed16b1"
 dependencies = [
  "aes256ctr_poly1305aes",
  "binrw",
@@ -4474,7 +4468,7 @@ dependencies = [
 [[package]]
 name = "rustic_testing"
 version = "0.3.4"
-source = "git+https://github.com/rustic-rs/rustic_core#a6f458932e4f13316dfc2daad9f4d2f15c239fb7"
+source = "git+https://github.com/rustic-rs/rustic_core#54463a9a2c785494d97efb10ea112c4e4aed16b1"
 dependencies = [
  "aho-corasick",
  "anyhow",

--- a/src/snapshots/rustic_rs__config__tests__default_config_passes.snap
+++ b/src/snapshots/rustic_rs__config__tests__default_config_passes.snap
@@ -168,8 +168,9 @@ RusticConfig {
     },
     copy: CopyCmd {
         ids: [],
-        init: false,
         targets: [],
+        init: false,
+        force: false,
         key_opts: KeyOptions {
             hostname: None,
             username: None,

--- a/src/snapshots/rustic_rs__config__tests__global_env_roundtrip_passes-3.snap
+++ b/src/snapshots/rustic_rs__config__tests__global_env_roundtrip_passes-3.snap
@@ -179,8 +179,9 @@ RusticConfig {
     },
     copy: CopyCmd {
         ids: [],
-        init: false,
         targets: [],
+        init: false,
+        force: false,
         key_opts: KeyOptions {
             hostname: None,
             username: None,


### PR DESCRIPTION
Updates the `copy` command to use the enhancements of https://github.com/rustic-rs/rustic_core/pull/464.
Also adds the new option `--force` which copies snapshots even if they seem to already exist on the target.