### PR TITLE
fix: update h2 to 0.4.16

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2300,9 +2300,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.15"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6cb093c84e8bd9b188d4c4a8cb6579fc016968d14c99882163cd3ff402a4f155"
+checksum = "a9f37a958b41b3b19ee2707c06439c0e9e547e847223eb791ecb0cb821c65e27"
 dependencies = [
  "atomic-waker",
  "bytes",


### PR DESCRIPTION
## Summary

- update the locked h2 dependency from 0.4.15 to 0.4.16
- keep the lockfile change limited to the patched advisory release

Fixes #1884

## Validation

- cargo metadata --locked --no-deps --format-version 1
- cargo tree --locked --all-features -i h2@0.4.16
- cargo check --locked --features release