### PR TITLE
docs: Add link/note to opendal's backend documentation

### DIFF
--- a/config/README.md
+++ b/config/README.md
@@ -156,11 +156,8 @@ e.g. `use-password = "true"` becomes `RUSTIC_REPO_OPT_USE_PASSWORD=true`.
 
 Moreover, for opendal parameters (which need to be in lower snake case), you can
 use upper snake case and prefix with "OPENDAL_" as env variable, e.g.
-`application_key = "my-key"` becomes `OPENDAL_APPLICATION_KEY=my-key`. A list
-of available parameters for a backend can be found in [opendal's documentation](https://opendal.apache.org/docs/rust/opendal/services/index.html)
-under the respective backend's struct.
-
-See the respective backends entry for a list of it's options.
+`application_key = "my-key"` becomes `OPENDAL_APPLICATION_KEY=my-key`. 
+A list of available parameters for a backend can be found in [opendal's documentation](https://opendal.apache.org/docs/rust/opendal/services/index.html) under the respective backend's struct.
 
 | Attribute           | Description                                                        | Default Value | Example Value                  |
 | ------------------- | ------------------------------------------------------------------ | ------------- | ------------------------------ |

--- a/config/README.md
+++ b/config/README.md
@@ -156,7 +156,11 @@ e.g. `use-password = "true"` becomes `RUSTIC_REPO_OPT_USE_PASSWORD=true`.
 
 Moreover, for opendal parameters (which need to be in lower snake case), you can
 use upper snake case and prefix with "OPENDAL_" as env variable, e.g.
-`application_key = "my-key"` becomes `OPENDAL_APPLICATION_KEY=my-key`.
+`application_key = "my-key"` becomes `OPENDAL_APPLICATION_KEY=my-key`. A list
+of available parameters for a backend can be found in [opendal's documentation](https://opendal.apache.org/docs/rust/opendal/services/index.html)
+under the respective backend's struct.
+
+See the respective backends entry for a list of it's options.
 
 | Attribute           | Description                                                        | Default Value | Example Value                  |
 | ------------------- | ------------------------------------------------------------------ | ------------- | ------------------------------ |

--- a/config/README.md
+++ b/config/README.md
@@ -156,8 +156,10 @@ e.g. `use-password = "true"` becomes `RUSTIC_REPO_OPT_USE_PASSWORD=true`.
 
 Moreover, for opendal parameters (which need to be in lower snake case), you can
 use upper snake case and prefix with "OPENDAL_" as env variable, e.g.
-`application_key = "my-key"` becomes `OPENDAL_APPLICATION_KEY=my-key`. 
-A list of available parameters for a backend can be found in [opendal's documentation](https://opendal.apache.org/docs/rust/opendal/services/index.html) under the respective backend's struct.
+`application_key = "my-key"` becomes `OPENDAL_APPLICATION_KEY=my-key`. A list of
+available parameters for a backend can be found in
+[opendal's documentation](https://opendal.apache.org/docs/rust/opendal/services/index.html)
+under the respective backend's struct.
 
 | Attribute           | Description                                                        | Default Value | Example Value                  |
 | ------------------- | ------------------------------------------------------------------ | ------------- | ------------------------------ |


### PR DESCRIPTION
In the current documentation I could not find any information on, or link to, what options are available for which backend (although that might just be my oversight). This adds the best link I could find, and hopefully makes future searches a bit faster :)