### PR TITLE
fix: use backup config for local diffs

### DIFF
--- a/src/commands/backup.rs
+++ b/src/commands/backup.rs
@@ -106,7 +106,7 @@ pub struct BackupCmd {
     /// Node save options
     #[clap(flatten, next_help_heading = "Node modification options")]
     #[serde(flatten)]
-    ignore_save_opts: LocalSourceSaveOptions,
+    pub ignore_save_opts: LocalSourceSaveOptions,
 
     /// Parent processing options
     #[clap(flatten, next_help_heading = "Options for parent processing")]

--- a/src/commands/diff.rs
+++ b/src/commands/diff.rs
@@ -16,7 +16,7 @@ use std::{
 use anyhow::{Context, Result, bail};
 
 use rustic_core::{
-    Excludes, LocalDestination, LocalSource, LocalSourceFilterOptions, LocalSourceSaveOptions,
+    Excludes, LocalDestination, LocalSource, LocalSourceFilterOptions,
     LsOptions, ProgressBars, ProgressType, ReadSource, ReadSourceEntry, RusticResult,
     repofile::{Node, NodeType},
 };
@@ -178,7 +178,7 @@ impl DiffCmd {
                     .with_context(|| format!("Error accessing {path2:?}"))?
                     .is_dir();
                 let src = LocalSource::new(
-                    LocalSourceSaveOptions::default(),
+                    config.backup.ignore_save_opts.clone(),
                     &self.excludes,
                     &self.ignore_opts,
                     &[&path2],


### PR DESCRIPTION
Fixes: #1816

Here's my attempted fix. I manually tested it on Windows and it works:

```sh
C:\tmp>patched\rustic.exe -P myprofile diff --no-content --metadata "latest:" "local:C:/tmp/myprofile/data"
[INFO] using config C:\Users\<username>\AppData\Roaming\rustic\config\myprofile.toml
[INFO] repository local:C:\tmp\myprofile\repo: password is correct.
[INFO] comparing df8cfa49: (latest:) with local dir C:/tmp/myprofile/data (local:C:/tmp/myprofile/data)
Files   : 2 =, 0 +, 0 -, 0 M, 0 U
```

Please feel free to take over and iterate on the changes to better fit the codebase.