### PR TITLE
Document Debian installation from the pkg.haus APT archive

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,14 @@ scoop install rustic
 brew install rustic
 ```
 
+#### Debian
+
+rustic is available from the [pkg.haus](https://pkg.haus) APT archive for Debian stable, testing and unstable (amd64 and arm64), built from source at release tags. Set up the archive per the instructions on [pkg.haus](https://pkg.haus), then run:
+
+```bash
+sudo apt install rustic
+```
+
 Or you can check out the
 [releases](https://github.com/rustic-rs/rustic/releases).
 


### PR DESCRIPTION
[pkg.haus](https://pkg.haus) is a signed APT archive carrying rustic for Debian stable, testing and unstable (amd64/arm64), built from source at upstream release tags. This adds a Debian subsection to the install docs.