### PR TITLE
feat: support source-level skip-if-command

### DIFF
--- a/config/README.md
+++ b/config/README.md
@@ -252,6 +252,7 @@ can be overwritten in the source-specific configuration, see below.
 | one-file-system    | If true, only backs up files from the same filesystem as the source.                                           | false                    |               | --one-file-system       |
 | parents            | Parent snapshot(s) for the backup.                                                                             | Not set                  |               | --parent                |
 | skip-if-unchanged  | Skip saving of the snapshot if it is identical to the parent.                                                  | false                    |               | --skip-identical-parent |
+| skip-if-command    | Run a config-only command; skip when it writes exactly "skip", continue when it writes nothing.                | Not set                  | "test -f /mnt/ready && printf skip" | |
 | stdin-command      | Call this command and use it's stdout as stdin to backup.                                                      | Not set                  |               | --stdin-command         |
 | stdin-filename     | File name to be used when reading from stdin.                                                                  | Not set                  |               | --stdin-filename        |
 | tags               | Array of tags for the backup.                                                                                  | []                       |               | --tag                   |

--- a/config/full.toml
+++ b/config/full.toml
@@ -134,6 +134,7 @@ force = false
 ignore-ctime = false
 ignore-inode = false
 stdin-command = "echo test" # Default: empty
+skip-if-command = "test -f /mnt/ready && printf skip" # Default: not set; config only
 stdin-filename = "stdin" # Only for stdin source
 as-path = "/my/path" # Default: not set; Note: This only works if source contains of a single path.
 set-atime = "mtime" # Allowed: "yes", "no", "mtime"

--- a/src/commands/backup.rs
+++ b/src/commands/backup.rs
@@ -78,6 +78,11 @@ pub struct BackupCmd {
     #[merge(strategy=conflate::option::overwrite_none)]
     stdin_command: Option<CommandInput>,
 
+    /// Skip this source when the configured command writes `skip` to stdout.
+    #[clap(skip)]
+    #[merge(strategy=conflate::option::overwrite_none)]
+    skip_if_command: Option<CommandInput>,
+
     /// Manually set backup path in snapshot
     #[clap(long, value_name = "PATH", value_hint = ValueHint::DirPath)]
     #[merge(strategy=conflate::option::overwrite_none)]
@@ -171,6 +176,35 @@ pub struct BackupCmd {
 }
 
 impl BackupCmd {
+    fn should_skip_backup(&self, source: &PathList) -> Result<bool> {
+        let Some(command) = &self.skip_if_command else {
+            return Ok(false);
+        };
+        if !command.is_set() {
+            return Ok(false);
+        }
+
+        let output = std::process::Command::new(command.command())
+            .args(command.args())
+            .env("RUSTIC_COMMAND", "backup")
+            .env("RUSTIC_ACTION", "source-specific-backup")
+            .env("RUSTIC_BACKUP_SOURCES", source.to_string())
+            .stderr(std::process::Stdio::inherit())
+            .output()
+            .context("failed to run `skip-if-command`")?;
+        if !output.status.success() {
+            bail!("`skip-if-command` exited with status {}", output.status);
+        }
+
+        let directive = output.stdout.strip_suffix(b"\n").unwrap_or(&output.stdout);
+        let directive = directive.strip_suffix(b"\r").unwrap_or(directive);
+        match directive {
+            b"" => Ok(false),
+            b"skip" => Ok(true),
+            _ => bail!("`skip-if-command` must write exactly `skip` or nothing to stdout"),
+        }
+    }
+
     fn validate(&self) -> Result<(), &str> {
         // manually check for a "source" field, check is not done by serde, see above.
         if !self.sources.is_empty() {
@@ -437,6 +471,11 @@ impl BackupCmd {
 
         // merge "backup" section from config file, if given
         self.merge(config.backup.clone());
+
+        if self.should_skip_backup(&source)? {
+            info!("skipping backup of {source} at the request of `skip-if-command`");
+            return Ok(());
+        }
 
         let hooks = self.hooks(&hooks, "source-specific-backup", &source);
 

--- a/src/commands/backup.rs
+++ b/src/commands/backup.rs
@@ -802,3 +802,61 @@ fn publish_metrics(
 
     Ok(())
 }
+
+#[cfg(test)]
+mod skip_if_command_tests {
+    use super::*;
+
+    #[cfg(unix)]
+    fn command(output: &str, status: i32) -> CommandInput {
+        CommandInput::from(vec![
+            "sh".to_string(),
+            "-c".to_string(),
+            format!("printf %s {output}; exit {status}"),
+        ])
+    }
+
+    #[cfg(windows)]
+    fn command(output: &str, status: i32) -> CommandInput {
+        CommandInput::from(vec![
+            "cmd".to_string(),
+            "/C".to_string(),
+            format!("<nul set /p ={output} & exit /b {status}"),
+        ])
+    }
+
+    fn backup_with(command: CommandInput) -> BackupCmd {
+        BackupCmd {
+            skip_if_command: Some(command),
+            ..BackupCmd::default()
+        }
+    }
+
+    #[test]
+    fn skip_directive_skips_source() -> Result<()> {
+        assert!(backup_with(command("skip", 0)).should_skip_backup(&PathList::default())?);
+        Ok(())
+    }
+
+    #[test]
+    fn empty_output_continues_backup() -> Result<()> {
+        assert!(!backup_with(command("", 0)).should_skip_backup(&PathList::default())?);
+        Ok(())
+    }
+
+    #[test]
+    fn unexpected_output_is_rejected() {
+        let error = backup_with(command("maybe", 0))
+            .should_skip_backup(&PathList::default())
+            .expect_err("unexpected output must fail");
+        assert!(error.to_string().contains("exactly `skip` or nothing"));
+    }
+
+    #[test]
+    fn command_failure_is_rejected() {
+        let error = backup_with(command("", 7))
+            .should_skip_backup(&PathList::default())
+            .expect_err("command failure must fail");
+        assert!(error.to_string().contains("exited with status"));
+    }
+}

--- a/src/snapshots/rustic_rs__config__tests__default_config_passes.snap
+++ b/src/snapshots/rustic_rs__config__tests__default_config_passes.snap
@@ -93,6 +93,7 @@ RusticConfig {
         name: None,
         stdin_filename: None,
         stdin_command: None,
+        skip_if_command: None,
         as_path: None,
         no_scan: false,
         json: false,

--- a/src/snapshots/rustic_rs__config__tests__global_env_roundtrip_passes-3.snap
+++ b/src/snapshots/rustic_rs__config__tests__global_env_roundtrip_passes-3.snap
@@ -104,6 +104,7 @@ RusticConfig {
         name: None,
         stdin_filename: None,
         stdin_command: None,
+        skip_if_command: None,
         as_path: None,
         no_scan: false,
         json: false,


### PR DESCRIPTION
## Summary

Adds the profile-only `skip-if-command` protocol: exact `skip` omits a source, empty output continues, and other output or command failure stops with an error.

## Validation

- 4 directive/failure unit tests
- Configuration reference and full-profile example
- `cargo clippy --locked --all-targets --features release -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`
- `typos`

Fixes #1524.