### PR TITLE
feat: select backup sources by marker file

### DIFF
--- a/config/README.md
+++ b/config/README.md
@@ -244,6 +244,7 @@ can be overwritten in the source-specific configuration, see below.
 | iglob-files        | Like glob-file, but apply case-insensitive                                                                     | []                       |               | --iglob-file            |
 | ignore-ctime       | If true, ignore file change time (ctime).                                                                      | false                    |               | --ignore-ctime          |
 | ignore-inode       | If true, ignore file inode for the backup.                                                                     | false                    |               | --ignore-inode          |
+| include-if-present | Back up only local directory trees containing this marker filename.                                            | Not set                  | ".rustic-include" | --include-if-present    |
 | init               | If true, initialize repository if it doesn't exist, yet.                                                       | false                    |               | --init                  |
 | json               | If true, returns output of the command as json.                                                                | false                    |               | --json                  |
 | label              | Set label for the snapshot.                                                                                    | Not set                  |               | --label                 |

--- a/config/full.toml
+++ b/config/full.toml
@@ -134,6 +134,7 @@ force = false
 ignore-ctime = false
 ignore-inode = false
 stdin-command = "echo test" # Default: empty
+include-if-present = ".rustic-include" # Default: not set; local directory sources only
 stdin-filename = "stdin" # Only for stdin source
 as-path = "/my/path" # Default: not set; Note: This only works if source contains of a single path.
 set-atime = "mtime" # Allowed: "yes", "no", "mtime"

--- a/src/commands/backup.rs
+++ b/src/commands/backup.rs
@@ -1,8 +1,8 @@
 //! `backup` subcommand
 
-use std::collections::HashMap;
+use std::collections::{BTreeSet, HashMap};
 use std::fmt::Display;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::{collections::BTreeMap, env};
 
 use crate::commands::ls::LsCmd;
