### PR TITLE
fix: accept an empty backup as-path

### DIFF
--- a/src/commands/backup.rs
+++ b/src/commands/backup.rs
@@ -583,21 +583,6 @@ fn publish_metrics(
     Err(anyhow!("metrics support is not compiled-in!"))
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn as_path_accepts_an_empty_cli_value() {
-        use clap::Parser;
-
-        let backup = BackupCmd::try_parse_from(["backup", "--as-path", ""])
-            .expect("an empty as-path should be accepted");
-
-        assert_eq!(backup.as_path, Some(PathBuf::new()));
-    }
-}
-
 #[cfg(any(feature = "prometheus", feature = "opentelemetry"))]
 fn publish_metrics(
     snap: &SnapshotFile,
@@ -785,4 +770,19 @@ fn publish_metrics(
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn as_path_accepts_an_empty_cli_value() {
+        use clap::Parser;
+
+        let backup = BackupCmd::try_parse_from(["backup", "--as-path", ""])
+            .expect("an empty as-path should be accepted");
+
+        assert_eq!(backup.as_path, Some(PathBuf::new()));
+    }
 }

--- a/src/commands/backup.rs
+++ b/src/commands/backup.rs
@@ -19,7 +19,10 @@ use crate::{
 
 use abscissa_core::{Command, Runnable, Shutdown};
 use anyhow::{Context, Result, anyhow, bail};
-use clap::ValueHint;
+use clap::{
+    ValueHint,
+    builder::{OsStringValueParser, TypedValueParser},
+};
 use comfy_table::Cell;
 use conflate::{Merge, MergeFrom};
 use log::{debug, error, info, warn};
@@ -79,7 +82,12 @@ pub struct BackupCmd {
     stdin_command: Option<CommandInput>,
 
     /// Manually set backup path in snapshot
-    #[clap(long, value_name = "PATH", value_hint = ValueHint::DirPath)]
+    #[clap(
+        long,
+        value_name = "PATH",
+        value_hint = ValueHint::DirPath,
+        value_parser = OsStringValueParser::new().map(PathBuf::from)
+    )]
     #[merge(strategy=conflate::option::overwrite_none)]
     as_path: Option<PathBuf>,
 
@@ -573,6 +581,21 @@ fn publish_metrics(
     mut labels: BTreeMap<String, String>,
 ) -> Result<()> {
     Err(anyhow!("metrics support is not compiled-in!"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn as_path_accepts_an_empty_cli_value() {
+        use clap::Parser;
+
+        let backup = BackupCmd::try_parse_from(["backup", "--as-path", ""])
+            .expect("an empty as-path should be accepted");
+
+        assert_eq!(backup.as_path, Some(PathBuf::new()));
+    }
 }
 
 #[cfg(any(feature = "prometheus", feature = "opentelemetry"))]

--- a/tests/backup_restore.rs
+++ b/tests/backup_restore.rs
@@ -104,6 +104,23 @@ fn test_backup_and_check_passes() -> TestResult<()> {
 }
 
 #[test]
+fn backup_accepts_an_empty_as_path() -> TestResult<()> {
+    let temp_dir = setup()?;
+    let source = temp_dir.path().join("source");
+    std::fs::create_dir(&source)?;
+    std::fs::write(source.join("payload.txt"), "payload")?;
+
+    rustic_runner(&temp_dir)?
+        .args(["backup", "--as-path", ""])
+        .arg(&source)
+        .assert()
+        .success()
+        .stderr(predicate::str::contains("successfully saved."));
+
+    Ok(())
+}
+
+#[test]
 fn test_backup_records_cli_version_in_snapshot() -> TestResult<()> {
     let temp_dir = setup()?;
     let backup = src_snapshot()?.into_path();


### PR DESCRIPTION
## Summary

Allows an explicitly empty `--as-path` value and adds unit and integration regression coverage.

## Validation

- `cargo test --locked --lib commands::backup::tests::as_path_accepts_an_empty_cli_value`
- `cargo test --locked --test backup_restore backup_accepts_an_empty_as_path`
- `cargo clippy --locked --all-targets --features release -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`
- `typos`

Fixes #1135.