### PR TITLE
feat: Allow to use masterkey instead of password/keyfile

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2100,7 +2100,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.1",
+ "socket2 0.5.10",
  "tokio",
  "tower-service",
  "tracing",
@@ -3656,7 +3656,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn 2.0.109",
@@ -3669,7 +3669,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9120690fafc389a67ba3803df527d0ec9cbbc9cc45e4cc20b332996dfb672425"
 dependencies = [
  "anyhow",
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn 2.0.109",
@@ -3694,6 +3694,12 @@ checksum = "3e36c2f31e0a47f9280fb347ef5e461ffcd2c52dd520d8e216b52f93b0b0d7d6"
 dependencies = [
  "thiserror 1.0.69",
 ]
+
+[[package]]
+name = "qrcode"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d68782463e408eb1e668cf6152704bd856c78c5b6417adaee3203d8f4c1fc9ec"
 
 [[package]]
 name = "quanta"
@@ -3786,7 +3792,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls 0.23.35",
- "socket2 0.6.1",
+ "socket2 0.5.10",
  "thiserror 2.0.17",
  "tokio",
  "tracing",
@@ -3823,7 +3829,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.1",
+ "socket2 0.5.10",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -4346,6 +4352,7 @@ dependencies = [
  "predicates",
  "pretty_assertions",
  "prometheus",
+ "qrcode",
  "quickcheck",
  "quickcheck_macros",
  "ratatui",
@@ -4375,7 +4382,7 @@ dependencies = [
 [[package]]
 name = "rustic_backend"
 version = "0.5.4"
-source = "git+https://github.com/rustic-rs/rustic_core#54463a9a2c785494d97efb10ea112c4e4aed16b1"
+source = "git+https://github.com/rustic-rs/rustic_core#fd592d99adfa67eba0bec0073ceea9ff9b2a85c0"
 dependencies = [
  "aho-corasick",
  "backon",
@@ -4414,7 +4421,7 @@ checksum = "fbcebf2228827bc4b61cb54dfd84cf43aacf06ca2dfe4c014b136a0e32b876e2"
 [[package]]
 name = "rustic_core"
 version = "0.9.0"
-source = "git+https://github.com/rustic-rs/rustic_core#54463a9a2c785494d97efb10ea112c4e4aed16b1"
+source = "git+https://github.com/rustic-rs/rustic_core#fd592d99adfa67eba0bec0073ceea9ff9b2a85c0"
 dependencies = [
  "aes256ctr_poly1305aes",
  "binrw",
@@ -4468,7 +4475,7 @@ dependencies = [
 [[package]]
 name = "rustic_testing"
 version = "0.3.4"
-source = "git+https://github.com/rustic-rs/rustic_core#54463a9a2c785494d97efb10ea112c4e4aed16b1"
+source = "git+https://github.com/rustic-rs/rustic_core#fd592d99adfa67eba0bec0073ceea9ff9b2a85c0"
 dependencies = [
  "aho-corasick",
  "anyhow",
@@ -6124,7 +6131,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -124,6 +124,7 @@ itertools = "0.14"
 jiff = "0.2.16"
 open = "5.3.2"
 prometheus = { version = "0.14.0", optional = true }
+qrcode = { version = "0.14.1", default-features = false, features = ["svg"] }
 reqwest = { version = "0.12.24", default-features = false, features = ["rustls-tls-native-roots", "blocking"] }
 self_update = { version = "=0.39.0", default-features = false, optional = true, features = ["rustls", "archive-tar", "compression-flate2"] } # FIXME: Downgraded to 0.39.0 due to https://github.com/jaemk/self_update/issues/136
 tar = "0.4.44"

--- a/config/README.md
+++ b/config/README.md
@@ -129,19 +129,22 @@ All given labels are included with the metrics, if it is configured.
 
 ### Repository Options `[repository]`
 
-| Attribute            | Description                                                | Default Value            | Example Value          | Environment Variable    | CLI Option             |
-| -------------------- | ---------------------------------------------------------- | ------------------------ | ---------------------- | ----------------------- | ---------------------- |
-| cache-dir            | Path to the cache directory.                               | ~/.cache/rustic/$REPO_ID | ~/.cache/my_own_cache/ | RUSTIC_CACHE_DIR        | --cache-dir            |
-| no-cache             | If true, disables caching.                                 | false                    |                        | RUSTIC_NO_CACHE         | --no-cache             |
-| repository           | The path to the repository. Required.                      | Not set                  | "/tmp/rustic"          | RUSTIC_REPOSITORY       | --repositoy, -r        |
-| repo-hot             | The path to the hot repository.                            | Not set                  |                        | RUSTIC_REPO_HOT         | --repo-hot             |
-| password             | The password for the repository.                           | Not set                  | "mySecretPassword"     | RUSTIC_PASSWORD         | --password             |
-| password-file        | Path to a file containing the password for the repository. | Not set                  |                        | RUSTIC_PASSWORD_FILE    | --password-file, -p    |
-| password-command     | Command to retrieve the password for the repository.       | Not set                  |                        | RUSTIC_PASSWORD_COMMAND | --password-command     |
-| warm-up              | If true, warms up the repository by file access.           | false                    |                        |                         | ---warm-up             |
-| warm-up-command      | Command to warm up the repository.                         | Not set                  |                        |                         | --warm-up-command      |
-| warm-up-wait         | The wait time for warming up the repository.               | Not set                  |                        |                         | --warm-up-wait         |
-| warm-up-wait-command | Command to run to wait for packs to be warmed-up.          | Not set                  |                        |                         | --warm-up-wait-command |
+| Attribute            | Description                                                 | Default Value            | Example Value                          | Environment Variable    | CLI Option             |
+| -------------------- | ----------------------------------------------------------- | ------------------------ | -------------------------------------- | ----------------------- | ---------------------- |
+| repository           | The path to the repository. Required.                       | Not set                  | "/tmp/rustic"                          | RUSTIC_REPOSITORY       | --repositoy, -r        |
+| repo-hot             | The path to the hot repository.                             | Not set                  |                                        | RUSTIC_REPO_HOT         | --repo-hot             |
+| cache-dir            | Path to the cache directory.                                | ~/.cache/rustic/$REPO_ID | ~/.cache/my_own_cache/                 | RUSTIC_CACHE_DIR        | --cache-dir            |
+| no-cache             | If true, disables caching.                                  | false                    |                                        | RUSTIC_NO_CACHE         | --no-cache             |
+| warm-up              | If true, warms up the repository by file access.            | false                    |                                        |                         | ---warm-up             |
+| warm-up-command      | Command to warm up the repository.                          | Not set                  |                                        |                         | --warm-up-command      |
+| warm-up-wait         | The wait time for warming up the repository.                | Not set                  |                                        |                         | --warm-up-wait         |
+| warm-up-wait-command | Command to run to wait for packs to be warmed-up.           | Not set                  |                                        |                         | --warm-up-wait-command |
+| key                  | The masterkey for the repository.                           | Not set                  | (create one using `rustic key create`) | RUSTIC_KEY              | --key                  |
+| key-file             | Path to a file containing the masterkey for the repository. | Not set                  |                                        | RUSTIC_KEY_FILE         | --key-file             |
+| key-command          | Command to retrieve the masterkey for the repository.       | Not set                  |                                        | RUSTIC_KEY_COMMAND      | --key-command          |
+| password             | The password for the repository.                            | Not set                  | "mySecretPassword"                     | RUSTIC_PASSWORD         | --password             |
+| password-file        | Path to a file containing the password for the repository.  | Not set                  |                                        | RUSTIC_PASSWORD_FILE    | --password-file, -p    |
+| password-command     | Command to retrieve the password for the repository.        | Not set                  |                                        | RUSTIC_PASSWORD_COMMAND | --password-command     |
 
 ### Repository Options (Additional) `[repository.options]`
 

--- a/config/full.toml
+++ b/config/full.toml
@@ -51,10 +51,6 @@ label-a = "xxx"
 [repository]
 repository = "/repo/rustic" # Must be set
 repo-hot = "/my/hot/repo" # Default: not set
-# one of the three password options must be set
-password = "mySecretPassword"
-password-file = "/my/password.txt"
-password-command = "my_command.sh"
 no-cache = false
 cache-dir = "/my/rustic/cachedir" # Default: Applications default cache dir, e.g. ~/.cache/rustic
 # use either warm-up (warm-up by file access) or warm-up-command to specify warming up
@@ -62,6 +58,13 @@ warm-up = false
 warm-up-command = "warmup.sh %id" # Default: not set
 warm-up-wait = "10min" # Default: not set
 warm-up-wait-command = "warmup_wait.sh" # Default: not set
+# one of the following credential options should be set; if not you will be always asked for a password
+key = '{"mac":{"k":"TEQN3py56U36eH4hTTgaUA==","r":"+/Cc+P7jN42a7bZVZYyAcw=="},"encrypt":"LKyGDH7dfX24a9u+3q8DgvuFVDfI3fNrzeo6l4r8u64="}'
+key-file = "/my/key.txt"
+key-command = "my_key_command.sh"
+password = "mySecretPassword"
+password-file = "/my/password.txt"
+password-command = "my_command.sh"
 
 # Additional repository options - depending on backend. These can be only set in the config file or using env variables.
 # For env variables use upper snake case and prefix with "RUSTIC_REPO_OPT_", e.g. `use-passwort = "true"` becomes

--- a/src/commands/backup.rs
+++ b/src/commands/backup.rs
@@ -222,9 +222,14 @@ impl BackupCmd {
                     repo.name
                 );
             }
-            init(repo.0, &self.key_opts, &self.config_opts)?
+            init(
+                repo.0,
+                &config.repository.credential_opts,
+                &self.key_opts,
+                &self.config_opts,
+            )?
         } else {
-            repo.open()?
+            repo.open(&config.repository.credential_opts)?
         }
         .to_indexed_ids()?;
 

--- a/src/commands/cat.rs
+++ b/src/commands/cat.rs
@@ -32,6 +32,8 @@ enum CatSubCmd {
     Snapshot(IdOpt),
     /// Display a tree within a snapshot
     Tree(TreeOpts),
+    /// Display the masterkey
+    Masterkey,
 }
 
 #[derive(Default, clap::Parser, Debug)]
@@ -78,6 +80,9 @@ impl CatCmd {
             CatSubCmd::Tree(opt) => config.repository.run_indexed(|repo| {
                 Ok(repo.cat_tree(&opt.snap, |sn| config.snapshot_filter.matches(sn))?)
             })?,
+            CatSubCmd::Masterkey => config
+                .repository
+                .run_open(|repo| Ok(serde_json::to_vec(&repo.key())?.into()))?,
         };
         println!("{}", String::from_utf8(data.to_vec())?);
 

--- a/src/commands/repoinfo.rs
+++ b/src/commands/repoinfo.rs
@@ -16,7 +16,7 @@ use rustic_core::{IndexInfos, RepoFileInfo, RepoFileInfos};
 /// `repoinfo` subcommand
 #[derive(clap::Parser, Command, Debug)]
 pub(crate) struct RepoInfoCmd {
-    /// Only scan repository files (doesn't need repository password)
+    /// Only scan repository files (doesn't need credentials)
     #[clap(long)]
     only_files: bool,
 
@@ -54,12 +54,17 @@ struct Infos {
 
 impl RepoInfoCmd {
     fn inner_run(&self, repo: CliRepo) -> Result<()> {
+        let config = RUSTIC_APP.config();
         let infos = Infos {
             files: (!self.only_index)
                 .then(|| -> Result<_> { Ok(repo.infos_files()?) })
                 .transpose()?,
             index: (!self.only_files)
-                .then(|| -> Result<_> { Ok(repo.open()?.infos_index()?) })
+                .then(|| -> Result<_> {
+                    Ok(repo
+                        .open(&config.repository.credential_opts)?
+                        .infos_index()?)
+                })
                 .transpose()?,
         };
 

--- a/src/snapshots/rustic_rs__config__tests__default_config_passes.snap
+++ b/src/snapshots/rustic_rs__config__tests__default_config_passes.snap
@@ -46,15 +46,20 @@ RusticConfig {
             options_cold: {},
         },
         repo: RepositoryOptions {
-            password: None,
-            password_file: None,
-            password_command: None,
             no_cache: false,
             cache_dir: None,
             warm_up: false,
             warm_up_command: None,
             warm_up_wait_command: None,
             warm_up_wait: None,
+        },
+        credential_opts: CredentialOptions {
+            key: None,
+            key_file: None,
+            key_command: None,
+            password: None,
+            password_file: None,
+            password_command: None,
         },
         hooks: Hooks {
             run_before: [],

--- a/src/snapshots/rustic_rs__config__tests__global_env_roundtrip_passes-3.snap
+++ b/src/snapshots/rustic_rs__config__tests__global_env_roundtrip_passes-3.snap
@@ -57,15 +57,20 @@ RusticConfig {
             options_cold: {},
         },
         repo: RepositoryOptions {
-            password: None,
-            password_file: None,
-            password_command: None,
             no_cache: false,
             cache_dir: None,
             warm_up: false,
             warm_up_command: None,
             warm_up_wait_command: None,
             warm_up_wait: None,
+        },
+        credential_opts: CredentialOptions {
+            key: None,
+            key_file: None,
+            key_command: None,
+            password: None,
+            password_file: None,
+            password_command: None,
         },
         hooks: Hooks {
             run_before: [],


### PR DESCRIPTION
Adds the ability to use the masterkey directly instead of deriving it via a password from a keyfile. This includes the following enhancements:

- new repository options `key`, `key-file`, `key-command`
- new command `cat masterkey`
- new commands `key export` (also allows to generate a QR code of the masterkey) and `key create` (allows to create a new masterkey to be used to init a repository)
- adaption of `key` commands when using the masterkey, e.g. allow to remove all keys.