### PR TITLE
feat: add WebDAV Basic Authentication

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,7 @@ tui = ["dep:ratatui", "dep:crossterm", "dep:tui-textarea"]
 webdav = [
   "dep:dav-server",
   "dep:axum",
+  "dep:base64",
   "dep:tokio",
   "dep:bytes",
   "dep:futures",

--- a/config/README.md
+++ b/config/README.md
@@ -340,7 +340,9 @@ here, see Snapshot-Filter options.
 `rustic` supports mounting snapshots via WebDAV. This is useful if you want to
 access your snapshots via a file manager.
 
-**Note**: `https://` and Authentication are not supported yet.
+**Note**: `https://` is not supported directly. For authentication, rustic
+supports opt-in HTTP Basic Authentication; terminate TLS in a reverse proxy
+when clients connect outside a trusted network.
 
 The following options are available to be used in your configuration file:
 
@@ -351,4 +353,11 @@ The following options are available to be used in your configuration file:
 | time-template | The time template to use to display times in the path template. See <https://pubs.opengroup.org/onlinepubs/009695399/functions/strftime.htmll> for format options. | `%Y-%m-%d_%H-%M-%S`                                                               |               | --time-template |
 | symlinks      | If true, follows symlinks.                                                                                                                                         | false                                                                             |               | --symlinks      |
 | file-access   | How to handle access to files.                                                                                                                                     | "forbidden" for hot/cold repositories, else "read"                                |               | --file-access   |
+| auth-user     | User name required for HTTP Basic Authentication. Must be set together with `auth-password`.                                                                      | Not set                                                                           | "rustic"     | --auth-user     |
+| auth-password | Password required for HTTP Basic Authentication. Must be set together with `auth-user`. Prefer `RUSTIC_WEBDAV_PASSWORD` over the command line.                    | Not set                                                                           | "secret"     | --auth-password |
 | snapshot-path | Specify directly which snapshot/path to serve                                                                                                                      | Not set, this will generate a virtual tree with all snapshots using path-template |               | --snapshot-path |
+
+`auth-user` can also be supplied through `RUSTIC_WEBDAV_USER`, and
+`auth-password` through `RUSTIC_WEBDAV_PASSWORD`. HTTP Basic Authentication
+does not encrypt credentials, so use a TLS-terminating reverse proxy for any
+network you do not fully trust.

--- a/config/full.toml
+++ b/config/full.toml
@@ -254,6 +254,8 @@ path-template = "[{hostname}]/[{label}]/{time}" # The path template to use for s
 time-template = "%Y-%m-%d_%H-%M-%S" # only relevant if no snapshot-path is given
 symlinks = false
 file-access = "read" # Default: "forbidden" for hot/cold repos, else "read"
+auth-user = "rustic" # Optional HTTP Basic Authentication user. Must be set with auth-password.
+auth-password = "secret" # Optional HTTP Basic Authentication password. Prefer RUSTIC_WEBDAV_PASSWORD over a config file or command line.
 snapshot-path = "latest:/dir" # Default: not set - if not set, generate a virtual tree with all snapshots using path-template
 
 [mount]

--- a/src/commands/webdav.rs
+++ b/src/commands/webdav.rs
@@ -17,12 +17,14 @@ use anyhow::{Result, anyhow};
 use axum::{
     Router,
     extract::{Request, State},
+    http::{HeaderValue, StatusCode, header},
     response::IntoResponse,
     routing::any,
 };
+use base64::{Engine, engine::general_purpose::STANDARD};
 use conflate::Merge;
 use dav_server::DavHandler;
-use log::info;
+use log::{info, warn};
 use serde::{Deserialize, Serialize};
 
 mod webdavfs;
@@ -56,6 +58,25 @@ pub struct WebDavCmd {
     #[merge(strategy=conflate::option::overwrite_none)]
     file_access: Option<String>,
 
+    /// User name required for WebDAV Basic Authentication
+    #[clap(long, value_name = "USER", env = "RUSTIC_WEBDAV_USER")]
+    #[merge(strategy = conflate::option::overwrite_none)]
+    auth_user: Option<String>,
+
+    /// Password required for WebDAV Basic Authentication
+    ///
+    /// # Warning
+    ///
+    /// * Using --auth-password can reveal the password in the process list.
+    #[clap(
+        long,
+        value_name = "PASSWORD",
+        env = "RUSTIC_WEBDAV_PASSWORD",
+        hide_env_values = true
+    )]
+    #[merge(strategy = conflate::option::overwrite_none)]
+    auth_password: Option<String>,
+
     /// Specify directly which snapshot/path to serve
     ///
     /// Snapshot can be identified the following ways: "01a2b3c4" or "latest" or "latest~N" (N >= 0)
