### PR TITLE
docs: add a Windows VSS backup helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,9 @@ cargo binstall rustic-rs
 scoop install rustic
 ```
 
+For files that Windows keeps exclusively locked, see the
+[VSS backup wrapper example](util/windows/README.md).
+
 #### macOS
 
 ##### [Homebrew](https://brew.sh/)

--- a/util/windows/README.md
+++ b/util/windows/README.md
@@ -1,0 +1,63 @@
+# Backing up locked Windows files with VSS
+
+`rustic-vss-backup.ps1` is an administrator-run wrapper for backing up a
+single local Windows path from a temporary Volume Shadow Copy Service (VSS)
+snapshot. It is not native VSS support in rustic: the wrapper creates and
+removes the snapshot using Windows' built-in `Win32_ShadowCopy` CIM interface.
+
+The wrapper passes the shadow copy's `DeviceObject` path directly to rustic and
+uses `--as-path` to retain the original path in the resulting snapshot. It
+therefore does not need a symlink or a third-party VSS executable.
+
+## Requirements and scope
+
+- Run PowerShell as Administrator. VSS creation requires elevation.
+- Configure rustic normally, for example through its profile or the
+  `RUSTIC_REPOSITORY` and password environment variables. Do not put
+  credentials in this script.
+- The source must be a path on a local drive-letter volume, such as `C:\` or
+  `C:\Users\alice`. UNC paths and mounted volumes are deliberately out of
+  scope for this small example.
+- Confirm the workflow on a non-critical path first. The script removes the
+  shadow copy in a `finally` block, including when rustic fails, but a cleanup
+  failure is still reported as a failed run so it can be investigated.
+
+## Run it
+
+With `rustic` on `PATH`:
+
+```powershell
+$env:RUSTIC_REPOSITORY = "C:\backup-repository"
+$env:RUSTIC_PASSWORD_FILE = "C:\secure\rustic-password.txt"
+
+.\rustic-vss-backup.ps1 `
+    -Source "C:\Users\alice" `
+    -RusticArgument @("--tag", "vss")
+```
+
+If the executable is not on `PATH`, give its full path:
+
+```powershell
+.\rustic-vss-backup.ps1 `
+    -Source "C:\Users\alice" `
+    -RusticExe "C:\Program Files\rustic\rustic.exe" `
+    -RusticArgument @("--use-profile", "home", "--tag", "vss")
+```
+
+`-RusticArgument` is a PowerShell string array. Its values are passed to
+`rustic backup`, so it can contain ordinary backup and global rustic options.
+
+When using a source-specific profile section, make its `sources` entry match
+the original path, not the temporary VSS device path. The wrapper's
+`--as-path` lets rustic select that section while preserving the normal path in
+the snapshot:
+
+```toml
+[[backup.snapshots]]
+sources = ['C:\Users\alice']
+tags = ["documents"]
+```
+
+Windows exposes the VSS snapshot through `Win32_ShadowCopy.DeviceObject`; the
+wrapper creates it with the documented `ClientAccessible` context and removes
+that exact object after the backup.

--- a/util/windows/rustic-vss-backup.ps1
+++ b/util/windows/rustic-vss-backup.ps1
@@ -1,0 +1,84 @@
+#Requires -Version 5.1
+<#
+.SYNOPSIS
+Back up one local Windows path from a temporary VSS shadow copy with rustic.
+
+.DESCRIPTION
+Creates a ClientAccessible Win32_ShadowCopy for the source drive, invokes
+rustic with the shadow copy's DeviceObject path, and removes the shadow copy
+afterwards. See README.md in this directory for setup and limitations.
+#>
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory)]
+    [string]$Source,
+
+    [string]$RusticExe = "rustic",
+
+    # Passed to `rustic backup` after the source and --as-path arguments.
+    [string[]]$RusticArgument = @()
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+$principal = [Security.Principal.WindowsPrincipal]::new(
+    [Security.Principal.WindowsIdentity]::GetCurrent()
+)
+if (-not $principal.IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)) {
+    throw "Run this script from an elevated PowerShell session; Windows VSS creation requires Administrator privileges."
+}
+
+$sourceItem = Get-Item -LiteralPath $Source -Force
+$sourcePath = [System.IO.Path]::GetFullPath($sourceItem.FullName)
+$sourceDrive = [System.IO.Path]::GetPathRoot($sourcePath)
+
+# This example deliberately limits itself to a local drive-letter volume. A
+# VSS shadow copy cannot be made from a UNC path, and mounted volumes need
+# their own volume-root handling.
+if ([string]::IsNullOrWhiteSpace($sourceDrive) -or $sourceDrive -notmatch '^[A-Za-z]:\\$') {
+    throw "Source must be on a local drive-letter volume, for example C:\Users\alice."
+}
+
+$relativeSource = $sourcePath.Substring($sourceDrive.Length).TrimStart('\')
+$rustic = Get-Command -Name $RusticExe -CommandType Application -ErrorAction Stop
+
+$shadow = $null
+$exitCode = 1
+
+try {
+    $result = Invoke-CimMethod -ClassName Win32_ShadowCopy -MethodName Create -Arguments @{
+        Volume = $sourceDrive
+        Context = "ClientAccessible"
+    }
+
+    if ($result.ReturnValue -ne 0 -or [string]::IsNullOrWhiteSpace($result.ShadowID)) {
+        throw "Windows VSS creation failed with return value $($result.ReturnValue)."
+    }
+
+    $shadow = Get-CimInstance -ClassName Win32_ShadowCopy -Filter "ID = '$($result.ShadowID)'"
+    if ($null -eq $shadow -or [string]::IsNullOrWhiteSpace($shadow.DeviceObject)) {
+        throw "Windows created the VSS snapshot but did not expose its device path."
+    }
+
+    $shadowSource = "$($shadow.DeviceObject)\$relativeSource"
+    Write-Verbose "Backing up VSS source '$shadowSource' as '$sourcePath'."
+
+    & $rustic.Path backup $shadowSource --as-path $sourcePath @RusticArgument
+    $exitCode = $LASTEXITCODE
+}
+finally {
+    if ($null -ne $shadow) {
+        try {
+            Remove-CimInstance -InputObject $shadow -ErrorAction Stop
+        }
+        catch {
+            [Console]::Error.WriteLine("Unable to remove VSS shadow copy '$($shadow.ID)': $($_.Exception.Message)")
+            if ($exitCode -eq 0) {
+                $exitCode = 1
+            }
+        }
+    }
+}
+
+exit $exitCode


### PR DESCRIPTION
## Summary

Adds a Windows VSS backup helper and documents the permissions, path, and recovery constraints around it.

## Why

The issue needed a practical way to capture files that may be changing on Windows. The helper keeps the VSS invocation explicit and documents that VSS support does not remove the need to test restores and credentials.

## Validation

- PowerShell AST parsing and command-expression smoke check
- `git diff --check`

Fixes #1412.
