### PR TITLE
feat(commands): Add version command

### DIFF
--- a/src/commands.rs
+++ b/src/commands.rs
@@ -29,9 +29,9 @@ pub(crate) mod snapshots;
 pub(crate) mod tag;
 #[cfg(feature = "tui")]
 pub(crate) mod tui;
+pub(crate) mod version;
 #[cfg(feature = "webdav")]
 pub(crate) mod webdav;
-pub(crate) mod version;
 
 use std::fmt::Debug;
 use std::path::PathBuf;

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -270,7 +270,7 @@ impl Configurable<RusticConfig> for EntryPoint {
         }
 
         // start logger also check if version command was supplied by the user
-        // if so skip logging for verison
+        // if so skip logging for version
         if !matches!(self.commands, RusticCmd::Version(_)) {
             config
                 .global

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -31,6 +31,7 @@ pub(crate) mod tag;
 pub(crate) mod tui;
 #[cfg(feature = "webdav")]
 pub(crate) mod webdav;
+pub(crate) mod version;
 
 use std::fmt::Debug;
 use std::path::PathBuf;
@@ -155,6 +156,9 @@ enum RusticCmd {
     /// Start a webdav server which allows to access the repository
     #[cfg(feature = "webdav")]
     Webdav(Box<WebDavCmd>),
+
+    /// Print version information
+    Version(Box<version::VersionCmd>),
 }
 
 fn styles() -> Styles {
@@ -265,21 +269,24 @@ impl Configurable<RusticConfig> for EntryPoint {
             }
         }
 
-        // start logger
-        config
-            .global
-            .logging_options
-            .start_logger(config.global.dry_run)
-            .map_err(|e| FrameworkErrorKind::ConfigError.context(e))?;
+        // start logger also check if version command was supplied by the user
+        // if so skip logging for verison
+        if !matches!(self.commands, RusticCmd::Version(_)) {
+            config
+                .global
+                .logging_options
+                .start_logger(config.global.dry_run)
+                .map_err(|e| FrameworkErrorKind::ConfigError.context(e))?;
 
-        if config.global.logging_options.log_file.is_some() {
-            info!("rustic {}", version());
-            info!("command: {:?}", std::env::args_os().collect::<Vec<_>>());
-        }
+            if config.global.logging_options.log_file.is_some() {
+                info!("rustic {}", version());
+                info!("command: {:?}", std::env::args_os().collect::<Vec<_>>());
+            }
 
-        // display logs from merging
-        for (level, merge_log) in merge_logs {
-            log!(level, "{merge_log}");
+            // display logs from merging
+            for (level, merge_log) in merge_logs {
+                log!(level, "{merge_log}");
+            }
         }
 
         match &self.commands {

--- a/src/commands/version.rs
+++ b/src/commands/version.rs
@@ -1,0 +1,14 @@
+use abscissa_core::{Command, Runnable};
+use clap::Parser;
+
+// `version` command
+#[derive(Command, Debug, Parser)]
+pub struct VersionCmd {}
+
+impl Runnable for VersionCmd {
+    // Print the version and exit
+    fn run(&self) {
+        // Use the existing version helper from the parent module
+        println!("rustic {}", crate::commands::version());
+    }
+}


### PR DESCRIPTION
This PR introduces a dedicated version command to the CLI. While the version information is often available via `--version`, a standalone command allows for more detailed output, including build metadata, which is essential for debugging issues related to specific repository features or experimental locks.


This PR also adds consistency with common Rust tool patterns and also `restic` (e.g., cargo version, restic version).


Usage
----
```bash
rustic version
```

Output:
```
rustic 0.11.2
```

NOTE: I have disabled logging when using the version command.