### PR TITLE
Typo: restic instead of rustic

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Windows).
 The `restic` project is older and more mature than `rustic`, slow with new
 developments and conservative with changes. `rustic` was created by a heavy
 restic contributor who was at some point annoyed about that slow speed. So,
-`rustic` is of course very much inspired by `rustic` but is a complete new
+`rustic` is of course very much inspired by `restic` but is a complete new
 implementation aiming to be the better `restic` with respect to features and
 development speed.
 


### PR DESCRIPTION
This should have been a `restic`, not a `rustic`.