### PR TITLE
test: cover an occupied WebDAV address

### DIFF
--- a/tests/webdav.rs
+++ b/tests/webdav.rs
@@ -1,0 +1,64 @@
+//! Regression coverage for the WebDAV command.
+
+#[cfg(feature = "webdav")]
+mod webdav {
+    use std::net::TcpListener;
+
+    use assert_cmd::Command;
+    use rustic_testing::TestResult;
+    use tempfile::{TempDir, tempdir};
+
+    fn rustic_runner(temp_dir: &TempDir) -> Command {
+        let mut runner = Command::new(env!("CARGO_BIN_EXE_rustic"));
+        runner
+            .arg("--repository")
+            .arg(temp_dir.path().join("repo"))
+            .args(["--password", "test", "--no-progress"]);
+        runner
+    }
+
+    fn setup() -> TestResult<TempDir> {
+        let temp_dir = tempdir()?;
+        rustic_runner(&temp_dir).arg("init").assert().success();
+        Ok(temp_dir)
+    }
+
+    #[test]
+    fn occupied_address_is_reported_without_a_panic() -> TestResult<()> {
+        let temp_dir = setup()?;
+        let _listener = TcpListener::bind("127.0.0.1:0")?;
+        let address = _listener.local_addr()?.to_string();
+
+        let output = rustic_runner(&temp_dir)
+            .arg("webdav")
+            .arg("--address")
+            .arg(&address)
+            .output()?;
+        let output_text = format!(
+            "stdout:\n{}\nstderr:\n{}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr),
+        );
+
+        assert!(
+            !output.status.success(),
+            "webdav unexpectedly succeeded while {address} was occupied:\n{output_text}"
+        );
+        let reports_address_in_use = output_text
+            .to_ascii_lowercase()
+            .contains("address already in use")
+            // Windows renders `ErrorKind::AddrInUse` differently, but preserves
+            // its standard operating-system error code.
+            || output_text.contains("os error 10048");
+        assert!(
+            reports_address_in_use,
+            "webdav did not report the bind failure:\n{output_text}"
+        );
+        assert!(
+            !output_text.to_ascii_lowercase().contains("panic"),
+            "webdav panicked instead of reporting the bind failure:\n{output_text}"
+        );
+
+        Ok(())
+    }
+}


### PR DESCRIPTION
Fixes #1534

Adds regression coverage for the normal error path when the WebDAV listener cannot bind because its address is already occupied. This keeps the failure observable and prevents accidental changes to startup error handling.

Validation: cargo fmt --check; focused WebDAV tests; git diff --check.