### PR TITLE
perf: enable mimalloc in release and ARMv8 AES on aarch64

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -2,3 +2,13 @@
 rustdocflags = ["--document-private-items"]
 # rustflags = "-C target-cpu=native -D warnings"
 # incremental = true
+
+# aes-gcm on aarch64: ARMv8 AES / PMULL instead of software AES-GCM.
+[target.aarch64-apple-darwin]
+rustflags = ["--cfg", "aes_armv8", "--cfg", "polyval_armv8"]
+
+[target.aarch64-unknown-linux-gnu]
+rustflags = ["--cfg", "aes_armv8", "--cfg", "polyval_armv8"]
+
+[target.aarch64-unknown-linux-musl]
+rustflags = ["--cfg", "aes_armv8", "--cfg", "polyval_armv8"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ rustic - fast, encrypted, deduplicated backups powered by Rust
 
 [features]
 default = ["jq", "prometheus", "opentelemetry", "tui", "webdav"]
-release = ["default", "self-update"]
+release = ["default", "self-update", "mimalloc"]
 
 # Allocators
 mimalloc = ["dep:mimalloc"]


### PR DESCRIPTION
Part of rustic-rs/rustic_core#564.

CLI side of the prune warm-cache speedup:

- Enable mimalloc when building with `--features release`.
- Set `--cfg aes_armv8 --cfg polyval_armv8` for aarch64 Apple/Linux targets so AES-GCM uses ARMv8 crypto instead of `aes::soft`.

`rustic_core/.cargo/config.toml` already has those AES flags, but they do not apply when the workspace is this CLI. Without them, Darwin prune used-blobs stays on software AES and does not reach the 0:16 number in #564.