### PR TITLE
fix: handle closed stdout while listing snapshots

### DIFF
--- a/src/commands/rewrite.rs
+++ b/src/commands/rewrite.rs
@@ -3,6 +3,7 @@
 use crate::{
     Application, RUSTIC_APP,
     commands::snapshots::print_snapshots,
+    helpers::is_broken_pipe,
     repository::{IndexedRepo, OpenRepo, get_snapots_from_ids},
     status_err,
 };
@@ -10,6 +11,7 @@ use crate::{
 use abscissa_core::{Command, Runnable, Shutdown};
 use anyhow::Result;
 use log::info;
+use std::io::Write;
 
 use rustic_core::{
     Excludes, NodeModification, RewriteOptions, RewriteTreesOptions, StringList,
@@ -51,12 +53,15 @@ impl Runnable for RewriteCmd {
     fn run(&self) {
         let repo = &RUSTIC_APP.config().repository;
 
-        if let Err(err) =
+        let result =
             if self.excludes.is_empty() && self.node_modification.is_empty() && !self.all_trees {
                 repo.run_open(|repo| self.inner_run_open(repo))
             } else {
                 repo.run_indexed(|repo| self.inner_run_indexed(repo))
-            }
+            };
+
+        if let Err(err) = result
+            && !is_broken_pipe(&err)
         {
             status_err!("{}", err);
             RUSTIC_APP.shutdown(Shutdown::Crash);
@@ -79,7 +84,7 @@ impl RewriteCmd {
 
         let snaps = repo.rewrite_snapshots(snapshots, &self.opts())?;
 
-        self.output(snaps);
+        self.output(snaps)?;
 
         Ok(())
     }
@@ -93,18 +98,22 @@ impl RewriteCmd {
 
         let snaps = repo.rewrite_snapshots_and_trees(snapshots, &self.opts(), &tree_opts)?;
 
-        self.output(snaps);
+        self.output(snaps)?;
 
         Ok(())
     }
 
-    fn output(&self, snaps: Vec<SnapshotFile>) {
+    fn output(&self, snaps: Vec<SnapshotFile>) -> Result<()> {
         let config = RUSTIC_APP.config();
         if config.global.dry_run {
-            println!("Would have rewritten the following snapshots:");
-            print_snapshots(snaps, false, true);
+            let stdout = std::io::stdout();
+            let mut stdout = stdout.lock();
+            writeln!(stdout, "Would have rewritten the following snapshots:")?;
+            print_snapshots(snaps, false, true, &mut stdout)?;
         } else {
             info!("{} snapshots have been rewritten", snaps.len());
         }
+
+        Ok(())
     }
 }

--- a/src/commands/snapshots.rs
+++ b/src/commands/snapshots.rs
@@ -2,7 +2,7 @@
 
 use crate::{
     Application, RUSTIC_APP,
-    helpers::{bold_cell, bytes_size_to_string, table, table_right_from},
+    helpers::{bold_cell, bytes_size_to_string, is_broken_pipe, table, table_right_from},
     repository::{OpenRepo, get_global_grouped_snapshots},
     status_err,
 };
@@ -13,6 +13,7 @@ use comfy_table::Cell;
 use derive_more::From;
 use itertools::Itertools;
 use jiff::SignedDuration;
+use std::io::Write;
 
 use rustic_core::{
     Group, ProgressBars, ProgressType, SnapshotGroup,
@@ -56,6 +57,7 @@ impl Runnable for SnapshotCmd {
             .config()
             .repository
             .run_open(|repo| self.inner_run(repo))
+            && !is_broken_pipe(&err)
         {
             status_err!("{}", err);
             RUSTIC_APP.shutdown(Shutdown::Crash);
@@ -89,9 +91,10 @@ impl SnapshotCmd {
         }
 
         let groups = get_global_grouped_snapshots(&repo, &self.ids)?.groups;
+        let stdout = std::io::stdout();
+        let mut stdout = stdout.lock();
 
         if self.json {
-            let mut stdout = std::io::stdout();
             if groups.len() == 1 && groups[0].group_key.is_empty() {
                 // we don't use grouping, only output snapshots list
                 serde_json::to_writer_pretty(&mut stdout, &groups[0].items)?;
@@ -113,19 +116,24 @@ impl SnapshotCmd {
         let mut total_count = 0;
         for Group { group_key, items } in groups {
             if !group_key.is_empty() {
-                println!("\nsnapshots for {group_key}");
+                writeln!(stdout, "\nsnapshots for {group_key}")?;
             }
             total_count += items.len();
-            print_snapshots(items, self.long, self.all);
+            print_snapshots(items, self.long, self.all, &mut stdout)?;
         }
-        println!();
-        println!("total: {total_count} snapshot(s)");
+        writeln!(stdout)?;
+        writeln!(stdout, "total: {total_count} snapshot(s)")?;
 
         Ok(())
     }
 }
 
-pub fn print_snapshots(snapshots: Vec<SnapshotFile>, long: bool, all: bool) {
+pub(crate) fn print_snapshots(
+    snapshots: Vec<SnapshotFile>,
+    long: bool,
+    all: bool,
+    stdout: &mut impl Write,
+) -> std::io::Result<()> {
     let count = snapshots.len();
     if long {
         for snap in snapshots {
@@ -136,8 +144,8 @@ pub fn print_snapshots(snapshots: Vec<SnapshotFile>, long: bool, all: bool) {
             };
             fill_table(&snap, add_entry);
 
-            println!("{table}");
-            println!();
+            writeln!(stdout, "{table}")?;
+            writeln!(stdout)?;
         }
     } else {
         let mut table = table_right_from(
@@ -160,9 +168,11 @@ pub fn print_snapshots(snapshots: Vec<SnapshotFile>, long: bool, all: bool) {
                     .map(|(_, mut g)| snap_to_table(&g.next().unwrap(), g.count())),
             );
         }
-        println!("{table}");
+        writeln!(stdout, "{table}")?;
     }
-    println!("{count} snapshot(s)");
+    writeln!(stdout, "{count} snapshot(s)")?;
+
+    Ok(())
 }
 
 pub fn snap_to_table(sn: &SnapshotFile, count: usize) -> [String; 9] {
@@ -277,5 +287,30 @@ pub fn fill_table(snap: &SnapshotFile, mut add_entry: impl FnMut(&str, String)) 
     }
     if let Some(ref description) = snap.description {
         add_entry("Description", description.clone());
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::print_snapshots;
+    use std::io::{self, Write};
+
+    struct BrokenPipe;
+
+    impl Write for BrokenPipe {
+        fn write(&mut self, _buf: &[u8]) -> io::Result<usize> {
+            Err(io::Error::from(io::ErrorKind::BrokenPipe))
+        }
+
+        fn flush(&mut self) -> io::Result<()> {
+            Ok(())
+        }
+    }
+
+    #[test]
+    fn snapshot_output_propagates_broken_pipe() {
+        let error = print_snapshots(Vec::new(), false, true, &mut BrokenPipe).unwrap_err();
+
+        assert_eq!(error.kind(), io::ErrorKind::BrokenPipe);
     }
 }

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -3,6 +3,18 @@ use comfy_table::{
     Attribute, Cell, CellAlignment, ContentArrangement, Table, presets::ASCII_MARKDOWN,
 };
 
+/// Return whether an error was caused by a consumer closing stdout.
+pub(crate) fn is_broken_pipe(error: &anyhow::Error) -> bool {
+    error.chain().any(|cause| {
+        cause
+            .downcast_ref::<std::io::Error>()
+            .is_some_and(|error| error.kind() == std::io::ErrorKind::BrokenPipe)
+            || cause
+                .downcast_ref::<serde_json::Error>()
+                .is_some_and(|error| error.io_error_kind() == Some(std::io::ErrorKind::BrokenPipe))
+    })
+}
+
 /// Helpers for table output
 /// Create a new bold cell
 pub fn bold_cell<T: ToString>(s: T) -> Cell {
@@ -44,4 +56,36 @@ pub fn table_right_from<I: IntoIterator<Item = T>, T: ToString>(start: usize, ti
 #[must_use]
 pub fn bytes_size_to_string(b: u64) -> String {
     ByteSize(b).display().to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::is_broken_pipe;
+    use std::io::{self, Write};
+
+    #[test]
+    fn detects_broken_pipe() {
+        let error = anyhow::Error::from(io::Error::from(io::ErrorKind::BrokenPipe));
+
+        assert!(is_broken_pipe(&error));
+    }
+
+    struct BrokenPipe;
+
+    impl Write for BrokenPipe {
+        fn write(&mut self, _buf: &[u8]) -> io::Result<usize> {
+            Err(io::Error::from(io::ErrorKind::BrokenPipe))
+        }
+
+        fn flush(&mut self) -> io::Result<()> {
+            Ok(())
+        }
+    }
+
+    #[test]
+    fn detects_json_broken_pipe() {
+        let error = serde_json::to_writer(BrokenPipe, &()).unwrap_err();
+
+        assert!(is_broken_pipe(&anyhow::Error::from(error)));
+    }
 }


### PR DESCRIPTION
## Summary

- use fallible stdout writes for snapshot output
- treat an expected BrokenPipe as clean early termination
- cover the shared rewrite dry-run output path and JSON writer path

Fixes #1878

## Validation

- cargo fmt --check
- cargo clippy --locked --all-targets --features release -- -D warnings
- cargo test --locked --lib