### PR TITLE
docs: config/README.md: mention string requirement for [repository.options]

### DIFF
--- a/config/README.md
+++ b/config/README.md
@@ -158,6 +158,8 @@ Moreover, for opendal parameters (which need to be in lower snake case), you can
 use upper snake case and prefix with "OPENDAL_" as env variable, e.g.
 `application_key = "my-key"` becomes `OPENDAL_APPLICATION_KEY=my-key`.
 
+Note that all values under this table must be strings, regardless of their logical type. For example `use-password = true` needs to be `use-password = "true"`.
+
 | Attribute           | Description                                                        | Default Value | Example Value                  |
 | ------------------- | ------------------------------------------------------------------ | ------------- | ------------------------------ |
 | post-create-command | Command to execute after creating a snapshot in the local backend. | Not set       | "par2create -qq -n1 -r5 %file" |

--- a/config/README.md
+++ b/config/README.md
@@ -158,7 +158,9 @@ Moreover, for opendal parameters (which need to be in lower snake case), you can
 use upper snake case and prefix with "OPENDAL_" as env variable, e.g.
 `application_key = "my-key"` becomes `OPENDAL_APPLICATION_KEY=my-key`.
 
-Note that all values under this table must be strings, regardless of their logical type. For example `use-password = true` needs to be `use-password = "true"`.
+Note that all values under this table must be strings, regardless of their
+logical type. For example `use-password = true` needs to be
+`use-password = "true"`.
 
 | Attribute           | Description                                                        | Default Value | Example Value                  |
 | ------------------- | ------------------------------------------------------------------ | ------------- | ------------------------------ |


### PR DESCRIPTION
I'm not sure why this is the case, but it seems like non-string keys are not allowed, and produce a somewhat cryptic error message:
```
error: rustic-rs fatal error: parse error: TOML parse error at line 9, column 1
  |
9 | [repository]
  | ^^^^^^^^^^^^
invalid type: boolean `true`, expected a string
```.

This patch mentions this requirement in the readme :)