### PR TITLE
fix: add required scheme to sftp endpoint

### DIFF
--- a/config/services/sftp.toml
+++ b/config/services/sftp.toml
@@ -9,5 +9,5 @@ password = "mypassword"
 
 [repository.options]
 user = "myuser"
-endpoint = "host:port"
+endpoint = "ssh://host:port"
 root = "path/to/repo"


### PR DESCRIPTION
When using the "host:port" syntax to configure an opendal sftp endpoint, a scheme (i.e. ssh://) is required.

See also https://opendal.apache.org/docs/rust/opendal/services/struct.Sftp.html#configuration