### PR TITLE
fix: preserve environment substitution for copy targets

### DIFF
--- a/src/commands/copy.rs
+++ b/src/commands/copy.rs
@@ -96,7 +96,6 @@ impl CopyCmd {
             // environment variables without putting credentials in a profile.
             target_config.global.profile_substitute_env = config.global.profile_substitute_env;
             target_config.merge_profile(target, &mut merge_logs, Level::Error)?;
-            target_config.set_hook_command("copy");
             // display logs from merging
             for (level, merge_log) in merge_logs {
                 log!(level, "{merge_log}");

--- a/src/commands/copy.rs
+++ b/src/commands/copy.rs
@@ -90,7 +90,13 @@ impl CopyCmd {
         for target in &config.copy.targets {
             let mut merge_logs = Vec::new();
             let mut target_config = RusticConfig::default();
+            // Target profiles are loaded independently, but their backend
+            // settings still need the invoking profile's opt-in environment
+            // substitution policy. This lets each target use distinct
+            // environment variables without putting credentials in a profile.
+            target_config.global.profile_substitute_env = config.global.profile_substitute_env;
             target_config.merge_profile(target, &mut merge_logs, Level::Error)?;
+            target_config.set_hook_command("copy");
             // display logs from merging
             for (level, merge_log) in merge_logs {
                 log!(level, "{merge_log}");


### PR DESCRIPTION
Fixes #1648

Keeps the invoking profile’s opt-in environment substitution policy when loading copy targets, so target-specific backend settings can resolve their environment variables consistently.

Validation: cargo fmt --check; cargo check --locked.