### PR TITLE
fix: Throttle configuration example

### DIFF
--- a/config/full.toml
+++ b/config/full.toml
@@ -79,7 +79,7 @@ rclone-command = "rclone serve restic --addr localhost:0" # Only rclone; Default
 use-password = "true" # Only rclone
 rest-url = "http://localhost:8000" # Only rclone; Default: determine REST URL from rclone output
 connections = "20" # Only opendal backends; Default: Not set
-throttle = "10kB,10MB" # limit and burst per second; only opendal backends; Default: Not set
+throttle = "10kB,250MB" # limit and burst per second; only opendal backends; burst size *must* be greater than repository pack size; Default: Not set
 # Note that opendal backends use several service-dependent options which may be specified here, see
 # https://opendal.apache.org/docs/rust/opendal/services/index.html
 


### PR DESCRIPTION
Adjusted the example throttle config.
Opendal will refuse to push packets greater than burst size, so it must at least be as large as repository pack size.