### PR TITLE
fix: link jemallocator-global so the jemallocator feature applies

### DIFF
--- a/src/bin/rustic.rs
+++ b/src/bin/rustic.rs
@@ -15,6 +15,12 @@ use mimalloc::MiMalloc;
 #[global_allocator]
 static GLOBAL: MiMalloc = MiMalloc;
 
+// jemallocator-global registers the #[global_allocator] from within the crate, so it has
+// to be referenced here: an unused dependency is not linked into the binary and the
+// allocator would silently stay the default one.
+#[cfg(feature = "jemallocator")]
+use jemallocator_global as _;
+
 use rustic_rs::application::RUSTIC_APP;
 
 /// Boot Rustic


### PR DESCRIPTION
Building with `--features jemallocator` produces a binary with no jemalloc in it.

`jemallocator-global` registers the `#[global_allocator]` inside its own crate, so the
crate has to be linked for it to have any effect. Nothing in the source referenced it:
the only mention of the feature is the mimalloc/jemallocator `compile_error!` in
`src/bin/rustic.rs`. The unreferenced dependency is dropped at link time and the binary
keeps the system allocator.

Three `aarch64-unknown-linux-musl` release builds of the tree before this change:

| Build             | size (bytes) | jemalloc symbols | mimalloc symbols |
| ----------------- | ------------ | ---------------- | ---------------- |
| no allocator      | 23,155,552   | 0                | 0                |
| `-F mimalloc`     | 23,362,368   | 0                | 6                |
| `-F jemallocator` | 23,155,552   | 0                | 0                |

The jemalloc build is byte-size identical to the plain one, while the mimalloc build is
visibly larger and does contain its allocator.

To fix this we need to reference the crate from the binary, next to the existing mimalloc block, so it gets
linked when the feature is on.

## Verification

On `aarch64-unknown-linux-musl` after the change:

| Build             | size (bytes) | jemalloc symbols | mimalloc symbols |
| ----------------- | ------------ | ---------------- | ---------------- |
| no allocator      | 23,155,552   | 0                | 0                |
| `-F mimalloc`     | 23,362,368   | 0                | 6                |
| `-F jemallocator` | 23,811,248   | 30               | 0                |

The default and mimalloc builds are unchanged, and the jemalloc build grows by ~640 KiB
and now carries the allocator.

- Full cycle on the feature build: `init`, `backup`, `check --read-data`, `restore`, then
  a recursive diff of the restored tree against the source: identical.
- Also linked on macOS aarch64 (`_jemalloc_constructor` present in the binary).
- Nothing else changes: the new line is behind `#[cfg(feature = "jemallocator")]`, and CI
  builds with `--features release`, which does not enable it.