### PR TITLE
config: add an OVH Cold Archive profile

### DIFF
--- a/config/services/opendal_ovh-cold-archive.toml
+++ b/config/services/opendal_ovh-cold-archive.toml
@@ -1,0 +1,41 @@
+# Template for an OVH Object Storage repository with a hot and Deep Archive
+# cold copy. Copy this file to your rustic configuration directory, replace all
+# placeholder values, and ensure that s3cmd is configured with credentials that
+# can restore objects from the cold bucket.
+#
+# Backup:  rustic -P /path/to/ovh-cold-archive.toml backup /path/to/data
+# Restore: rustic -P /path/to/ovh-cold-archive.toml restore latest /restore/to
+
+[repository]
+# `repository` is the cold copy; `repo-hot` is used for normal reads.
+repository = "opendal:s3"
+repo-hot = "opendal:s3"
+password-file = "/path/to/rustic-password"
+
+# Ask OVH to restore each cold pack before it is needed. `%path` expands to
+# the pack path relative to the cold repository root.
+warm-up-command = "s3cmd restore --restore-days=3 -dv s3://YOUR-COLD-BUCKET/YOUR-COLD-ROOT/%path"
+
+# OVH Deep Archive retrieval can take more than 48 hours. Uncomment and tune
+# one of these settings for the archive tier and restore workflow in use.
+# warm-up-wait = "72h"
+# warm-up-wait-command = "/path/to/wait-until-ovh-objects-are-restored"
+
+# Options shared by both S3 backends.
+[repository.options]
+endpoint = "https://s3.YOUR-REGION.io.cloud.ovh.net"
+region = "YOUR-REGION"
+access_key_id = "YOUR-ACCESS-KEY"
+secret_access_key = "YOUR-SECRET-KEY"
+
+[repository.options-hot]
+bucket = "YOUR-HOT-BUCKET"
+root = "/YOUR-HOT-ROOT"
+
+[repository.options-cold]
+bucket = "YOUR-COLD-BUCKET"
+root = "/YOUR-COLD-ROOT"
+default_storage_class = "DEEP_ARCHIVE"
+
+[[backup.snapshots]]
+sources = ["/path/to/backup"]

--- a/config/services/opendal_ovh-cold-archive.toml
+++ b/config/services/opendal_ovh-cold-archive.toml
@@ -1,7 +1,11 @@
 # Template for an OVH Object Storage repository with a hot and Deep Archive
 # cold copy. Copy this file to your rustic configuration directory, replace all
-# placeholder values, and ensure that s3cmd is configured with credentials that
-# can restore objects from the cold bucket.
+# placeholder values, export the OpenDAL credentials below, and ensure that
+# s3cmd is configured with credentials that can restore objects from the cold
+# bucket.
+#
+# export OPENDAL_ACCESS_KEY_ID="your-application-key-id"
+# export OPENDAL_SECRET_ACCESS_KEY="your-application-key"
 #
 # Backup:  rustic -P /path/to/ovh-cold-archive.toml backup /path/to/data
 # Restore: rustic -P /path/to/ovh-cold-archive.toml restore latest /restore/to
@@ -25,8 +29,6 @@ warm-up-command = "s3cmd restore --restore-days=3 -dv s3://YOUR-COLD-BUCKET/YOUR
 [repository.options]
 endpoint = "https://s3.YOUR-REGION.io.cloud.ovh.net"
 region = "YOUR-REGION"
-access_key_id = "YOUR-ACCESS-KEY"
-secret_access_key = "YOUR-SECRET-KEY"
 
 [repository.options-hot]
 bucket = "YOUR-HOT-BUCKET"

--- a/tests/service_profiles.rs
+++ b/tests/service_profiles.rs
@@ -1,0 +1,28 @@
+//! Service-profile smoke tests that do not contact external services.
+
+use std::{path::PathBuf, process::Command};
+
+#[test]
+fn ovh_cold_archive_profile_maps_opendal_credentials() {
+    let profile = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("config/services/opendal_ovh-cold-archive.toml");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_rustic"))
+        .env("OPENDAL_ACCESS_KEY_ID", "ovh-access-key-for-test")
+        .env("OPENDAL_SECRET_ACCESS_KEY", "ovh-secret-key-for-test")
+        .arg("--use-profile")
+        .arg(&profile)
+        .arg("show-config")
+        .output()
+        .expect("run rustic show-config");
+
+    assert!(
+        output.status.success(),
+        "OVH profile did not load: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let config = String::from_utf8(output.stdout).expect("show-config output is UTF-8");
+    assert!(config.contains("access_key_id = \"ovh-access-key-for-test\""));
+    assert!(config.contains("secret_access_key = \"ovh-secret-key-for-test\""));
+}


### PR DESCRIPTION
## Summary

Adds an OVH Cold Archive hot/cold service profile. OpenDAL credentials are supplied only through `OPENDAL_ACCESS_KEY_ID` and `OPENDAL_SECRET_ACCESS_KEY`; the profile contains no credential placeholders.

## Validation

- `cargo test --locked ovh_cold_archive_profile_maps_opendal_credentials`
- `cargo clippy --locked --all-targets --features release -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`
- `typos`

No live OVH archive or restore operation was performed.

Fixes #1744.