### PR TITLE
docs: clarify snapshot glob replacement

### DIFF
--- a/config/README.md
+++ b/config/README.md
@@ -275,7 +275,10 @@ See [Global Metrics labels](#global-metrics-labels-globalmetrics-labels).
 ### Backup Snapshots `[[backup.snapshots]]`
 
 **Note**: All of the backup options mentioned before can also be used as
-snapshot-specific option and then only apply to this snapshot.
+snapshot-specific option and then only apply to this snapshot. A snapshot-level
+list replaces the corresponding `[backup]` list; options such as `globs` are
+not concatenated automatically. Put shared patterns in `glob-files` when both
+shared and snapshot-specific glob rules are needed.
 
 | Attribute | Description                                                                                                              | Default Value | Example Value                                                          |
 | --------- | ------------------------------------------------------------------------------------------------------------------------ | ------------- | ---------------------------------------------------------------------- |


### PR DESCRIPTION
## Summary

Clarifies how snapshot-specific list options, especially `globs`, relate to the shared `[backup]` configuration.

## Why

The previous wording did not say whether lists were combined or replaced. The reference now explains the replacement behavior and shows how to keep shared patterns in `glob-files`.

## Validation

- Reviewed the wording against the existing configuration merge behavior
- `git diff --check`

Fixes #1647.
