### PR TITLE
deps: update anyhow to 1.0.103

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -180,9 +180,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "arc-swap"


### PR DESCRIPTION
## Summary

Updates `anyhow` from 1.0.102 to 1.0.103 in the lockfile.

## Why

This picks up the upstream security fix without changing rustic's public dependency configuration.

## Validation

- `git diff --check`
- Lockfile resolution completed with `cargo update -p anyhow --precise 1.0.103`

Fixes #1791.
