### PR TITLE
docs: clarify hook scope and ordering

### DIFF
--- a/config/README.md
+++ b/config/README.md
@@ -102,10 +102,14 @@ If you want to contribute your own configuration, please
 
 ### Global Hooks `[global.hooks]`
 
-These external commands are run before and after each commands, respectively.
+These external commands run once around the top-level `rustic` invocation,
+using the configuration assembled for that invocation. They are not mutually
+exclusive with repository hooks.
 
-**Note**: There are also repository hooks, which should be used for commands
-needed to set up the repository (like mounting the repo dir), see below.
+For `copy`, global hooks from the source (invoking) profile run once. Global
+hooks in a target profile do not run when that profile is loaded to open the
+target repository; use that target profile's repository hooks for target
+repository setup and per-target failure handling.
 
 | Attribute   | Description                                       | Default Value | Example Value | Environment Variable |
 | ----------- | ------------------------------------------------- | ------------- | ------------- | -------------------- |
@@ -193,8 +197,10 @@ see [Repository Options](#repository-options-repository)
 
 ### Repository Hooks `[repository.hooks]`
 
-These external commands are run before and after each repository-accessing
-commands, respectively.
+These external commands run around each repository access. They are additional
+to the global hooks of the invoking profile. For `copy`, the source profile's
+repository hooks run for the source repository, and each target profile's
+repository hooks run for its target repository.
 
 See [Global Hooks](#global-hooks-globalhooks).
 

--- a/config/hooks.toml
+++ b/config/hooks.toml
@@ -5,6 +5,9 @@
 # The hooks are run in the order they are defined in the configuration file.
 # The hooks are divided into 4 categories: global, repository, backup,
 # and specific backup sources.
+# Global hooks run once for the invoking profile. When using `copy`, hooks in a
+# target profile's [global.hooks] section do not run; use that profile's
+# [repository.hooks] section for setup and per-target failure handling.
 #
 # You can also read a more detailed explanation of the hooks in the documentation:
 # https://rustic.cli.rs/docs/commands/misc/hooks.html


### PR DESCRIPTION
## Summary

Clarifies hook scope, ordering, and overlap in the hook configuration reference.

## Why

The existing examples left it unclear which global, repository, backup, and source hooks run for a command. The documentation now makes the nesting and execution scope explicit without changing hook behavior.

## Validation

- Audited the documented scopes against the existing hook call sites
- `git diff --check`

Fixes #1611.
