### PR TITLE
config: add a OneDrive service profile

### DIFF
--- a/config/services/onedrive.toml
+++ b/config/services/onedrive.toml
@@ -1,0 +1,33 @@
+# rustic config file to use Microsoft OneDrive storage via Apache OpenDAL
+#
+# The authoritative OpenDAL setup guide is at:
+# https://opendal.apache.org/docs/rust/opendal/services/struct.Onedrive.html
+#
+# For long-lived access (recommended):
+#
+# 1. Register a Microsoft Entra application for both organizational and
+#    personal Microsoft accounts. Follow a delegated OAuth 2.0
+#    authorization-code flow with the `Files.ReadWrite` and `offline_access`
+#    scopes; client-credentials authentication cannot access `/me/drive`.
+# 2. Supply the resulting refresh token and the application's client ID via
+#    environment variables. For a confidential Web application, also supply
+#    its client secret. Public/native applications must not use a client secret.
+#
+# Rustic maps the `OPENDAL_` variables below to the corresponding
+# `[repository.options]` names:
+# export OPENDAL_REFRESH_TOKEN="your-refresh-token"
+# export OPENDAL_CLIENT_ID="your-application-client-id"
+# export OPENDAL_CLIENT_SECRET="your-client-secret" # Web/confidential apps only
+# export RUSTIC_PASSWORD="your-repository-password"
+#
+# An `access_token` alone is short-lived. With `refresh_token` and `client_id`,
+# OpenDAL obtains and refreshes access tokens automatically. This example does
+# not acquire OAuth credentials; create them through the linked Microsoft/OpenDAL
+# flow before using it.
+
+[repository]
+repository = "opendal:onedrive"
+
+[repository.options]
+# Folder within OneDrive that contains the rustic repository.
+root = "/rustic-backups"

--- a/tests/service_profiles.rs
+++ b/tests/service_profiles.rs
@@ -1,0 +1,33 @@
+//! Service-profile smoke tests that do not contact external services.
+
+use std::{path::PathBuf, process::Command};
+
+#[test]
+fn onedrive_service_profile_maps_opendal_credentials() {
+    let profile = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("config/services/onedrive.toml");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_rustic"))
+        .env("OPENDAL_REFRESH_TOKEN", "one-drive-refresh-token-for-test")
+        .env("OPENDAL_CLIENT_ID", "one-drive-client-id-for-test")
+        .env("OPENDAL_CLIENT_SECRET", "one-drive-client-secret-for-test")
+        .env("RUSTIC_PASSWORD", "repository-password-for-test")
+        .arg("--use-profile")
+        .arg(&profile)
+        .arg("show-config")
+        .output()
+        .expect("run rustic show-config");
+
+    assert!(
+        output.status.success(),
+        "OneDrive profile did not load: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let config = String::from_utf8(output.stdout).expect("show-config output is UTF-8");
+    assert!(config.contains("repository = \"opendal:onedrive\""));
+    assert!(config.contains("root = \"/rustic-backups\""));
+    assert!(config.contains("refresh_token = \"one-drive-refresh-token-for-test\""));
+    assert!(config.contains("client_id = \"one-drive-client-id-for-test\""));
+    assert!(config.contains("client_secret = \"one-drive-client-secret-for-test\""));
+    assert!(config.contains("password = \"repository-password-for-test\""));
+}


### PR DESCRIPTION
## Summary

Adds a OneDrive OpenDAL service profile and a local regression test for environment-backed credential mapping.

## Scope

The profile documents the delegated authorization-code flow and refresh-token inputs. It does not acquire credentials and has not been validated against a live Microsoft account or OneDrive repository.

## Validation

- Local TOML/`show-config` credential-mapping smoke test
- `cargo fmt --all -- --check`
- `git diff --check`
- `typos`

Related to #1320.