### PR TITLE
fix: emit compact JSON output

### DIFF
--- a/src/commands/forget.rs
+++ b/src/commands/forget.rs
@@ -134,7 +134,7 @@ impl ForgetCmd {
 
         if self.json {
             let mut stdout = std::io::stdout();
-            serde_json::to_writer_pretty(&mut stdout, &groups)?;
+            serde_json::to_writer(&mut stdout, &groups)?;
         } else {
             print_groups(&groups);
         }

--- a/src/commands/forget.rs
+++ b/src/commands/forget.rs
@@ -1,7 +1,5 @@
 //! `forget` subcommand
 
-use std::{collections::BTreeMap, time::Instant};
-
 use crate::repository::{OpenRepo, get_grouped_snapshots};
 use crate::{Application, RUSTIC_APP, RusticConfig, helpers::table_with_titles, status_err};
 
@@ -10,15 +8,12 @@ use abscissa_core::{Shutdown, config::Override};
 use anyhow::Result;
 use conflate::Merge;
 use jiff::Zoned;
-use log::{info, warn};
+use log::info;
 use rustic_core::repofile::RusticTime;
 use serde::{Deserialize, Serialize};
 use serde_with::{DisplayFromStr, serde_as};
 
-use crate::{
-    commands::prune::{PruneCmd, PruneMetrics},
-    filtering::SnapshotFilter,
-};
+use crate::{commands::prune::PruneCmd, filtering::SnapshotFilter};
 
 use rustic_core::{ForgetGroups, ForgetSnapshot, KeepOptions, SnapshotGroupCriterion};
 
@@ -93,195 +88,6 @@ pub struct ForgetOptions {
     keep: KeepOptions,
 }
 
-#[cfg_attr(
-    not(any(feature = "prometheus", feature = "opentelemetry")),
-    allow(dead_code)
-)]
-#[derive(Clone, Copy)]
-struct RetentionMetric {
-    reason: &'static str,
-    name: &'static str,
-    description: &'static str,
-}
-
-const RETENTION_METRICS: &[RetentionMetric] = &[
-    RetentionMetric {
-        reason: "id",
-        name: "rustic_forget_snapshots_kept_id",
-        description: "Snapshots kept by the `id` retention rule",
-    },
-    RetentionMetric {
-        reason: "tags",
-        name: "rustic_forget_snapshots_kept_tags",
-        description: "Snapshots kept by the `tags` retention rule",
-    },
-    RetentionMetric {
-        reason: "last",
-        name: "rustic_forget_snapshots_kept_last",
-        description: "Snapshots kept by the `last` retention rule",
-    },
-    RetentionMetric {
-        reason: "minutely",
-        name: "rustic_forget_snapshots_kept_minutely",
-        description: "Snapshots kept by the `minutely` retention rule",
-    },
-    RetentionMetric {
-        reason: "hourly",
-        name: "rustic_forget_snapshots_kept_hourly",
-        description: "Snapshots kept by the `hourly` retention rule",
-    },
-    RetentionMetric {
-        reason: "daily",
-        name: "rustic_forget_snapshots_kept_daily",
-        description: "Snapshots kept by the `daily` retention rule",
-    },
-    RetentionMetric {
-        reason: "weekly",
-        name: "rustic_forget_snapshots_kept_weekly",
-        description: "Snapshots kept by the `weekly` retention rule",
-    },
-    RetentionMetric {
-        reason: "monthly",
-        name: "rustic_forget_snapshots_kept_monthly",
-        description: "Snapshots kept by the `monthly` retention rule",
-    },
-    RetentionMetric {
-        reason: "quarter-yearly",
-        name: "rustic_forget_snapshots_kept_quarter_yearly",
-        description: "Snapshots kept by the `quarter-yearly` retention rule",
-    },
-    RetentionMetric {
-        reason: "half-yearly",
-        name: "rustic_forget_snapshots_kept_half_yearly",
-        description: "Snapshots kept by the `half-yearly` retention rule",
-    },
-    RetentionMetric {
-        reason: "yearly",
-        name: "rustic_forget_snapshots_kept_yearly",
-        description: "Snapshots kept by the `yearly` retention rule",
-    },
-    RetentionMetric {
-        reason: "within",
-        name: "rustic_forget_snapshots_kept_within",
-        description: "Snapshots kept by the `within` retention rule",
-    },
-    RetentionMetric {
-        reason: "within minutely",
-        name: "rustic_forget_snapshots_kept_within_minutely",
-        description: "Snapshots kept by the `within minutely` retention rule",
-    },
-    RetentionMetric {
-        reason: "within hourly",
-        name: "rustic_forget_snapshots_kept_within_hourly",
-        description: "Snapshots kept by the `within hourly` retention rule",
-    },
-    RetentionMetric {
-        reason: "within daily",
-        name: "rustic_forget_snapshots_kept_within_daily",
-        description: "Snapshots kept by the `within daily` retention rule",
-    },
-    RetentionMetric {
-        reason: "within weekly",
-        name: "rustic_forget_snapshots_kept_within_weekly",
-        description: "Snapshots kept by the `within weekly` retention rule",
-    },
-    RetentionMetric {
-        reason: "within monthly",
-        name: "rustic_forget_snapshots_kept_within_monthly",
-        description: "Snapshots kept by the `within monthly` retention rule",
-    },
-    RetentionMetric {
-        reason: "within quarter-yearly",
-        name: "rustic_forget_snapshots_kept_within_quarter_yearly",
-        description: "Snapshots kept by the `within quarter-yearly` retention rule",
-    },
-    RetentionMetric {
-        reason: "within half-yearly",
-        name: "rustic_forget_snapshots_kept_within_half_yearly",
-        description: "Snapshots kept by the `within half-yearly` retention rule",
-    },
-    RetentionMetric {
-        reason: "within yearly",
-        name: "rustic_forget_snapshots_kept_within_yearly",
-        description: "Snapshots kept by the `within yearly` retention rule",
-    },
-    RetentionMetric {
-        reason: "snapshot",
-        name: "rustic_forget_snapshots_kept_snapshot",
-        description: "Snapshots kept by their snapshot deletion policy",
-    },
-];
-
-#[derive(Default)]
-struct SnapshotMetrics {
-    kept_by_reason: BTreeMap<&'static str, u64>,
-}
-
-#[cfg_attr(
-    not(any(feature = "prometheus", feature = "opentelemetry")),
-    allow(dead_code)
-)]
-struct PruneRunMetrics {
-    start: f64,
-    end: f64,
-    duration: f64,
-    summary: PruneMetrics,
-}
-
-#[cfg_attr(
-    not(any(feature = "prometheus", feature = "opentelemetry")),
-    allow(dead_code)
-)]
-struct ForgetRunMetrics {
-    time: f64,
-    forget_start: f64,
-    forget_end: f64,
-    forget_duration: f64,
-    total_duration: f64,
-    snapshots_total: u64,
-    snapshots_removed: u64,
-    snapshots_kept: u64,
-    snapshot_metrics: SnapshotMetrics,
-    prune: Option<PruneRunMetrics>,
-}
-
-fn unix_timestamp(time: &Zoned) -> f64 {
-    time.timestamp().as_millisecond() as f64 / 1000.
-}
-
-fn collect_snapshot_metrics(groups: &ForgetGroups) -> SnapshotMetrics {
-    collect_snapshot_metrics_from_snapshots(
-        groups
-            .0
-            .iter()
-            .flat_map(|group| group.items.iter())
-            .map(|snapshot| (snapshot.keep, snapshot.reasons.as_slice())),
-    )
-}
-
-fn collect_snapshot_metrics_from_snapshots<'a>(
-    snapshots: impl IntoIterator<Item = (bool, &'a [String])>,
-) -> SnapshotMetrics {
-    let mut metrics = SnapshotMetrics::default();
-
-    for (keep, reasons) in snapshots {
-        if !keep {
-            continue;
-        }
-
-        for reason in reasons {
-            if let Some(metric) = RETENTION_METRICS
-                .iter()
-                .find(|metric| metric.reason == reason)
-            {
-                *metrics.kept_by_reason.entry(metric.name).or_default() += 1;
-            }
-        }
-    }
-
-    metrics
-}
-
 impl Runnable for ForgetCmd {
     fn run(&self) {
         if let Err(err) = RUSTIC_APP
@@ -301,23 +107,6 @@ impl ForgetCmd {
     /// see <https://github.com/rustic-rs/rustic/issues/1242>
     fn inner_run(&self, repo: OpenRepo) -> Result<()> {
         let config = RUSTIC_APP.config();
-        let command_start = Zoned::now();
-        let command_timer = Instant::now();
-        // Dry runs and JSON output do not complete the normal forget operation, so publishing
-        // removal gauges for them would be misleading.
-        let metrics_requested =
-            config.global.is_metrics_configured() && !config.global.dry_run && !self.json;
-        let snapshots_total = if metrics_requested {
-            match repo.get_all_snapshots() {
-                Ok(snapshots) => Some(u64::try_from(snapshots.len()).unwrap_or(u64::MAX)),
-                Err(err) => {
-                    warn!("error collecting forget metrics: {err}");
-                    None
-                }
-            }
-        } else {
-            None
-        };
 
         let group_by = config
             .forget
@@ -345,16 +134,12 @@ impl ForgetCmd {
 
         if self.json {
             let mut stdout = std::io::stdout();
-            serde_json::to_writer(&mut stdout, &groups)?;
+            serde_json::to_writer_pretty(&mut stdout, &groups)?;
         } else {
             print_groups(&groups);
         }
 
-        let snapshot_metrics = snapshots_total.map(|_| collect_snapshot_metrics(&groups));
         let forget_snaps = groups.into_forget_ids();
-        let snapshots_removed = u64::try_from(forget_snaps.len()).unwrap_or(u64::MAX);
-        let forget_start = Zoned::now();
-        let forget_timer = Instant::now();
 
         match (forget_snaps.is_empty(), config.global.dry_run, self.json) {
             (true, _, false) => info!("nothing to remove"),
@@ -367,184 +152,14 @@ impl ForgetCmd {
             (_, _, true) => {}
         }
 
-        let forget_end = Zoned::now();
-        let forget_duration = forget_timer.elapsed().as_secs_f64();
-        let prune = if config.forget.prune {
+        if config.forget.prune {
             let mut prune_opts = self.prune_opts.clone();
             prune_opts.opts.ignore_snaps = forget_snaps;
-            let prune_start = Zoned::now();
-            let prune_timer = Instant::now();
-            let summary = prune_opts.inner_run(&repo)?;
-            Some(PruneRunMetrics {
-                start: unix_timestamp(&prune_start),
-                end: unix_timestamp(&Zoned::now()),
-                duration: prune_timer.elapsed().as_secs_f64(),
-                summary,
-            })
-        } else {
-            None
-        };
-
-        if let (Some(snapshot_metrics), Some(snapshots_total)) = (snapshot_metrics, snapshots_total)
-        {
-            let metrics = ForgetRunMetrics {
-                time: unix_timestamp(&command_start),
-                forget_start: unix_timestamp(&forget_start),
-                forget_end: unix_timestamp(&forget_end),
-                forget_duration,
-                total_duration: command_timer.elapsed().as_secs_f64(),
-                snapshots_total,
-                snapshots_removed,
-                snapshots_kept: snapshots_total.saturating_sub(snapshots_removed),
-                snapshot_metrics,
-                prune,
-            };
-            if let Err(err) = publish_forget_metrics(&metrics, &config.global.metrics_labels) {
-                warn!("error pushing metrics: {err}");
-            }
+            prune_opts.run();
         }
 
         Ok(())
     }
-}
-
-#[cfg(not(any(feature = "prometheus", feature = "opentelemetry")))]
-fn publish_forget_metrics(
-    _metrics: &ForgetRunMetrics,
-    _labels: &BTreeMap<String, String>,
-) -> Result<()> {
-    Err(anyhow::anyhow!("metrics support is not compiled-in!"))
-}
-
-#[cfg(any(feature = "prometheus", feature = "opentelemetry"))]
-fn publish_forget_metrics(
-    forget: &ForgetRunMetrics,
-    labels: &BTreeMap<String, String>,
-) -> Result<()> {
-    use crate::metrics::Metric;
-    use crate::metrics::MetricValue::*;
-
-    let mut metrics = vec![
-        Metric {
-            name: "rustic_forget_time",
-            description: "Unix timestamp when the forget command started",
-            value: Float(forget.time),
-        },
-        Metric {
-            name: "rustic_forget_forget_start",
-            description: "Unix timestamp when the forget phase started",
-            value: Float(forget.forget_start),
-        },
-        Metric {
-            name: "rustic_forget_forget_end",
-            description: "Unix timestamp when the forget phase completed",
-            value: Float(forget.forget_end),
-        },
-        Metric {
-            name: "rustic_forget_forget_duration",
-            description: "Duration of the forget phase in seconds",
-            value: Float(forget.forget_duration),
-        },
-        Metric {
-            name: "rustic_forget_total_duration",
-            description: "Total duration of the successful forget command in seconds",
-            value: Float(forget.total_duration),
-        },
-        Metric {
-            name: "rustic_forget_snapshots_total",
-            description: "Total snapshots in the repository before this forget run",
-            value: Int(forget.snapshots_total),
-        },
-        Metric {
-            name: "rustic_forget_snapshots_removed",
-            description: "Snapshots deleted by this forget run",
-            value: Int(forget.snapshots_removed),
-        },
-        Metric {
-            name: "rustic_forget_snapshots_kept",
-            description: "Snapshots remaining after this forget run",
-            value: Int(forget.snapshots_kept),
-        },
-    ];
-
-    for retention in RETENTION_METRICS {
-        metrics.push(Metric {
-            name: retention.name,
-            description: retention.description,
-            value: Int(forget
-                .snapshot_metrics
-                .kept_by_reason
-                .get(retention.name)
-                .copied()
-                .unwrap_or_default()),
-        });
-    }
-
-    if let Some(prune) = &forget.prune {
-        let summary = prune.summary;
-        metrics.extend([
-            Metric {
-                name: "rustic_forget_prune_start",
-                description: "Unix timestamp when the prune phase started",
-                value: Float(prune.start),
-            },
-            Metric {
-                name: "rustic_forget_prune_end",
-                description: "Unix timestamp when the prune phase completed",
-                value: Float(prune.end),
-            },
-            Metric {
-                name: "rustic_forget_prune_duration",
-                description: "Duration of the prune phase in seconds",
-                value: Float(prune.duration),
-            },
-            // The prune plan reports packed blob lengths, not raw/uncompressed byte lengths.
-            // Keep the raw `rustic_forget_data_removed*` gauges absent until core exposes those
-            // values, instead of presenting packed bytes as raw bytes.
-            Metric {
-                name: "rustic_forget_data_removed_packed",
-                description: "Compressed and encrypted blob bytes removed from the active index by the completed prune plan; this excludes pack headers and may not yet be physically deleted",
-                value: Int(summary.data_removed_packed + summary.tree_removed_packed),
-            },
-            Metric {
-                name: "rustic_forget_data_removed_files_packed",
-                description: "Compressed and encrypted data-blob bytes removed from the active index by the completed prune plan; this may not yet be physically deleted",
-                value: Int(summary.data_removed_packed),
-            },
-            Metric {
-                name: "rustic_forget_data_removed_trees_packed",
-                description: "Compressed and encrypted tree-blob bytes removed from the active index by the completed prune plan; this may not yet be physically deleted",
-                value: Int(summary.tree_removed_packed),
-            },
-            Metric {
-                name: "rustic_forget_data_blobs_removed",
-                description: "Data blobs removed from the active index by the completed prune plan",
-                value: Int(summary.data_blobs_removed),
-            },
-            Metric {
-                name: "rustic_forget_tree_blobs_removed",
-                description: "Tree blobs removed from the active index by the completed prune plan",
-                value: Int(summary.tree_blobs_removed),
-            },
-            Metric {
-                name: "rustic_forget_packs_removed",
-                description: "Fully unreferenced pack candidates identified by the completed prune plan; --keep-pack can retain candidates and non-instant prune marks selected packs for later deletion",
-                value: Int(summary.packs_unreferenced),
-            },
-            Metric {
-                name: "rustic_forget_packs_rewritten",
-                description: "Packs rewritten by the completed prune plan",
-                value: Int(summary.packs_rewritten),
-            },
-            Metric {
-                name: "rustic_forget_packs_kept",
-                description: "Unmarked packs left untouched by the completed prune plan",
-                value: Int(summary.packs_kept),
-            },
-        ]);
-    }
-
-    crate::metrics::push_metrics(&metrics, "rustic_forget", labels, labels)
 }
 
 /// Print groups to stdout
@@ -586,92 +201,6 @@ fn print_groups(groups: &ForgetGroups) {
             info!("snapshots for {}:\n{table}", group.group_key);
         } else {
             info!("snapshots:\n{table}");
-        }
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn retention_metrics_count_each_keep_reason_and_skip_removed_snapshots() {
-        let retained = vec![
-            "last".to_string(),
-            "daily".to_string(),
-            "within daily".to_string(),
-        ];
-        let retained_by_policy = vec!["snapshot".to_string()];
-        let removed = vec!["unchanged".to_string()];
-
-        let metrics = collect_snapshot_metrics_from_snapshots([
-            (true, retained.as_slice()),
-            (true, retained_by_policy.as_slice()),
-            (false, removed.as_slice()),
-        ]);
-
-        assert_eq!(
-            metrics
-                .kept_by_reason
-                .get("rustic_forget_snapshots_kept_last"),
-            Some(&1)
-        );
-        assert_eq!(
-            metrics
-                .kept_by_reason
-                .get("rustic_forget_snapshots_kept_daily"),
-            Some(&1)
-        );
-        assert_eq!(
-            metrics
-                .kept_by_reason
-                .get("rustic_forget_snapshots_kept_within_daily"),
-            Some(&1)
-        );
-        assert_eq!(
-            metrics
-                .kept_by_reason
-                .get("rustic_forget_snapshots_kept_snapshot"),
-            Some(&1)
-        );
-        assert!(
-            metrics
-                .kept_by_reason
-                .get("rustic_forget_snapshots_kept_unchanged")
-                .is_none()
-        );
-    }
-
-    #[test]
-    fn retention_metrics_cover_every_current_core_reason() {
-        for reason in [
-            "id",
-            "tags",
-            "last",
-            "minutely",
-            "hourly",
-            "daily",
-            "weekly",
-            "monthly",
-            "quarter-yearly",
-            "half-yearly",
-            "yearly",
-            "within",
-            "within minutely",
-            "within hourly",
-            "within daily",
-            "within weekly",
-            "within monthly",
-            "within quarter-yearly",
-            "within half-yearly",
-            "within yearly",
-            "snapshot",
-        ] {
-            assert!(
-                RETENTION_METRICS
-                    .iter()
-                    .any(|metric| metric.reason == reason)
-            );
         }
     }
 }

--- a/src/commands/forget.rs
+++ b/src/commands/forget.rs
@@ -1,5 +1,7 @@
 //! `forget` subcommand
 
+use std::{collections::BTreeMap, time::Instant};
+
 use crate::repository::{OpenRepo, get_grouped_snapshots};
 use crate::{Application, RUSTIC_APP, RusticConfig, helpers::table_with_titles, status_err};
 
@@ -8,12 +10,15 @@ use abscissa_core::{Shutdown, config::Override};
 use anyhow::Result;
 use conflate::Merge;
 use jiff::Zoned;
-use log::info;
+use log::{info, warn};
 use rustic_core::repofile::RusticTime;
 use serde::{Deserialize, Serialize};
 use serde_with::{DisplayFromStr, serde_as};
 
-use crate::{commands::prune::PruneCmd, filtering::SnapshotFilter};
+use crate::{
+    commands::prune::{PruneCmd, PruneMetrics},
+    filtering::SnapshotFilter,
+};
 
 use rustic_core::{ForgetGroups, ForgetSnapshot, KeepOptions, SnapshotGroupCriterion};
 
@@ -88,6 +93,195 @@ pub struct ForgetOptions {
     keep: KeepOptions,
 }
 
+#[cfg_attr(
+    not(any(feature = "prometheus", feature = "opentelemetry")),
+    allow(dead_code)
+)]
+#[derive(Clone, Copy)]
+struct RetentionMetric {
+    reason: &'static str,
+    name: &'static str,
+    description: &'static str,
+}
+
+const RETENTION_METRICS: &[RetentionMetric] = &[
+    RetentionMetric {
+        reason: "id",
+        name: "rustic_forget_snapshots_kept_id",
+        description: "Snapshots kept by the `id` retention rule",
+    },
+    RetentionMetric {
+        reason: "tags",
+        name: "rustic_forget_snapshots_kept_tags",
+        description: "Snapshots kept by the `tags` retention rule",
+    },
+    RetentionMetric {
+        reason: "last",
+        name: "rustic_forget_snapshots_kept_last",
+        description: "Snapshots kept by the `last` retention rule",
+    },
+    RetentionMetric {
+        reason: "minutely",
+        name: "rustic_forget_snapshots_kept_minutely",
+        description: "Snapshots kept by the `minutely` retention rule",
+    },
+    RetentionMetric {
+        reason: "hourly",
+        name: "rustic_forget_snapshots_kept_hourly",
+        description: "Snapshots kept by the `hourly` retention rule",
+    },
+    RetentionMetric {
+        reason: "daily",
+        name: "rustic_forget_snapshots_kept_daily",
+        description: "Snapshots kept by the `daily` retention rule",
+    },
+    RetentionMetric {
+        reason: "weekly",
+        name: "rustic_forget_snapshots_kept_weekly",
+        description: "Snapshots kept by the `weekly` retention rule",
+    },
+    RetentionMetric {
+        reason: "monthly",
+        name: "rustic_forget_snapshots_kept_monthly",
+        description: "Snapshots kept by the `monthly` retention rule",
+    },
+    RetentionMetric {
+        reason: "quarter-yearly",
+        name: "rustic_forget_snapshots_kept_quarter_yearly",
+        description: "Snapshots kept by the `quarter-yearly` retention rule",
+    },
+    RetentionMetric {
+        reason: "half-yearly",
+        name: "rustic_forget_snapshots_kept_half_yearly",
+        description: "Snapshots kept by the `half-yearly` retention rule",
+    },
+    RetentionMetric {
+        reason: "yearly",
+        name: "rustic_forget_snapshots_kept_yearly",
+        description: "Snapshots kept by the `yearly` retention rule",
+    },
+    RetentionMetric {
+        reason: "within",
+        name: "rustic_forget_snapshots_kept_within",
+        description: "Snapshots kept by the `within` retention rule",
+    },
+    RetentionMetric {
+        reason: "within minutely",
+        name: "rustic_forget_snapshots_kept_within_minutely",
+        description: "Snapshots kept by the `within minutely` retention rule",
+    },
+    RetentionMetric {
+        reason: "within hourly",
+        name: "rustic_forget_snapshots_kept_within_hourly",
+        description: "Snapshots kept by the `within hourly` retention rule",
+    },
+    RetentionMetric {
+        reason: "within daily",
+        name: "rustic_forget_snapshots_kept_within_daily",
+        description: "Snapshots kept by the `within daily` retention rule",
+    },
+    RetentionMetric {
+        reason: "within weekly",
+        name: "rustic_forget_snapshots_kept_within_weekly",
+        description: "Snapshots kept by the `within weekly` retention rule",
+    },
+    RetentionMetric {
+        reason: "within monthly",
+        name: "rustic_forget_snapshots_kept_within_monthly",
+        description: "Snapshots kept by the `within monthly` retention rule",
+    },
+    RetentionMetric {
+        reason: "within quarter-yearly",
+        name: "rustic_forget_snapshots_kept_within_quarter_yearly",
+        description: "Snapshots kept by the `within quarter-yearly` retention rule",
+    },
+    RetentionMetric {
+        reason: "within half-yearly",
+        name: "rustic_forget_snapshots_kept_within_half_yearly",
+        description: "Snapshots kept by the `within half-yearly` retention rule",
+    },
+    RetentionMetric {
+        reason: "within yearly",
+        name: "rustic_forget_snapshots_kept_within_yearly",
+        description: "Snapshots kept by the `within yearly` retention rule",
+    },
+    RetentionMetric {
+        reason: "snapshot",
+        name: "rustic_forget_snapshots_kept_snapshot",
+        description: "Snapshots kept by their snapshot deletion policy",
+    },
+];
+
+#[derive(Default)]
+struct SnapshotMetrics {
+    kept_by_reason: BTreeMap<&'static str, u64>,
+}
+
+#[cfg_attr(
+    not(any(feature = "prometheus", feature = "opentelemetry")),
+    allow(dead_code)
+)]
+struct PruneRunMetrics {
+    start: f64,
+    end: f64,
+    duration: f64,
+    summary: PruneMetrics,
+}
+
+#[cfg_attr(
+    not(any(feature = "prometheus", feature = "opentelemetry")),
+    allow(dead_code)
+)]
+struct ForgetRunMetrics {
+    time: f64,
+    forget_start: f64,
+    forget_end: f64,
+    forget_duration: f64,
+    total_duration: f64,
+    snapshots_total: u64,
+    snapshots_removed: u64,
+    snapshots_kept: u64,
+    snapshot_metrics: SnapshotMetrics,
+    prune: Option<PruneRunMetrics>,
+}
+
+fn unix_timestamp(time: &Zoned) -> f64 {
+    time.timestamp().as_millisecond() as f64 / 1000.
+}
+
+fn collect_snapshot_metrics(groups: &ForgetGroups) -> SnapshotMetrics {
+    collect_snapshot_metrics_from_snapshots(
+        groups
+            .0
+            .iter()
+            .flat_map(|group| group.items.iter())
+            .map(|snapshot| (snapshot.keep, snapshot.reasons.as_slice())),
+    )
+}
+
+fn collect_snapshot_metrics_from_snapshots<'a>(
+    snapshots: impl IntoIterator<Item = (bool, &'a [String])>,
+) -> SnapshotMetrics {
+    let mut metrics = SnapshotMetrics::default();
+
+    for (keep, reasons) in snapshots {
+        if !keep {
+            continue;
+        }
+
+        for reason in reasons {
+            if let Some(metric) = RETENTION_METRICS
+                .iter()
+                .find(|metric| metric.reason == reason)
+            {
+                *metrics.kept_by_reason.entry(metric.name).or_default() += 1;
+            }
+        }
+    }
+
+    metrics
+}
+
 impl Runnable for ForgetCmd {
     fn run(&self) {
         if let Err(err) = RUSTIC_APP
@@ -107,6 +301,23 @@ impl ForgetCmd {
     /// see <https://github.com/rustic-rs/rustic/issues/1242>
     fn inner_run(&self, repo: OpenRepo) -> Result<()> {
         let config = RUSTIC_APP.config();
+        let command_start = Zoned::now();
+        let command_timer = Instant::now();
+        // Dry runs and JSON output do not complete the normal forget operation, so publishing
+        // removal gauges for them would be misleading.
+        let metrics_requested =
+            config.global.is_metrics_configured() && !config.global.dry_run && !self.json;
+        let snapshots_total = if metrics_requested {
+            match repo.get_all_snapshots() {
+                Ok(snapshots) => Some(u64::try_from(snapshots.len()).unwrap_or(u64::MAX)),
+                Err(err) => {
+                    warn!("error collecting forget metrics: {err}");
+                    None
+                }
+            }
+        } else {
+            None
+        };
 
         let group_by = config
             .forget
@@ -134,12 +345,16 @@ impl ForgetCmd {
 
         if self.json {
             let mut stdout = std::io::stdout();
-            serde_json::to_writer_pretty(&mut stdout, &groups)?;
+            serde_json::to_writer(&mut stdout, &groups)?;
         } else {
             print_groups(&groups);
         }
 
+        let snapshot_metrics = snapshots_total.map(|_| collect_snapshot_metrics(&groups));
         let forget_snaps = groups.into_forget_ids();
+        let snapshots_removed = u64::try_from(forget_snaps.len()).unwrap_or(u64::MAX);
+        let forget_start = Zoned::now();
+        let forget_timer = Instant::now();
 
         match (forget_snaps.is_empty(), config.global.dry_run, self.json) {
             (true, _, false) => info!("nothing to remove"),
@@ -152,14 +367,184 @@ impl ForgetCmd {
             (_, _, true) => {}
         }
 
-        if config.forget.prune {
+        let forget_end = Zoned::now();
+        let forget_duration = forget_timer.elapsed().as_secs_f64();
+        let prune = if config.forget.prune {
             let mut prune_opts = self.prune_opts.clone();
             prune_opts.opts.ignore_snaps = forget_snaps;
-            prune_opts.run();
+            let prune_start = Zoned::now();
+            let prune_timer = Instant::now();
+            let summary = prune_opts.inner_run(&repo)?;
+            Some(PruneRunMetrics {
+                start: unix_timestamp(&prune_start),
+                end: unix_timestamp(&Zoned::now()),
+                duration: prune_timer.elapsed().as_secs_f64(),
+                summary,
+            })
+        } else {
+            None
+        };
+
+        if let (Some(snapshot_metrics), Some(snapshots_total)) = (snapshot_metrics, snapshots_total)
+        {
+            let metrics = ForgetRunMetrics {
+                time: unix_timestamp(&command_start),
+                forget_start: unix_timestamp(&forget_start),
+                forget_end: unix_timestamp(&forget_end),
+                forget_duration,
+                total_duration: command_timer.elapsed().as_secs_f64(),
+                snapshots_total,
+                snapshots_removed,
+                snapshots_kept: snapshots_total.saturating_sub(snapshots_removed),
+                snapshot_metrics,
+                prune,
+            };
+            if let Err(err) = publish_forget_metrics(&metrics, &config.global.metrics_labels) {
+                warn!("error pushing metrics: {err}");
+            }
         }
 
         Ok(())
     }
+}
+
+#[cfg(not(any(feature = "prometheus", feature = "opentelemetry")))]
+fn publish_forget_metrics(
+    _metrics: &ForgetRunMetrics,
+    _labels: &BTreeMap<String, String>,
+) -> Result<()> {
+    Err(anyhow::anyhow!("metrics support is not compiled-in!"))
+}
+
+#[cfg(any(feature = "prometheus", feature = "opentelemetry"))]
+fn publish_forget_metrics(
+    forget: &ForgetRunMetrics,
+    labels: &BTreeMap<String, String>,
+) -> Result<()> {
+    use crate::metrics::Metric;
+    use crate::metrics::MetricValue::*;
+
+    let mut metrics = vec![
+        Metric {
+            name: "rustic_forget_time",
+            description: "Unix timestamp when the forget command started",
+            value: Float(forget.time),
+        },
+        Metric {
+            name: "rustic_forget_forget_start",
+            description: "Unix timestamp when the forget phase started",
+            value: Float(forget.forget_start),
+        },
+        Metric {
+            name: "rustic_forget_forget_end",
+            description: "Unix timestamp when the forget phase completed",
+            value: Float(forget.forget_end),
+        },
+        Metric {
+            name: "rustic_forget_forget_duration",
+            description: "Duration of the forget phase in seconds",
+            value: Float(forget.forget_duration),
+        },
+        Metric {
+            name: "rustic_forget_total_duration",
+            description: "Total duration of the successful forget command in seconds",
+            value: Float(forget.total_duration),
+        },
+        Metric {
+            name: "rustic_forget_snapshots_total",
+            description: "Total snapshots in the repository before this forget run",
+            value: Int(forget.snapshots_total),
+        },
+        Metric {
+            name: "rustic_forget_snapshots_removed",
+            description: "Snapshots deleted by this forget run",
+            value: Int(forget.snapshots_removed),
+        },
+        Metric {
+            name: "rustic_forget_snapshots_kept",
+            description: "Snapshots remaining after this forget run",
+            value: Int(forget.snapshots_kept),
+        },
+    ];
+
+    for retention in RETENTION_METRICS {
+        metrics.push(Metric {
+            name: retention.name,
+            description: retention.description,
+            value: Int(forget
+                .snapshot_metrics
+                .kept_by_reason
+                .get(retention.name)
+                .copied()
+                .unwrap_or_default()),
+        });
+    }
+
+    if let Some(prune) = &forget.prune {
+        let summary = prune.summary;
+        metrics.extend([
+            Metric {
+                name: "rustic_forget_prune_start",
+                description: "Unix timestamp when the prune phase started",
+                value: Float(prune.start),
+            },
+            Metric {
+                name: "rustic_forget_prune_end",
+                description: "Unix timestamp when the prune phase completed",
+                value: Float(prune.end),
+            },
+            Metric {
+                name: "rustic_forget_prune_duration",
+                description: "Duration of the prune phase in seconds",
+                value: Float(prune.duration),
+            },
+            // The prune plan reports packed blob lengths, not raw/uncompressed byte lengths.
+            // Keep the raw `rustic_forget_data_removed*` gauges absent until core exposes those
+            // values, instead of presenting packed bytes as raw bytes.
+            Metric {
+                name: "rustic_forget_data_removed_packed",
+                description: "Compressed and encrypted blob bytes removed from the active index by the completed prune plan; this excludes pack headers and may not yet be physically deleted",
+                value: Int(summary.data_removed_packed + summary.tree_removed_packed),
+            },
+            Metric {
+                name: "rustic_forget_data_removed_files_packed",
+                description: "Compressed and encrypted data-blob bytes removed from the active index by the completed prune plan; this may not yet be physically deleted",
+                value: Int(summary.data_removed_packed),
+            },
+            Metric {
+                name: "rustic_forget_data_removed_trees_packed",
+                description: "Compressed and encrypted tree-blob bytes removed from the active index by the completed prune plan; this may not yet be physically deleted",
+                value: Int(summary.tree_removed_packed),
+            },
+            Metric {
+                name: "rustic_forget_data_blobs_removed",
+                description: "Data blobs removed from the active index by the completed prune plan",
+                value: Int(summary.data_blobs_removed),
+            },
+            Metric {
+                name: "rustic_forget_tree_blobs_removed",
+                description: "Tree blobs removed from the active index by the completed prune plan",
+                value: Int(summary.tree_blobs_removed),
+            },
+            Metric {
+                name: "rustic_forget_packs_removed",
+                description: "Fully unreferenced pack candidates identified by the completed prune plan; --keep-pack can retain candidates and non-instant prune marks selected packs for later deletion",
+                value: Int(summary.packs_unreferenced),
+            },
+            Metric {
+                name: "rustic_forget_packs_rewritten",
+                description: "Packs rewritten by the completed prune plan",
+                value: Int(summary.packs_rewritten),
+            },
+            Metric {
+                name: "rustic_forget_packs_kept",
+                description: "Unmarked packs left untouched by the completed prune plan",
+                value: Int(summary.packs_kept),
+            },
+        ]);
+    }
+
+    crate::metrics::push_metrics(&metrics, "rustic_forget", labels, labels)
 }
 
 /// Print groups to stdout
@@ -201,6 +586,92 @@ fn print_groups(groups: &ForgetGroups) {
             info!("snapshots for {}:\n{table}", group.group_key);
         } else {
             info!("snapshots:\n{table}");
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn retention_metrics_count_each_keep_reason_and_skip_removed_snapshots() {
+        let retained = vec![
+            "last".to_string(),
+            "daily".to_string(),
+            "within daily".to_string(),
+        ];
+        let retained_by_policy = vec!["snapshot".to_string()];
+        let removed = vec!["unchanged".to_string()];
+
+        let metrics = collect_snapshot_metrics_from_snapshots([
+            (true, retained.as_slice()),
+            (true, retained_by_policy.as_slice()),
+            (false, removed.as_slice()),
+        ]);
+
+        assert_eq!(
+            metrics
+                .kept_by_reason
+                .get("rustic_forget_snapshots_kept_last"),
+            Some(&1)
+        );
+        assert_eq!(
+            metrics
+                .kept_by_reason
+                .get("rustic_forget_snapshots_kept_daily"),
+            Some(&1)
+        );
+        assert_eq!(
+            metrics
+                .kept_by_reason
+                .get("rustic_forget_snapshots_kept_within_daily"),
+            Some(&1)
+        );
+        assert_eq!(
+            metrics
+                .kept_by_reason
+                .get("rustic_forget_snapshots_kept_snapshot"),
+            Some(&1)
+        );
+        assert!(
+            metrics
+                .kept_by_reason
+                .get("rustic_forget_snapshots_kept_unchanged")
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn retention_metrics_cover_every_current_core_reason() {
+        for reason in [
+            "id",
+            "tags",
+            "last",
+            "minutely",
+            "hourly",
+            "daily",
+            "weekly",
+            "monthly",
+            "quarter-yearly",
+            "half-yearly",
+            "yearly",
+            "within",
+            "within minutely",
+            "within hourly",
+            "within daily",
+            "within weekly",
+            "within monthly",
+            "within quarter-yearly",
+            "within half-yearly",
+            "within yearly",
+            "snapshot",
+        ] {
+            assert!(
+                RETENTION_METRICS
+                    .iter()
+                    .any(|metric| metric.reason == reason)
+            );
         }
     }
 }

--- a/tests/backup_restore.rs
+++ b/tests/backup_restore.rs
@@ -127,6 +127,28 @@ fn test_backup_records_cli_version_in_snapshot() -> TestResult<()> {
 }
 
 #[test]
+fn test_forget_json_is_compact() -> TestResult<()> {
+    let temp_dir = setup()?;
+    let backup = src_snapshot()?.into_path();
+
+    rustic_runner(&temp_dir)?
+        .arg("backup")
+        .arg(backup.path())
+        .assert()
+        .success();
+
+    let output = rustic_runner(&temp_dir)?
+        .args(["forget", "--json", "--keep-last", "1"])
+        .output()?;
+
+    assert!(output.status.success());
+    assert!(!output.stdout.contains(&b'\n'));
+    let _: serde_json::Value = serde_json::from_slice(&output.stdout)?;
+
+    Ok(())
+}
+
+#[test]
 fn test_backup_and_restore_passes() -> TestResult<()> {
     let temp_dir = setup()?;
     let restore_dir = temp_dir.path().join("restore");


### PR DESCRIPTION
## Summary

Makes `forget --json` compact and single-line while preserving the JSON data.

## Validation

- `cargo test --locked test_forget_json_is_compact`
- `cargo clippy --locked --all-targets --features release -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`
- `typos`

Fixes #1572.