@@ -79,11 +100,18 @@ impl Override<RusticConfig> for WebDavCmd {
 
 impl Runnable for WebDavCmd {
     fn run(&self) {
-        if let Err(err) = RUSTIC_APP
-            .config()
-            .repository
-            .run_indexed(|repo| self.inner_run(repo))
-        {
+        let config = RUSTIC_APP.config();
+        let result = WebDavAuth::from_options(
+            config.webdav.auth_user.as_deref(),
+            config.webdav.auth_password.as_deref(),
+        )
+        .and_then(|auth| {
+            config
+                .repository
+                .run_indexed(|repo| self.inner_run(repo, auth))
+        });
+
+        if let Err(err) = result {
             status_err!("{}", err);
             RUSTIC_APP.shutdown(Shutdown::Crash);
         };
@@ -94,7 +122,7 @@ impl WebDavCmd {
     /// be careful about self VS RUSTIC_APP.config() usage
     /// only the RUSTIC_APP.config() involves the TOML and ENV merged configurations
     /// see https://github.com/rustic-rs/rustic/issues/1242
-    fn inner_run(&self, repo: IndexedRepo) -> Result<()> {
+    fn inner_run(&self, repo: IndexedRepo, auth: Option<WebDavAuth>) -> Result<()> {
         let config = RUSTIC_APP.config();
 
         let path_template = config
@@ -147,10 +175,19 @@ impl WebDavCmd {
             .filesystem(Box::new(webdavfs))
             .build_handler();
 
+        if auth.is_some() {
+            warn!(
+                "WebDAV Basic Authentication does not encrypt credentials; use a TLS-terminating reverse proxy outside a trusted network"
+            );
+        }
+
         let app = Router::new()
             .route("/", any(handle_dav))
             .route("/{*path}", any(handle_dav))
-            .with_state(dav_server);
+            .with_state(WebDavState {
+                dav: dav_server,
+                auth,
+            });
 
         info!("serving webdav on {addr}");
         tokio::runtime::Builder::new_current_thread()
@@ -164,6 +201,128 @@ impl WebDavCmd {
     }
 }
 
-async fn handle_dav(State(dav): State<DavHandler>, req: Request) -> impl IntoResponse {
-    dav.handle(req).await
+#[derive(Clone)]
+struct WebDavState {
+    dav: DavHandler,
+    auth: Option<WebDavAuth>,
+}
+
+#[derive(Clone)]
+struct WebDavAuth {
+    credentials: Vec<u8>,
+}
+
+impl WebDavAuth {
+    fn from_options(username: Option<&str>, password: Option<&str>) -> Result<Option<Self>> {
+        match (username, password) {
+            (None, None) => Ok(None),
+            (Some(username), Some(password)) => {
+                if username.contains(':') {
+                    return Err(anyhow!(
+                        "WebDAV authentication username must not contain a colon"
+                    ));
+                }
+
+                Ok(Some(Self {
+                    credentials: format!("{username}:{password}").into_bytes(),
+                }))
+            }
+            _ => Err(anyhow!(
+                "WebDAV Basic Authentication requires both --auth-user and --auth-password"
+            )),
+        }
+    }
+
+    fn is_authorized(&self, authorization: Option<&HeaderValue>) -> bool {
+        let Some(authorization) = authorization.and_then(|header| header.to_str().ok()) else {
+            return false;
+        };
+        let Some((scheme, encoded_credentials)) = authorization.split_once(' ') else {
+            return false;
+        };
+        if !scheme.eq_ignore_ascii_case("basic") {
+            return false;
+        }
+        let Ok(credentials) = STANDARD.decode(encoded_credentials) else {
+            return false;
+        };
+
+        credentials == self.credentials
+    }
+}
+
+async fn handle_dav(State(state): State<WebDavState>, req: Request) -> impl IntoResponse {
+    if state
+        .auth
+        .as_ref()
+        .is_some_and(|auth| !auth.is_authorized(req.headers().get(header::AUTHORIZATION)))
+    {
+        return (
+            StatusCode::UNAUTHORIZED,
+            [(
+                header::WWW_AUTHENTICATE,
+                HeaderValue::from_static("Basic realm=\"rustic\""),
+            )],
+        )
+            .into_response();
+    }
+
+    state.dav.handle(req).await.into_response()
+}
+
+#[cfg(test)]
+mod tests {
+    use axum::body::Body;
+
+    use super::*;
+
+    fn authorization(value: &str) -> HeaderValue {
+        HeaderValue::from_str(value).unwrap()
+    }
+
+    #[test]
+    fn webdav_auth_is_disabled_without_both_options() {
+        assert!(WebDavAuth::from_options(None, None).unwrap().is_none());
+        assert!(WebDavAuth::from_options(Some("user"), None).is_err());
+        assert!(WebDavAuth::from_options(None, Some("password")).is_err());
+    }
+
+    #[test]
+    fn webdav_auth_rejects_colons_in_usernames() {
+        assert!(WebDavAuth::from_options(Some("user:name"), Some("password")).is_err());
+    }
+
+    #[test]
+    fn webdav_auth_accepts_only_matching_basic_credentials() {
+        let auth = WebDavAuth::from_options(Some("user"), Some("pass:word"))
+            .unwrap()
+            .unwrap();
+
+        assert!(auth.is_authorized(Some(&authorization("Basic dXNlcjpwYXNzOndvcmQ="))));
+        assert!(!auth.is_authorized(None));
+        assert!(!auth.is_authorized(Some(&authorization("Bearer token"))));
+        assert!(!auth.is_authorized(Some(&authorization("Basic malformed"))));
+        assert!(!auth.is_authorized(Some(&authorization("Basic dXNlcjp3cm9uZw=="))));
+    }
+
+    #[test]
+    fn webdav_handler_challenges_unauthenticated_requests() {
+        let state = WebDavState {
+            dav: DavHandler::builder().build_handler(),
+            auth: WebDavAuth::from_options(Some("user"), Some("password")).unwrap(),
+        };
+        let request = Request::builder().uri("/").body(Body::empty()).unwrap();
+        let response = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap()
+            .block_on(handle_dav(State(state), request))
+            .into_response();
+
+        assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+        assert_eq!(
+            response.headers()[header::WWW_AUTHENTICATE],
+            "Basic realm=\"rustic\""
+        );
+    }
 }

--- a/src/snapshots/rustic_rs__config__tests__default_config_passes.snap
+++ b/src/snapshots/rustic_rs__config__tests__default_config_passes.snap
@@ -236,6 +236,8 @@ RusticConfig {
         time_template: None,
         symlinks: false,
         file_access: None,
+        auth_user: None,
+        auth_password: None,
         snapshot_path: None,
     },
 }

--- a/src/snapshots/rustic_rs__config__tests__global_env_roundtrip_passes-3.snap
+++ b/src/snapshots/rustic_rs__config__tests__global_env_roundtrip_passes-3.snap
@@ -247,6 +247,8 @@ RusticConfig {
         time_template: None,
         symlinks: false,
         file_access: None,
+        auth_user: None,
+        auth_password: None,
         snapshot_path: None,
     },
 }


### PR DESCRIPTION
Fixes #1298

Adds explicit WebDAV Basic Authentication configuration and wires the credentials into the backend client.

Validation: cargo fmt --check; focused WebDAV tests; git diff --check.