### PR TITLE
fix: keep restore JSON progress on stdout

### DIFF
--- a/src/commands/restore.rs
+++ b/src/commands/restore.rs
@@ -72,15 +72,29 @@ impl RestoreCmd {
         let restore_infos = repo.prepare_restore(&self.opts, ls, &dest, dry_run)?;
 
         let fs = restore_infos.stats.files;
-        println!(
-            "Files:  {} to restore, {} unchanged, {} verified, {} to modify, {} additional",
-            fs.restore, fs.unchanged, fs.verified, fs.modify, fs.additional
-        );
         let ds = restore_infos.stats.dirs;
-        println!(
-            "Dirs:   {} to restore, {} to modify, {} additional",
-            ds.restore, ds.modify, ds.additional
-        );
+        if config.global.progress_options.json_progress {
+            // `--json-progress` reserves stdout for newline-delimited JSON.
+            // Keep the human-readable plan available through the normal log
+            // stream (stderr) without corrupting a consumer's JSON input.
+            info!(
+                "Files:  {} to restore, {} unchanged, {} verified, {} to modify, {} additional",
+                fs.restore, fs.unchanged, fs.verified, fs.modify, fs.additional
+            );
+            info!(
+                "Dirs:   {} to restore, {} to modify, {} additional",
+                ds.restore, ds.modify, ds.additional
+            );
+        } else {
+            println!(
+                "Files:  {} to restore, {} unchanged, {} verified, {} to modify, {} additional",
+                fs.restore, fs.unchanged, fs.verified, fs.modify, fs.additional
+            );
+            println!(
+                "Dirs:   {} to restore, {} to modify, {} additional",
+                ds.restore, ds.modify, ds.additional
+            );
+        }
 
         info!(
             "total restore size: {}",
@@ -104,7 +118,11 @@ impl RestoreCmd {
 
             let ls = repo.ls(&node, &ls_opts)?;
             repo.restore(restore_infos, &self.opts, ls, &dest)?;
-            println!("restore done.");
+            if config.global.progress_options.json_progress {
+                info!("restore done.");
+            } else {
+                println!("restore done.");
+            }
         } else {
             debug!(
                 "--dry-run is without warmup, --dry-run --dry-run-warmup also issues the warmup script."

--- a/tests/backup_restore.rs
+++ b/tests/backup_restore.rs
@@ -34,6 +34,23 @@ pub fn rustic_runner(temp_dir: &TempDir) -> TestResult<Command> {
     Ok(runner)
 }
 
+fn rustic_runner_with_json_progress(temp_dir: &TempDir) -> TestResult<Command> {
+    let password = "test";
+    let repo_dir = temp_dir.path().join("repo");
+
+    let mut runner = Command::new(env!("CARGO_BIN_EXE_rustic"));
+
+    runner
+        .arg("-r")
+        .arg(repo_dir)
+        .arg("--password")
+        .arg(password)
+        .arg("--json-progress")
+        .args(["--progress-interval", "1ms"]);
+
+    Ok(runner)
+}
+
 fn setup() -> TestResult<TempDir> {
     let temp_dir = tempdir()?;
     rustic_runner(&temp_dir)?
@@ -122,6 +139,49 @@ fn test_backup_records_cli_version_in_snapshot() -> TestResult<()> {
     let snapshot: serde_json::Value = serde_json::from_slice(&backup_output.stdout)?;
 
     assert_eq!(snapshot["program_version"].as_str(), Some(version.trim()));
+
+    Ok(())
+}
+
+#[test]
+fn restore_json_progress_writes_only_newline_delimited_json_to_stdout() -> TestResult<()> {
+    let temp_dir = setup()?;
+    let source = temp_dir.path().join("source");
+    std::fs::create_dir(&source)?;
+    std::fs::write(source.join("payload.bin"), vec![0_u8; 256 * 1024])?;
+
+    rustic_runner(&temp_dir)?
+        .arg("backup")
+        .arg(&source)
+        .assert()
+        .success();
+
+    let output = rustic_runner_with_json_progress(&temp_dir)?
+        .args(["restore", "latest"])
+        .arg(temp_dir.path().join("restore"))
+        .output()?;
+
+    assert!(
+        output.status.success(),
+        "restore command failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stdout = String::from_utf8(output.stdout)?;
+    let events = stdout
+        .lines()
+        .filter(|line| !line.is_empty())
+        .map(serde_json::from_str::<serde_json::Value>)
+        .collect::<Result<Vec<_>, _>>()?;
+
+    assert!(
+        !events.is_empty(),
+        "restore --json-progress did not produce progress events"
+    );
+    assert!(
+        events.iter().all(|event| event["message_type"] == "status"),
+        "unexpected restore JSON progress output: {stdout}"
+    );
 
     Ok(())
 }


### PR DESCRIPTION
Fixes #1441

Keeps restore plan and completion messages on the log stream when --json-progress is enabled, reserving stdout for newline-delimited JSON progress events.

Validation: cargo fmt --check; focused restore JSON-progress test attempted in an isolated target; git diff --check.