### PR TITLE
fix: expose the rustic command to hooks

### DIFF
--- a/src/commands.rs
+++ b/src/commands.rs
@@ -161,6 +161,43 @@ enum RusticCmd {
     Version(Box<version::VersionCmd>),
 }
 
+impl RusticCmd {
+    fn hook_command(&self) -> &'static str {
+        match self {
+            Self::Backup(_) => "backup",
+            Self::Cat(_) => "cat",
+            Self::Config(_) => "config",
+            Self::Completions(_) => "completions",
+            Self::Check(_) => "check",
+            Self::Copy(_) => "copy",
+            Self::Diff(_) => "diff",
+            Self::Docs(_) => "docs",
+            Self::Dump(_) => "dump",
+            Self::Find(_) => "find",
+            Self::Forget(_) => "forget",
+            Self::Init(_) => "init",
+            Self::Key(_) => "key",
+            Self::List(_) => "list",
+            #[cfg(feature = "mount")]
+            Self::Mount(_) => "mount",
+            Self::Ls(_) => "ls",
+            Self::Merge(_) => "merge",
+            Self::Snapshots(_) => "snapshots",
+            Self::ShowConfig(_) => "show-config",
+            Self::SelfUpdate(_) => "self-update",
+            Self::Prune(_) => "prune",
+            Self::Restore(_) => "restore",
+            Self::Rewrite(_) => "rewrite",
+            Self::Repair(_) => "repair",
+            Self::Repoinfo(_) => "repoinfo",
+            Self::Tag(_) => "tag",
+            #[cfg(feature = "webdav")]
+            Self::Webdav(_) => "webdav",
+            Self::Version(_) => "version",
+        }
+    }
+}
+
 fn styles() -> Styles {
     Styles::styled()
         .header(AnsiColor::Red.on_default() | Effects::BOLD)
@@ -293,17 +330,19 @@ impl Configurable<RusticConfig> for EntryPoint {
             }
         }
 
-        match &self.commands {
-            RusticCmd::Forget(cmd) => cmd.override_config(config),
-            RusticCmd::Copy(cmd) => cmd.override_config(config),
+        let mut config = match &self.commands {
+            RusticCmd::Forget(cmd) => cmd.override_config(config)?,
+            RusticCmd::Copy(cmd) => cmd.override_config(config)?,
             #[cfg(feature = "webdav")]
-            RusticCmd::Webdav(cmd) => cmd.override_config(config),
+            RusticCmd::Webdav(cmd) => cmd.override_config(config)?,
             #[cfg(feature = "mount")]
-            RusticCmd::Mount(cmd) => cmd.override_config(config),
+            RusticCmd::Mount(cmd) => cmd.override_config(config)?,
 
             // subcommands that don't need special overrides use a catch all
-            _ => Ok(config),
-        }
+            _ => config,
+        };
+        config.set_hook_command(self.commands.hook_command());
+        Ok(config)
     }
 }
 

