### PR TITLE
fix: apply snapshot filters to configured backups

### DIFF
--- a/src/commands/backup.rs
+++ b/src/commands/backup.rs
@@ -275,6 +275,8 @@ impl BackupCmd {
 
     fn get_snapshots_to_backup(&self) -> Result<Vec<(Self, PathList)>> {
         let config = RUSTIC_APP.config();
+        let mut shared_tags = StringList::default();
+        shared_tags.add_all(config.backup.snap_opts.tags.clone());
         let mut config_snapshots = config
             .backup
             .snapshots
@@ -300,6 +302,11 @@ impl BackupCmd {
                         .name
                         .as_ref()
                         .is_some_and(|name| self.cli_name.contains(name))
+            })
+            .filter(|(opt, sources)| {
+                let mut tags = shared_tags.clone();
+                tags.add_all(opt.snap_opts.tags.clone());
+                config.snapshot_filter.matches_backup_config(sources, &tags)
             })
             .map(|(opt, sources)| (self.clone().merge_from(opt), sources))
             .collect();

--- a/src/filtering.rs
+++ b/src/filtering.rs
@@ -15,7 +15,7 @@ use derive_more::derive::Display;
 use jiff::{Zoned, civil::Time, tz::TimeZone};
 use log::warn;
 use rustic_core::{
-    StringList,
+    PathList, StringList,
     repofile::{RusticTime, SnapshotFile},
 };
 
@@ -285,20 +285,30 @@ impl SnapshotFilter {
             return false;
         }
 
+        self.matches_paths_and_tags(&snapshot.paths, &snapshot.tags)
+            && (self.filter_hosts.is_empty() || self.filter_hosts.contains(&snapshot.hostname))
+            && (self.filter_labels.is_empty() || self.filter_labels.contains(&snapshot.label))
+    }
+
+    pub(crate) fn matches_backup_config(&self, sources: &PathList, tags: &StringList) -> bool {
+        let mut paths = StringList::default();
+        for path in sources.paths() {
+            paths.add(path.to_string_lossy().into_owned());
+        }
+        self.matches_paths_and_tags(&paths, tags)
+    }
+
+    fn matches_paths_and_tags(&self, paths: &StringList, tags: &StringList) -> bool {
         // For the the `Vec`s we have two possibilities:
         // - There exists a suitable matches method on the snapshot item
         //   (this automatically handles empty filter correctly):
-        snapshot.paths.matches(&self.filter_paths)
-            && snapshot.tags.matches(&self.filter_tags)
+        paths.matches(&self.filter_paths)
+            && tags.matches(&self.filter_tags)
         //  - manually check if the snapshot item is contained in the `Vec`
         //    but only if the `Vec` is not empty.
         //    If it is empty, no condition is given.
-            && (self.filter_paths_exact.is_empty()
-                || self.filter_paths_exact.contains(&snapshot.paths))
-            && (self.filter_tags_exact.is_empty()
-                || self.filter_tags_exact.contains(&snapshot.tags))
-            && (self.filter_hosts.is_empty() || self.filter_hosts.contains(&snapshot.hostname))
-            && (self.filter_labels.is_empty() || self.filter_labels.contains(&snapshot.label))
+            && (self.filter_paths_exact.is_empty() || self.filter_paths_exact.contains(paths))
+            && (self.filter_tags_exact.is_empty() || self.filter_tags_exact.contains(tags))
     }
 
     pub fn post_process(&self, snapshots: &mut Vec<SnapshotFile>) {


### PR DESCRIPTION
Fixes #1638

Applies path and tag snapshot filters when rustic selects configured backup sources, while leaving time, size, host, and label filters for historical snapshots only.

Validation: cargo fmt; cargo check --locked.