### PR TITLE
feat: Add option `--forget-time` to forget

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1253,7 +1253,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1426,7 +1426,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2515,7 +2515,7 @@ dependencies = [
  "portable-atomic",
  "portable-atomic-util",
  "serde_core",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2880,7 +2880,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2911,9 +2911,9 @@ dependencies = [
 
 [[package]]
 name = "num-conv"
-version = "0.1.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+checksum = "cf97ec579c3c42f953ef76dbf8d55ac91fb219dde70e49aa4a6b7d74e9919050"
 
 [[package]]
 name = "num-derive"
@@ -3831,7 +3831,7 @@ dependencies = [
  "once_cell",
  "socket2 0.6.1",
  "tracing",
- "windows-sys 0.60.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4382,7 +4382,7 @@ dependencies = [
 [[package]]
 name = "rustic_backend"
 version = "0.5.4"
-source = "git+https://github.com/rustic-rs/rustic_core#60f8ea15403c6e02ebb1ac9df601cb3ed5192a2f"
+source = "git+https://github.com/rustic-rs/rustic_core#9c6359e0aad52cd2c265605cdbc6fcbb0c3e90cb"
 dependencies = [
  "aho-corasick",
  "backon",
@@ -4421,7 +4421,7 @@ checksum = "fbcebf2228827bc4b61cb54dfd84cf43aacf06ca2dfe4c014b136a0e32b876e2"
 [[package]]
 name = "rustic_core"
 version = "0.9.0"
-source = "git+https://github.com/rustic-rs/rustic_core#60f8ea15403c6e02ebb1ac9df601cb3ed5192a2f"
+source = "git+https://github.com/rustic-rs/rustic_core#9c6359e0aad52cd2c265605cdbc6fcbb0c3e90cb"
 dependencies = [
  "aes256ctr_poly1305aes",
  "binrw",
@@ -4475,7 +4475,7 @@ dependencies = [
 [[package]]
 name = "rustic_testing"
 version = "0.3.4"
-source = "git+https://github.com/rustic-rs/rustic_core#60f8ea15403c6e02ebb1ac9df601cb3ed5192a2f"
+source = "git+https://github.com/rustic-rs/rustic_core#9c6359e0aad52cd2c265605cdbc6fcbb0c3e90cb"
 dependencies = [
  "aho-corasick",
  "anyhow",
@@ -4508,7 +4508,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.11.0",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5273,7 +5273,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix 1.1.2",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5380,30 +5380,30 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.44"
+version = "0.3.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91e7d9e3bb61134e77bde20dd4825b97c010155709965fedf0f49bb138e52a9d"
+checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
 dependencies = [
  "deranged",
  "itoa",
  "num-conv",
  "powerfmt",
- "serde",
+ "serde_core",
  "time-core",
  "time-macros",
 ]
 
 [[package]]
 name = "time-core"
-version = "0.1.6"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40868e7c1d2f0b8d73e4a8c7f0ff63af4f6d19be117e90bd73eb1d62cf831c6b"
+checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
 
 [[package]]
 name = "time-macros"
-version = "0.2.24"
+version = "0.2.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30cfb0125f12d9c277f35663a0a33f8c30190f4e4574868a330595412d34ebf3"
+checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
 dependencies = [
  "num-conv",
  "time-core",
@@ -6131,7 +6131,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/src/commands/check.rs
+++ b/src/commands/check.rs
@@ -8,7 +8,7 @@ use crate::{
 
 use abscissa_core::{Command, Runnable, Shutdown};
 use anyhow::Result;
-use rustic_core::CheckOptions;
+use rustic_core::{CheckOptions, repofile::SnapshotFile};
 
 /// `check` subcommand
 #[derive(clap::Parser, Command, Debug)]
@@ -39,12 +39,8 @@ impl Runnable for CheckCmd {
 
 impl CheckCmd {
     fn inner_run(&self, repo: OpenRepo) -> Result<()> {
-        let groups = get_global_grouped_snapshots(&repo, &self.ids)?;
-        let trees = groups
-            .into_iter()
-            .flat_map(|(_, snaps)| snaps)
-            .map(|snap| snap.tree)
-            .collect();
+        let snaps: Vec<SnapshotFile> = get_global_grouped_snapshots(&repo, &self.ids)?.into();
+        let trees = snaps.into_iter().map(|snap| snap.tree).collect();
         repo.check_with_trees(self.opts, trees)?.is_ok()?;
         Ok(())
     }

--- a/src/commands/tui/snapshots.rs
+++ b/src/commands/tui/snapshots.rs
@@ -810,8 +810,11 @@ impl<'a> Snapshots<'a> {
     pub fn reread(&mut self) -> Result<()> {
         let snapshots = mem::take(&mut self.snapshots);
         self.snapshots = self.repo.update_all_snapshots(snapshots)?;
-        self.snapshots
-            .sort_unstable_by(|sn1, sn2| sn1.cmp_group(self.group_by, sn2).then(sn1.cmp(sn2)));
+        self.snapshots.sort_unstable_by(|sn1, sn2| {
+            SnapshotGroup::from_snapshot(sn1, self.group_by)
+                .cmp(&SnapshotGroup::from_snapshot(sn1, self.group_by))
+                .then(sn1.time.cmp(&sn2.time))
+        });
         self.snaps_status = vec![SnapStatus::default(); self.snapshots.len()];
         self.original_snapshots.clone_from(&self.snapshots);
         self.table.widget.select(None);


### PR DESCRIPTION
Applies the refactoring of grouping from rustic_core. This should have no effect for users.
As side-effect the option `--forget-time` has been added allowing to choose another time than "now". (This can be useful for testing retention policy in combination with `--dry-run`)