### PR TITLE
feat: Add ls option to backup command

### DIFF
--- a/src/commands/backup.rs
+++ b/src/commands/backup.rs
@@ -5,6 +5,7 @@ use std::fmt::Display;
 use std::path::PathBuf;
 use std::{collections::BTreeMap, env};
 
+use crate::commands::ls::LsCmd;
 use crate::repository::IndexedIdsRepo;
 use crate::{
     Application, RUSTIC_APP,
@@ -22,7 +23,7 @@ use comfy_table::Cell;
 use conflate::{Merge, MergeFrom};
 use log::{debug, error, info, warn};
 use rustic_backend::OpenDALBackend;
-use rustic_core::{ChildStdoutSource, Excludes, LocalSource, StdinSource, StringList};
+use rustic_core::{ChildStdoutSource, Excludes, LocalSource, ReadSource, StdinSource, StringList};
 use serde::{Deserialize, Serialize};
 use serde_with::serde_as;
 
@@ -55,6 +56,12 @@ pub struct BackupCmd {
     #[merge(skip)]
     #[serde(skip)]
     cli_name: Vec<String>,
+
+    /// Don't run the backup, but only list files which would be backup'ed.
+    #[clap(long)]
+    #[merge(skip)]
+    #[serde(skip)]
+    ls: bool,
 
     #[clap(skip)]
     #[merge(skip)]
@@ -336,10 +343,11 @@ impl BackupCmd {
     fn backup_source(
         source: &PathList,
         options: BTreeMap<String, String>,
+        ls: bool,
         backup_opts: BackupOptions,
-        snap: SnapshotFile,
+        snap: &mut SnapshotFile,
         repo: &IndexedIdsRepo,
-    ) -> Result<SnapshotFile> {
+    ) -> Result<()> {
         let backup_stdin = PathList::from_string("-")?;
         let source = source
             .clone()
@@ -347,23 +355,22 @@ impl BackupCmd {
             .with_context(|| format!("error sanitizing source=s\"{:?}\"", source))?
             .merge();
 
-        let snap = if source.len() == 1
+        if source.len() == 1
                 // TODO: This check should not be done on PathList, but in the sources list directly
                 && let Some(path) = source[0].to_string_lossy().strip_prefix("opendal:")
         {
             let source = OpenDALBackend::new(path, options)?.as_source()?;
-            repo.archive(&backup_opts, &source, snap, &[PathBuf::new()])?
+            Self::archive(repo, &backup_opts, ls, &source, snap, &[PathBuf::new()])?;
         } else if source == backup_stdin {
             let path = PathBuf::from(&backup_opts.stdin_filename);
             let backup_paths = vec![path.clone()];
             if let Some(command) = &backup_opts.stdin_command {
                 let src = ChildStdoutSource::new(command, path)?;
-                let res = repo.archive(&backup_opts, &src, snap, &backup_paths)?;
+                Self::archive(repo, &backup_opts, ls, &src, snap, &backup_paths)?;
                 src.finish()?;
-                res
             } else {
                 let src = StdinSource::new(path);
-                repo.archive(&backup_opts, &src, snap, &backup_paths)?
+                Self::archive(repo, &backup_opts, ls, &src, snap, &backup_paths)?;
             }
         } else {
             let backup_path = source.paths();
@@ -373,9 +380,36 @@ impl BackupCmd {
                 &backup_opts.ignore_filter_opts,
                 &backup_path,
             )?;
-            repo.archive(&backup_opts, &src, snap, &backup_path)?
+            Self::archive(repo, &backup_opts, ls, &src, snap, &backup_path)?;
         };
-        Ok(snap)
+        Ok(())
+    }
+
+    pub fn archive<R>(
+        repo: &IndexedIdsRepo,
+        opts: &BackupOptions,
+        ls: bool,
+        src: &R,
+        snap: &mut SnapshotFile,
+        backup_paths: &[PathBuf],
+    ) -> Result<()>
+    where
+        R: ReadSource + 'static,
+        <R as ReadSource>::Open: Send,
+        <R as ReadSource>::Iter: Send,
+    {
+        if ls {
+            let lister = LsCmd {
+                long: true,
+                ..Default::default()
+            };
+            lister.display(src.entries().map(|e| Ok(e?.as_tree_entry())))?;
+        } else {
+            let snapshot = std::mem::take(snap);
+            let snapshot = repo.archive(opts, src, snapshot, backup_paths)?;
+            *snap = snapshot;
+        }
+        Ok(())
     }
 
     fn backup_snapshot(mut self, source: PathList, repo: &IndexedIdsRepo) -> Result<()> {
@@ -420,12 +454,14 @@ impl BackupCmd {
             .no_scan(self.no_scan)
             .dry_run(config.global.dry_run);
 
-        let snap = self.snap_opts.to_snapshot()?;
-        let snap = hooks.use_with(|| -> Result<_> {
-            Self::backup_source(&source, self.options, backup_opts, snap, repo)
+        let mut snap = self.snap_opts.to_snapshot()?;
+        hooks.use_with(|| {
+            Self::backup_source(&source, self.options, self.ls, backup_opts, &mut snap, repo)
         })?;
 
-        if config.global.progress_options.json_progress {
+        if self.ls {
+            // no output here
+        } else if config.global.progress_options.json_progress {
             write_json_progress_summary(&snap)?;
         } else if self.json {
             let mut stdout = std::io::stdout();

--- a/src/commands/ls.rs
+++ b/src/commands/ls.rs
@@ -38,29 +38,29 @@ mod constants {
 use constants::{S_IRGRP, S_IROTH, S_IRUSR, S_IWGRP, S_IWOTH, S_IWUSR, S_IXGRP, S_IXOTH, S_IXUSR};
 
 /// `ls` subcommand
-#[derive(clap::Parser, Command, Debug)]
+#[derive(clap::Parser, Command, Debug, Default)]
 pub(crate) struct LsCmd {
     /// Snapshot:path to list (uses local path if no snapshot is given)
     ///
     /// The snapshot can be an id: "01a2b3c4" or "latest" or "latest~N" (N >= 0)
     #[clap(value_name = "SNAPSHOT[:PATH]|PATH")]
-    snap: String,
+    pub snap: String,
 
     /// show summary
     #[clap(long, short = 's', conflicts_with = "json")]
-    summary: bool,
+    pub summary: bool,
 
     /// show long listing
     #[clap(long, short = 'l', conflicts_with = "json")]
-    long: bool,
+    pub long: bool,
 
     /// show listing in json
     #[clap(long, conflicts_with_all = ["summary", "long"])]
-    json: bool,
+    pub json: bool,
 
     /// show uid/gid instead of user/group
     #[clap(long, long("numeric-uid-gid"))]
-    numeric_id: bool,
+    pub numeric_id: bool,
 
     /// recursively list the dir
     #[clap(long)]
@@ -69,14 +69,14 @@ pub(crate) struct LsCmd {
     #[cfg(feature = "tui")]
     /// Run in interactive UI mode
     #[clap(long, short)]
-    interactive: bool,
+    pub interactive: bool,
 
     #[clap(flatten, next_help_heading = "Exclude options")]
     /// exclude options
     pub excludes: Excludes,
 
     #[clap(flatten, next_help_heading = "Exclude options for local source")]
-    ignore_opts: LocalSourceFilterOptions,
+    pub ignore_opts: LocalSourceFilterOptions,
 }
 
 impl Runnable for LsCmd {
@@ -212,7 +212,7 @@ impl LsCmd {
         Ok(())
     }
 
-    fn inner_run_local(&self, path: Option<&str>) -> Result<()> {
+    pub fn inner_run_local(&self, path: Option<&str>) -> Result<()> {
         #[cfg(feature = "tui")]
         if self.interactive {
             anyhow::bail!("interactive ls with local path is not yet implemented!");
@@ -233,7 +233,7 @@ impl LsCmd {
         Ok(())
     }
 
-    fn display(
+    pub fn display(
         &self,
         tree_streamer: impl Iterator<Item = RusticResult<(PathBuf, Node)>>,
     ) -> Result<()> {

--- a/src/snapshots/rustic_rs__config__tests__default_config_passes.snap
+++ b/src/snapshots/rustic_rs__config__tests__default_config_passes.snap
@@ -89,6 +89,7 @@ RusticConfig {
     backup: BackupCmd {
         cli_sources: [],
         cli_name: [],
+        ls: false,
         name: None,
         stdin_filename: "",
         stdin_command: None,

--- a/src/snapshots/rustic_rs__config__tests__global_env_roundtrip_passes-3.snap
+++ b/src/snapshots/rustic_rs__config__tests__global_env_roundtrip_passes-3.snap
@@ -100,6 +100,7 @@ RusticConfig {
     backup: BackupCmd {
         cli_sources: [],
         cli_name: [],
+        ls: false,
         name: None,
         stdin_filename: "",
         stdin_command: None,


### PR DESCRIPTION
Adds the new option `--ls` to the `backup` command. With this option enabled, no backup is performed, but instead the files-to-backup are just listed, like in the `ls` command.

The differences to the `--dry-run` option are:
- `--ls` doesn't read or process any file contents, it only lists the files. It is therefore much faster than `--dry-run`.
- `--dry-run` does every step a real backup would do except writing to the backend. It can therefore also show details about the size which would be added and about new or changed/unchanged files.

closes #1757
closes #1676 