### PR TITLE
fix(scripts): portable bash shebang and prevented array expansions

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,2 +1,2 @@
-#!/bin/bash
-PROJECT_VERSION=$(git describe --tags) cargo build -r $@
+#!/usr/bin/env bash
+PROJECT_VERSION=$(git describe --tags) cargo build -r "$@"

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,2 +1,2 @@
-#!/bin/bash
-PROJECT_VERSION=$(git describe --tags) cargo build -r $@
+#!/usr/bin/env bash
+PROJECT_VERSION=$(git describe --tags) cargo build -r "$@"


### PR DESCRIPTION
- Replaced `#!/bin/bash` to `#!/usr/bin/env bash` to improve portability on different operating systems.
- Wrapped $@ with quotes to prevent array expansions.