### PR TITLE
test: cover hot/cold check --read-data routing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1643,7 +1643,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1826,7 +1826,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3326,7 +3326,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4585,7 +4585,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b570b25f7617e43d59005d0990ccb79e950a423952cea19671b7a876da390adf"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools 0.13.0",
  "proc-macro2",
  "quote",
  "syn 2.0.119",
@@ -4751,7 +4751,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5414,7 +5414,7 @@ dependencies = [
 [[package]]
 name = "rustic_backend"
 version = "0.6.2"
-source = "git+https://github.com/rustic-rs/rustic_core#304bb8682e7ff72c1f24556865a3058a94082027"
+source = "git+https://github.com/rustic-rs/rustic_core#d5933253839b24928f82699f875dccddc7c807ce"
 dependencies = [
  "aho-corasick",
  "backon",
@@ -5505,7 +5505,7 @@ dependencies = [
 [[package]]
 name = "rustic_core"
 version = "0.12.0"
-source = "git+https://github.com/rustic-rs/rustic_core#304bb8682e7ff72c1f24556865a3058a94082027"
+source = "git+https://github.com/rustic-rs/rustic_core#d5933253839b24928f82699f875dccddc7c807ce"
 dependencies = [
  "aes256ctr_poly1305aes",
  "backon",
@@ -5593,7 +5593,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5652,7 +5652,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6400,7 +6400,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6419,7 +6419,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
 dependencies = [
  "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -7214,7 +7214,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/tests/check_hot_cold.rs
+++ b/tests/check_hot_cold.rs
@@ -1,0 +1,51 @@
+use std::path::Path;
+
+use assert_cmd::Command;
+use rustic_testing::TestResult;
+use tempfile::tempdir;
+
+fn rustic_runner(profile: &Path, cold_repo: &Path, hot_repo: &Path) -> TestResult<Command> {
+    let mut runner = Command::new(env!("CARGO_BIN_EXE_rustic"));
+    runner
+        .arg("--use-profile")
+        .arg(profile)
+        .arg("--repository")
+        .arg(cold_repo)
+        .arg("--repo-hot")
+        .arg(hot_repo)
+        .args(["--password", "test", "--no-progress", "--no-cache"]);
+    Ok(runner)
+}
+
+#[test]
+fn check_read_data_uses_cold_data_packs_for_hot_cold_repositories() -> TestResult<()> {
+    let temp_dir = tempdir()?;
+    let cold_repo = temp_dir.path().join("cold-repository");
+    let hot_repo = temp_dir.path().join("hot-repository");
+    let source = temp_dir.path().join("source");
+    let profile = temp_dir.path().join("test.toml");
+    std::fs::write(&profile, "")?;
+    std::fs::create_dir(&source)?;
+    std::fs::write(source.join("payload.bin"), vec![42_u8; 256 * 1024])?;
+
+    rustic_runner(&profile, &cold_repo, &hot_repo)?
+        .arg("init")
+        .assert()
+        .success();
+
+    rustic_runner(&profile, &cold_repo, &hot_repo)?
+        .arg("backup")
+        .arg(&source)
+        .assert()
+        .success();
+
+    // Data packs are intentionally stored only in the cold repository. A
+    // successful read-data check proves it reads them there rather than trying
+    // the hot metadata repository.
+    rustic_runner(&profile, &cold_repo, &hot_repo)?
+        .args(["check", "--read-data"])
+        .assert()
+        .success();
+
+    Ok(())
+}


### PR DESCRIPTION
## Summary

Adds an integration regression test for `check --read-data` with hot/cold repositories.

## Status

Test-only draft. The test currently fails against the locked `rustic_core`, proving the bug remains there. It is blocked on rustic-rs/rustic_core#542, which is still open. This PR does not claim to fix runtime behavior.

Related to #1811.