### PR TITLE
fix: merge backup tags across profiles

### DIFF
--- a/src/commands/backup.rs
+++ b/src/commands/backup.rs
@@ -171,6 +171,13 @@ pub struct BackupCmd {
 }
 
 impl BackupCmd {
+    pub(crate) fn merge_with_tags(&mut self, other: Self) {
+        let mut tags = std::mem::take(&mut self.snap_opts.tags);
+        tags.extend(other.snap_opts.tags.iter().cloned());
+        self.merge(other);
+        self.snap_opts.tags = tags;
+    }
+
     fn validate(&self) -> Result<(), &str> {
         // manually check for a "source" field, check is not done by serde, see above.
         if !self.sources.is_empty() {
@@ -287,7 +294,7 @@ impl BackupCmd {
             // merge Options from config file, if given
             if let Some((config_opts, _)) = config_snapshots.find(|(_, s)| s == &sources) {
                 info!("merging sources={sources} section from config file");
-                opts.merge(config_opts);
+                opts.merge_with_tags(config_opts);
             }
             return Ok(vec![(opts, sources)]);
         }
@@ -301,7 +308,11 @@ impl BackupCmd {
                         .as_ref()
                         .is_some_and(|name| self.cli_name.contains(name))
             })
-            .map(|(opt, sources)| (self.clone().merge_from(opt), sources))
+            .map(|(opt, sources)| {
+                let mut backup = self.clone();
+                backup.merge_with_tags(opt);
+                (backup, sources)
+            })
             .collect();
 
         if config_snapshots.is_empty() {
@@ -428,7 +439,7 @@ impl BackupCmd {
                     .position(|opt| opt.sources == vec![path])
             {
                 info!("merging snapshot=\"{path}\" section from config file");
-                self.merge(snapshot_opts[idx].clone());
+                self.merge_with_tags(snapshot_opts[idx].clone());
             }
         }
 
@@ -436,7 +447,7 @@ impl BackupCmd {
         let hooks = self.hooks.clone();
 
         // merge "backup" section from config file, if given
-        self.merge(config.backup.clone());
+        self.merge_with_tags(config.backup.clone());
 
         let hooks = self.hooks(&hooks, "source-specific-backup", &source);
 

--- a/src/commands/backup.rs
+++ b/src/commands/backup.rs
@@ -21,7 +21,7 @@ use abscissa_core::{Command, Runnable, Shutdown};
 use anyhow::{Context, Result, anyhow, bail};
 use clap::ValueHint;
 use comfy_table::Cell;
-use conflate::{Merge, MergeFrom};
+use conflate::Merge;
 use log::{debug, error, info, warn};
 use rustic_backend::OpenDALBackend;
 use rustic_core::{ChildStdoutSource, Excludes, LocalSource, ReadSource, StdinSource, StringList};

--- a/src/config.rs
+++ b/src/config.rs
@@ -103,6 +103,12 @@ impl Display for RusticConfig {
 }
 
 impl RusticConfig {
+    pub(crate) fn merge_with_backup_tags(&mut self, mut other: Self) {
+        let backup = std::mem::take(&mut other.backup);
+        self.merge(other);
+        self.backup.merge_with_tags(backup);
+    }
+
     /// Merge a profile into the current config by reading the corresponding config file.
     /// Also recursively merge all profiles given within this config file.
     ///
@@ -146,7 +152,7 @@ impl RusticConfig {
             for profile in &config.global.use_profiles.clone() {
                 config.merge_profile(profile, merge_logs, Level::Warn)?;
             }
-            self.merge(config);
+            self.merge_with_backup_tags(config);
         } else {
             let paths_string = paths.iter().map(|path| path.display()).join(", ");
             merge_logs.push((


### PR DESCRIPTION
## Summary

Combines backup tags from the command profile, configured source, snapshot options, and CLI without changing other option precedence.

## Validation

- `cargo clippy --locked --all-targets --features release -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`
- `typos`

Fixes #1438.