@@ -77,6 +77,11 @@ pub struct BackupCmd {
     #[clap(long, value_name = "COMMAND")]
     #[merge(strategy=conflate::option::overwrite_none)]
     stdin_command: Option<CommandInput>,
+
+    /// Only back up directory trees marked by this filename.
+    #[clap(long, value_name = "FILENAME", value_hint = ValueHint::FilePath)]
+    #[merge(strategy=conflate::option::overwrite_none)]
+    include_if_present: Option<PathBuf>,
 
     /// Manually set backup path in snapshot
     #[clap(long, value_name = "PATH", value_hint = ValueHint::DirPath)]
@@ -171,6 +176,54 @@ pub struct BackupCmd {
 }
 
 impl BackupCmd {
+    fn sources_with_marker(source: &PathList, marker: &Path) -> Result<Option<PathList>> {
+        if marker.components().count() != 1 || marker.file_name().is_none() {
+            bail!(
+                "`include-if-present` must be a single filename, not a path: `{}`",
+                marker.display()
+            );
+        }
+
+        let mut marked_sources = BTreeSet::new();
+        for root in source.paths() {
+            let metadata = std::fs::symlink_metadata(&root).with_context(|| {
+                format!(
+                    "failed to inspect source `{}` for include marker `{}`",
+                    root.display(),
+                    marker.display()
+                )
+            })?;
+            if !metadata.file_type().is_dir() {
+                bail!(
+                    "`include-if-present` only supports local directory sources; `{}` is not a directory",
+                    root.display()
+                );
+            }
+            Self::find_marked_sources(&root, marker, &mut marked_sources)?;
+        }
+
+        Ok((!marked_sources.is_empty()).then(|| marked_sources.into_iter().collect()))
+    }
+
+    fn find_marked_sources(
+        directory: &Path,
+        marker: &Path,
+        marked_sources: &mut BTreeSet<PathBuf>,
+    ) -> Result<()> {
+        if directory.join(marker).is_file() {
+            let _ = marked_sources.insert(directory.to_path_buf());
+            return Ok(());
+        }
+
+        for entry in std::fs::read_dir(directory)? {
+            let entry = entry?;
+            if entry.file_type()?.is_dir() {
+                Self::find_marked_sources(&entry.path(), marker, marked_sources)?;
+            }
+        }
+        Ok(())
+    }
+
     fn validate(&self) -> Result<(), &str> {
         // manually check for a "source" field, check is not done by serde, see above.
         if !self.sources.is_empty() {
@@ -437,6 +490,24 @@ impl BackupCmd {
 
         // merge "backup" section from config file, if given
         self.merge(config.backup.clone());
+
+        let source = if let Some(marker) = &self.include_if_present {
+            if self.as_path.is_some() {
+                bail!("`include-if-present` cannot be combined with `as-path`");
+            }
+            match Self::sources_with_marker(&source, marker)? {
+                Some(source) => source,
+                None => {
+                    info!(
+                        "skipping backup: no `{}` marker was found below {source}",
+                        marker.display()
+                    );
+                    return Ok(());
+                }
+            }
+        } else {
+            source
+        };
 
         let hooks = self.hooks(&hooks, "source-specific-backup", &source);
 

--- a/src/commands/backup.rs
+++ b/src/commands/backup.rs
@@ -834,3 +834,43 @@ fn publish_metrics(
 
     Ok(())
 }
+
+#[cfg(test)]
+mod include_if_present_tests {
+    use super::*;
+
+    #[test]
+    fn marker_selects_only_marked_directory_trees() -> Result<()> {
+        let temp = tempfile::tempdir()?;
+        let marked = temp.path().join("marked");
+        let unmarked = temp.path().join("unmarked");
+        std::fs::create_dir_all(&marked)?;
+        std::fs::create_dir_all(&unmarked)?;
+        std::fs::write(marked.join(".rustic-include"), "")?;
+
+        let sources = PathList::from_iter([temp.path()]);
+        let selected = BackupCmd::sources_with_marker(&sources, Path::new(".rustic-include"))?
+            .expect("marker should select a source");
+
+        assert_eq!(selected.paths(), vec![marked]);
+        Ok(())
+    }
+
+    #[test]
+    fn missing_marker_skips_the_source() -> Result<()> {
+        let temp = tempfile::tempdir()?;
+        let sources = PathList::from_iter([temp.path()]);
+
+        assert!(BackupCmd::sources_with_marker(&sources, Path::new(".rustic-include"))?.is_none());
+        Ok(())
+    }
+
+    #[test]
+    fn marker_must_be_a_filename() {
+        let sources = PathList::default();
+        let error = BackupCmd::sources_with_marker(&sources, Path::new("nested/marker"))
+            .expect_err("paths must be rejected");
+
+        assert!(error.to_string().contains("must be a single filename"));
+    }
+}

--- a/src/snapshots/rustic_rs__config__tests__default_config_passes.snap
+++ b/src/snapshots/rustic_rs__config__tests__default_config_passes.snap
@@ -93,6 +93,7 @@ RusticConfig {
         name: None,
         stdin_filename: None,
         stdin_command: None,
+        include_if_present: None,
         as_path: None,
         no_scan: false,
         json: false,

--- a/src/snapshots/rustic_rs__config__tests__global_env_roundtrip_passes-3.snap
+++ b/src/snapshots/rustic_rs__config__tests__global_env_roundtrip_passes-3.snap
@@ -104,6 +104,7 @@ RusticConfig {
         name: None,
         stdin_filename: None,
         stdin_command: None,
+        include_if_present: None,
         as_path: None,
         no_scan: false,
         json: false,


### PR DESCRIPTION
## Summary

Adds `--include-if-present` to select local directory trees containing a marker filename.

## Validation

- 3 marker selection/rejection unit tests
- Configuration reference and full-profile example
- `cargo clippy --locked --all-targets --features release -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`
- `typos`

Fixes #1382.