### PR TITLE
docs: add OpenDAL attribution

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,16 @@
 <a href="https://github.com/rustic-rs/rustic/actions/workflows/release-image.yml"><img src="https://github.com/rustic-rs/rustic/actions/workflows/release-image.yml/badge.svg" /></a>
 <p>
 
+<p align="center">
+Most backends featured by<br />
+<a href="https://opendal.apache.org/">
+<picture>
+<source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/apache/opendal/main/website/static/img/logo_dark.svg">
+<img src="https://raw.githubusercontent.com/apache/opendal/main/website/static/img/logo.svg" alt="Powered by Apache OpenDAL" height="64" />
+</picture>
+</a>
+</p>
+
 ## About
 
 `rustic` is a backup tool that provides fast, encrypted, deduplicated backups.


### PR DESCRIPTION
## Summary

- add Apache OpenDAL attribution to the rustic binary README
- introduce it as Most backends featured by
- select the readable light or dark SVG with a picture element

Companion to rustic-rs/rustic_core#552 and rustic-rs/rustic_core#135.

## Validation

- both linked SVGs return HTTP 200
- npx --yes dprint check
- git diff --check