### PR TITLE
fix: validate and load glob files

### DIFF
--- a/src/commands/backup.rs
+++ b/src/commands/backup.rs
@@ -189,6 +189,28 @@ impl BackupCmd {
         }
         Ok(())
     }
+
+    fn load_glob_files(mut excludes: Excludes) -> Result<Excludes> {
+        for file in std::mem::take(&mut excludes.glob_files) {
+            let patterns = std::fs::read_to_string(&file).with_context(|| {
+                format!(
+                    "failed to read glob file `{file}`; expected a file containing glob patterns"
+                )
+            })?;
+            excludes.globs.extend(patterns.lines().map(str::to_owned));
+        }
+
+        for file in std::mem::take(&mut excludes.iglob_files) {
+            let patterns = std::fs::read_to_string(&file).with_context(|| {
+                format!(
+                    "failed to read case-insensitive glob file `{file}`; expected a file containing glob patterns"
+                )
+            })?;
+            excludes.iglobs.extend(patterns.lines().map(str::to_owned));
+        }
+
+        Ok(excludes)
+    }
 }
 
 /// Merge backup snapshots to generate
@@ -444,13 +466,14 @@ impl BackupCmd {
         let mut parent_opts = self.parent_opts;
         parent_opts.group_by = parent_opts.group_by.or(config.global.group_by);
 
+        let excludes = Self::load_glob_files(self.excludes)?;
         let backup_opts = BackupOptions::default()
             .stdin_filename(self.stdin_filename.unwrap_or_else(|| "stdin".to_string()))
             .stdin_command(self.stdin_command)
             .as_path(self.as_path)
             .parent_opts(parent_opts)
             .ignore_save_opts(self.ignore_save_opts)
-            .excludes(self.excludes)
+            .excludes(excludes)
             .ignore_filter_opts(self.ignore_filter_opts)
             .no_scan(self.no_scan)
             .dry_run(config.global.dry_run);

--- a/tests/glob_files.rs
+++ b/tests/glob_files.rs
@@ -1,0 +1,85 @@
+//! Regression tests for glob-file input handling.
+
+use assert_cmd::Command;
+use predicates::prelude::{PredicateBooleanExt, predicate};
+use rustic_testing::TestResult;
+use tempfile::{tempdir, TempDir};
+
+fn rustic_runner(temp_dir: &TempDir) -> TestResult<Command> {
+    let repo_dir = temp_dir.path().join("repo");
+    let mut runner = Command::new(env!("CARGO_BIN_EXE_rustic"));
+
+    runner
+        .arg("--repo")
+        .arg(repo_dir)
+        .arg("--password")
+        .arg("test")
+        .arg("--no-progress");
+
+    Ok(runner)
+}
+
+fn setup() -> TestResult<TempDir> {
+    let temp_dir = tempdir()?;
+    rustic_runner(&temp_dir)?.arg("init").assert().success();
+    Ok(temp_dir)
+}
+
+#[test]
+fn directory_passed_as_glob_file_is_a_normal_input_error() -> TestResult<()> {
+    let temp_dir = setup()?;
+    let source = temp_dir.path().join("source");
+    let glob_directory = temp_dir.path().join("not-a-glob-file");
+    std::fs::create_dir(&source)?;
+    std::fs::create_dir(&glob_directory)?;
+
+    rustic_runner(&temp_dir)?
+        .args(["backup", "--glob-file"])
+        .arg(&glob_directory)
+        .arg(&source)
+        .assert()
+        .failure()
+        .stderr(
+            predicate::str::contains(format!(
+                "failed to read glob file `{}`",
+                glob_directory.display()
+            ))
+            .and(predicate::str::contains(
+                "expected a file containing glob patterns",
+            ))
+            .and(predicate::str::contains("We believe this is a bug").not()),
+        );
+
+    Ok(())
+}
+
+#[test]
+fn glob_file_patterns_are_applied() -> TestResult<()> {
+    let temp_dir = setup()?;
+    let source = temp_dir.path().join("source");
+    let glob_file = temp_dir.path().join("excludes.glob");
+    std::fs::create_dir(&source)?;
+    std::fs::write(source.join("included.txt"), "included")?;
+    std::fs::write(source.join("excluded.txt"), "excluded")?;
+    std::fs::write(&glob_file, "!**/excluded.txt\n")?;
+
+    let output = rustic_runner(&temp_dir)?
+        .args(["backup", "--ls", "--glob-file"])
+        .arg(&glob_file)
+        .arg(&source)
+        .output()?;
+
+    assert!(
+        output.status.success(),
+        "backup --ls failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8(output.stdout)?;
+    assert!(stdout.contains("included.txt"), "unexpected output: {stdout}");
+    assert!(
+        !stdout.contains("excluded.txt"),
+        "glob-file exclusion was ignored: {stdout}"
+    );
+
+    Ok(())
+}

--- a/tests/glob_files.rs
+++ b/tests/glob_files.rs
@@ -3,7 +3,7 @@
 use assert_cmd::Command;
 use predicates::prelude::{PredicateBooleanExt, predicate};
 use rustic_testing::TestResult;
-use tempfile::{tempdir, TempDir};
+use tempfile::{TempDir, tempdir};
 
 fn rustic_runner(temp_dir: &TempDir) -> TestResult<Command> {
     let repo_dir = temp_dir.path().join("repo");
@@ -75,7 +75,10 @@ fn glob_file_patterns_are_applied() -> TestResult<()> {
         String::from_utf8_lossy(&output.stderr)
     );
     let stdout = String::from_utf8(output.stdout)?;
-    assert!(stdout.contains("included.txt"), "unexpected output: {stdout}");
+    assert!(
+        stdout.contains("included.txt"),
+        "unexpected output: {stdout}"
+    );
     assert!(
         !stdout.contains("excluded.txt"),
         "glob-file exclusion was ignored: {stdout}"


### PR DESCRIPTION
## Summary

Loads glob-file patterns before traversal and reports a directory passed as a glob file as a normal input error.

## Validation

- `cargo test --locked --test glob_files`
- `cargo clippy --locked --all-targets --features release -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`
- `typos`

Fixes #1497.