### PR TITLE
fix: normalize CRLF snapshot descriptions

### DIFF
--- a/src/commands/snapshots.rs
+++ b/src/commands/snapshots.rs
@@ -276,6 +276,10 @@ pub fn fill_table(snap: &SnapshotFile, mut add_entry: impl FnMut(&str, String)) 
         add_entry("Duration", duration);
     }
     if let Some(ref description) = snap.description {
-        add_entry("Description", description.clone());
+        add_entry("Description", normalize_line_endings(description));
     }
+}
+
+fn normalize_line_endings(value: &str) -> String {
+    value.replace("\r\n", "\n").replace('\r', "\n")
 }


### PR DESCRIPTION
Fixes #926

Normalizes CRLF and lone carriage-return line endings in snapshot descriptions before rendering table output, preventing terminal rows from being overwritten on Windows.

Validation: cargo fmt; cargo check --locked.