--- a/src/commands/backup.rs
+++ b/src/commands/backup.rs
@@ -171,6 +171,13 @@ pub struct BackupCmd {
 }
 
 impl BackupCmd {
+    pub(crate) fn set_hook_command(&mut self, command: &str) {
+        self.hooks = self.hooks.with_command(command);
+        for snapshot in &mut self.snapshots {
+            snapshot.set_hook_command(command);
+        }
+    }
+
     fn validate(&self) -> Result<(), &str> {
         // manually check for a "source" field, check is not done by serde, see above.
         if !self.sources.is_empty() {

--- a/src/config.rs
+++ b/src/config.rs
@@ -103,6 +103,12 @@ impl Display for RusticConfig {
 }
 
 impl RusticConfig {
+    pub(crate) fn set_hook_command(&mut self, command: &str) {
+        self.global.hooks = self.global.hooks.with_command(command);
+        self.repository.hooks = self.repository.hooks.with_command(command);
+        self.backup.set_hook_command(command);
+    }
+
     /// Merge a profile into the current config by reading the corresponding config file.
     /// Also recursively merge all profiles given within this config file.
     ///

--- a/src/config/hooks.rs
+++ b/src/config/hooks.rs
@@ -46,12 +46,22 @@ pub struct Hooks {
     #[serde(skip)]
     #[merge(skip)]
     pub env: HashMap<String, String>,
+
+    #[serde(skip)]
+    #[merge(strategy = conflate::option::overwrite_none)]
+    command: Option<String>,
 }
 
 impl Hooks {
     pub fn with_context(&self, context: &str) -> Self {
         let mut hooks = self.clone();
         hooks.context = context.to_string();
+        hooks
+    }
+
+    pub fn with_command(&self, command: &str) -> Self {
+        let mut hooks = self.clone();
+        hooks.command = Some(command.to_string());
         hooks
     }
 
@@ -69,8 +79,13 @@ impl Hooks {
         context: &str,
         what: &str,
         env: &HashMap<String, String>,
+        command: Option<&str>,
     ) -> Result<()> {
         let mut env = env.clone();
+
+        if let Some(command) = command {
+            _ = env.insert("RUSTIC_COMMAND".to_string(), command.to_string());
+        }
 
         let _ = env.insert("RUSTIC_HOOK_TYPE".to_string(), what.to_string());
 
@@ -82,19 +97,43 @@ impl Hooks {
     }
 
     pub fn run_before(&self) -> Result<()> {
-        Self::run_all(&self.run_before, &self.context, "run-before", &self.env)
+        Self::run_all(
+            &self.run_before,
+            &self.context,
+            "run-before",
+            &self.env,
+            self.command.as_deref(),
+        )
     }
 
     pub fn run_after(&self) -> Result<()> {
-        Self::run_all(&self.run_after, &self.context, "run-after", &self.env)
+        Self::run_all(
+            &self.run_after,
+            &self.context,
+            "run-after",
+            &self.env,
+            self.command.as_deref(),
+        )
     }
 
     pub fn run_failed(&self) -> Result<()> {
-        Self::run_all(&self.run_failed, &self.context, "run-failed", &self.env)
+        Self::run_all(
+            &self.run_failed,
+            &self.context,
+            "run-failed",
+            &self.env,
+            self.command.as_deref(),
+        )
     }
 
     pub fn run_finally(&self) -> Result<()> {
-        Self::run_all(&self.run_finally, &self.context, "run-finally", &self.env)
+        Self::run_all(
+            &self.run_finally,
+            &self.context,
+            "run-finally",
+            &self.env,
+            self.command.as_deref(),
+        )
     }
 
     /// Run the given closure using the specified hooks.

--- a/src/snapshots/rustic_rs__config__tests__default_config_passes.snap
+++ b/src/snapshots/rustic_rs__config__tests__default_config_passes.snap
@@ -29,6 +29,7 @@ RusticConfig {
             run_finally: [],
             context: "",
             env: {},
+            command: None,
         },
         env: {},
         prometheus: None,
@@ -70,6 +71,7 @@ RusticConfig {
             run_finally: [],
             context: "",
             env: {},
+            command: None,
         },
     },
     snapshot_filter: SnapshotFilter {
@@ -169,6 +171,7 @@ RusticConfig {
             run_finally: [],
             context: "",
             env: {},
+            command: None,
         },
         snapshots: [],
         sources: [],

--- a/src/snapshots/rustic_rs__config__tests__global_env_roundtrip_passes-3.snap
+++ b/src/snapshots/rustic_rs__config__tests__global_env_roundtrip_passes-3.snap
@@ -29,6 +29,7 @@ RusticConfig {
             run_finally: [],
             context: "",
             env: {},
+            command: None,
         },
         env: {
             "KEY0": "VALUE0",
@@ -81,6 +82,7 @@ RusticConfig {
             run_finally: [],
             context: "",
             env: {},
+            command: None,
         },
     },
     snapshot_filter: SnapshotFilter {
@@ -180,6 +182,7 @@ RusticConfig {
             run_finally: [],
             context: "",
             env: {},
+            command: None,
         },
         snapshots: [],
         sources: [],


### PR DESCRIPTION
Fixes #1578

Sets RUSTIC_COMMAND for hooks based on the top-level rustic subcommand, including backup snapshot hooks. This makes hook scripts able to distinguish backup, restore, copy, and other command contexts reliably.

Validation: cargo fmt; cargo check --locked.