### PR TITLE
fix: add CA certificates to Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,8 @@
 FROM alpine AS builder
 ARG RUSTIC_VERSION
 ARG TARGETARCH
-RUN if [ "$TARGETARCH" = "amd64" ]; then \
+RUN apk add --no-cache ca-certificates && \
+    if [ "$TARGETARCH" = "amd64" ]; then \
         ASSET="rustic-${RUSTIC_VERSION}-x86_64-unknown-linux-musl.tar.gz";\
     elif [ "$TARGETARCH" = "arm64" ]; then \
         ASSET="rustic-${RUSTIC_VERSION}-aarch64-unknown-linux-musl.tar.gz"; \
@@ -15,4 +16,5 @@ RUN if [ "$TARGETARCH" = "amd64" ]; then \
 FROM scratch
 COPY --from=builder /rustic /
 COPY --from=builder /etc_files/ /etc/
+COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 ENTRYPOINT ["/rustic"]


### PR DESCRIPTION
## What this changes

Fixes #1777 

This PR adds the Alpine CA certificate bundle to the final Docker image.

The runtime image still uses `scratch`; it now also includes:

```text
/etc/ssl/certs/ca-certificates.crt
````

## Why

The official Docker image is currently based on `scratch`. When using HTTPS/S3/REST-style backends, `reqwest` needs system CA certificates for TLS verification.

Without a CA bundle, rustic can panic during HTTP client initialization:

```text
Client::new(): reqwest::Error { kind: Builder, source: General("No CA certificates were loaded from the system") }
```

This happened with `ghcr.io/rustic-rs/rustic:latest` / rustic `0.11.3` while backing up to an OpenDAL B2 repository.

## Testing

I built and pushed a test image with this change, then used it in my Docker Compose backup setup with an OpenDAL B2 repository.

The backup completed successfully:

```text
[INFO] repository opendal:b2:: password is correct.
[INFO] snapshot 8706869a successfully saved.
backup completed for data artifact=8706869a
step backup succeeded
backup task finished successfully
```

This confirms that TLS initialization works when the CA bundle is available in the Docker image.
