### PR TITLE
fix: Add keep-{within-}hourly to config/full.toml

### DIFF
--- a/config/full.toml
+++ b/config/full.toml
@@ -214,6 +214,7 @@ keep-ids = [
 ] # Keep all snapshots whose ID starts with any of these strings, default: not set
 keep-last = 0
 keep-minutely = 10
+keep-hourly = 5
 keep-daily = 3
 keep-weekly = 0
 keep-monthly = 0
@@ -222,6 +223,7 @@ keep-half-yearly = 0
 keep-yearly = 10
 keep-within = "0s"
 keep-within-minutely = "2 hours"
+keep-within-hourly = "3 days"
 keep-within-daily = "0 seconds"
 keep-within-weekly = "2 months"
 keep-within-monthly = "1 year"


### PR DESCRIPTION
These seem to be missing from the full config example, but do exist in the code and some other examples.
I can't test this right now, but I think it should be correct.