### PR TITLE
fix: keep completions independent from profiles

### DIFF
--- a/src/commands.rs
+++ b/src/commands.rs
@@ -229,6 +229,12 @@ impl Configurable<RusticConfig> for EntryPoint {
         // That's why it says `_config`, because it's not read at all and therefore not needed.
         let mut config = self.config.clone();
 
+        // Completion generation only needs the command definition. In particular, it must not
+        // try to read a profile which may be inaccessible to the user generating completions.
+        if matches!(self.commands, RusticCmd::Completions(_)) {
+            return Ok(config);
+        }
+
         // collect "RUSTIC_REPO_OPT*" and "OPENDAL*" env variables.
         // also add the standardized OTEL variables manually
         // since clap does not support multiple variables for a single arg

--- a/tests/completions.rs
+++ b/tests/completions.rs
@@ -10,7 +10,7 @@
 //     unused_qualifications
 // )]
 
-use std::{io::Read, sync::LazyLock};
+use std::{io::Read, process::Command, sync::LazyLock};
 
 use abscissa_core::testing::prelude::*;
 use insta::assert_snapshot;
@@ -64,6 +64,26 @@ fn test_completions_passes(#[case] shell: &str) -> TestResult<()> {
     assert_snapshot!(name, output);
 
     cmd.wait()?.expect_success();
+
+    Ok(())
+}
+
+#[test]
+fn completions_do_not_load_profiles() -> TestResult<()> {
+    let profile = tempfile::Builder::new().suffix(".toml").tempfile()?;
+    std::fs::write(profile.path(), "this is not valid TOML")?;
+
+    let output = Command::new(env!("CARGO_BIN_EXE_rustic"))
+        .env("RUSTIC_USE_PROFILE", profile.path())
+        .args(["completions", "bash"])
+        .output()?;
+
+    assert!(
+        output.status.success(),
+        "completion command failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(!output.stdout.is_empty());
 
     Ok(())
 }


### PR DESCRIPTION
## Summary

Keeps shell completion generation independent from profile loading and adds a regression test with an intentionally invalid profile.

## Why

Users should be able to generate completions even when a configured profile is unavailable or malformed. Completion generation only needs the command definition and should not initialize the runtime configuration.

## Validation

- `cargo test --locked --test completions completions_do_not_load_profiles`
- `git diff --check`

Fixes #1503.
